### PR TITLE
Rename SSL to TLS in many places

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Lemur
 .. image:: https://travis-ci.org/Netflix/lemur.svg
     :target: https://travis-ci.org/Netflix/lemur
 
-Lemur manages SSL certificate creation. It provides a central portal for developers to issuer their own SSL certificates with 'sane' defaults.
+Lemur manages TLS certificate creation. It provides a central portal for developers to issue their own TLS certificates with 'sane' defaults.
 
 It works on CPython 2.7, 3.3, 3.4. We deploy on Ubuntu and develop on OS X.
 

--- a/docs/administration/index.rst
+++ b/docs/administration/index.rst
@@ -222,7 +222,7 @@ for those plugins.
 .. data:: VERISIGN_PEM_PATH
     :noindex:
 
-        This is the path to the mutual SSL certificate used for communicating with Verisign
+        This is the path to the mutual TLS certificate used for communicating with Verisign
 
 
 .. data:: VERISIGN_FIRST_NAME
@@ -297,7 +297,7 @@ AWS Plugin Configuration
 
 In order for Lemur to manage it's own account and other accounts we must ensure it has the correct AWS permissions.
 
-.. note:: AWS usage is completely optional. Lemur can upload, find and manage SSL certificates in AWS. But is not required to do so.
+.. note:: AWS usage is completely optional. Lemur can upload, find and manage TLS certificates in AWS. But is not required to do so.
 
 Setting up IAM roles
 --------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,8 @@
 Lemur
 =====
 
-Lemur is a SSL management service. It attempts to help track and create certificates. By removing common issues with
-CSR creation it gives normal developers 'sane' SSL defaults and helps security teams push SSL usage throughout an organization.
+Lemur is a TLS management service. It attempts to help track and create certificates. By removing common issues with
+CSR creation it gives normal developers 'sane' TLS defaults and helps security teams push TLS usage throughout an organization.
 
 Installation
 ------------

--- a/lemur/plugins/lemur_email/templates/expiration.html
+++ b/lemur/plugins/lemur_email/templates/expiration.html
@@ -49,7 +49,7 @@
                     <td class="container-padding" bgcolor="#ffffff" style="background-color: #ffffff; padding-left: 30px; padding-right: 30px; font-size: 14px; line-height: 20px; font-family: Helvetica, sans-serif; color: #333;">
                        <br />
                        <div style="font-weight: bold; font-size: 18px; line-height: 24px; color: #202d3b">
-                            <span style="color: #29abe0">Notice: Your SSL certificates are expiring!</span>
+                            <span style="color: #29abe0">Notice: Your TLS certificates are expiring!</span>
                             <hr />
                        </div>
                         <p>

--- a/lemur/static/app/angular/welcome/welcome.html
+++ b/lemur/static/app/angular/welcome/welcome.html
@@ -1,12 +1,12 @@
 <div class="jumbotron">
   <h1>Hey there!</h1>
 
-  <p>Welcome to Lemur! A central portal for all (most) of your SSL needs.</p>
+  <p>Welcome to Lemur! A central portal for all (most) of your TLS needs.</p>
 
   <p><a href="/#/certificates/create" class="btn btn-primary btn-lg" role="button">Create a Certificate</a></p>
 </div>
 <div class="row featurette">
   <div class="col-md-10">
-    <h2 class="featurette-heading">SSL In The Cloud <span class="text-muted">Encrypt it all </span></h2>
+    <h2 class="featurette-heading">TLS In The Cloud <span class="text-muted">Encrypt it all </span></h2>
   </div>
 </div>

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 Lemur
 =====
 
-Is an SSL management and orchestration tool.
+Is a TLS management and orchestration tool.
 
 :copyright: (c) 2015 by Netflix, see AUTHORS for more
 :license: Apache, see LICENSE for more details.


### PR DESCRIPTION
This changes "SSL" to "TLS" in many places (not 100% comprehensive, but the important places).

Since the SSL protocol (last formally updated in 1999) is now fully deprecated in the browser and [by the IETF](https://tools.ietf.org/html/rfc7568), we should be doing our best to move to "TLS" as the primary descriptor.