### PR TITLE
Update example supervisor configuration file

### DIFF
--- a/docs/production/index.rst
+++ b/docs/production/index.rst
@@ -257,13 +257,12 @@ Create a configuration file named supervisor.ini::
     nodaemon=false
     minfds=1024
     minprocs=200
-    user=lemur
 
     [program:lemur]
     command=python /path/to/lemur/manage.py manage.py start
 
     directory=/path/to/lemur/
-    environment=PYTHONPATH='/path/to/lemur/'
+    environment=PYTHONPATH='/path/to/lemur/',LEMUR_CONF='/home/lemur/.lemur/lemur.conf.py'
     user=lemur
     autostart=true
     autorestart=true


### PR DESCRIPTION
supervisord should run as root and spawn the lemur process as the lemur
user. I also added the LEMUR_CONF environment variable because it was
not reading the configuration file in by default.