### PR TITLE
Fixes issue where the issuer has special chars in the name.

### DIFF
--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -116,8 +116,10 @@ def cert_get_issuer(cert):
     :param cert:
     :return: Issuer
     """
+    delchars = ''.join(c for c in map(chr, range(256)) if not c.isalnum())
     try:
-        return cert.subject.get_attributes_for_oid(x509.OID_ORGANIZATION_NAME)[0].value
+        issuer = str(cert.subject.get_attributes_for_oid(x509.OID_ORGANIZATION_NAME)[0].value)
+        return issuer.translate(None, delchars)
     except Exception as e:
         current_app.logger.error("Unable to get issuer! {0}".format(e))
 


### PR DESCRIPTION
AWS dislikes special chars in certificate names so we strip them out here. In general we want to have the name tracked by Lemur be the same as what is uploaded to various destinations.
