### PR TITLE
Add Mandrill as a notification email provider

### DIFF
--- a/docs/administration/index.rst
+++ b/docs/administration/index.rst
@@ -167,7 +167,7 @@ Lemur supports sending certification expiration notifications through SES and SM
 .. data:: LEMUR_EMAIL_SENDER
     :noindex:
 
-            Specifies which service will be delivering notification emails. Valid values are `SMTP` or `SES`
+            Specifies which service will be delivering notification emails. Valid values are `SMTP`, `Mandrill`, or `SES`
 
 .. note::
     If using STMP as your provider you will need to define additional configuration options as specified by Flask-Mail.
@@ -185,6 +185,15 @@ Lemur supports sending certification expiration notifications through SES and SM
 
         LEMUR_MAIL = 'lemur.example.com'
 
+
+.. data:: MANDRILL_KEY
+    :noindex:
+
+            This is the API key for use with Mandrill's API. It is generated from Mandrill's website.
+
+        ::
+
+        MANDRILL_KEY = 'KEY'
 
 .. data:: LEMUR_SECURITY_TEAM_EMAIL
     :noindex:

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ install_requires = [
     'xmltodict==0.9.2',
     'lockfile==0.10.2',
     'future==0.15.0',
+    'mandrill==1.0.57',  # it might be good to make this optional
 ]
 
 tests_require = [


### PR DESCRIPTION
This PR would add mandrill as an email provider for the email notification plugin.

Right now it adds a hard dependency on the mandrill client (similar to how boto is a hard dependency), but I'd be willing to revisit that and make mandrill a soft dependency.