### PR TITLE
Minor spelling fix

### DIFF
--- a/lemur/static/app/angular/certificates/certificate/export.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/export.tpl.html
@@ -31,7 +31,7 @@
     </form>
     <div ng-show="passphrase">
       <h3>Successfully exported!</h3>
-      <h4>You're passphrase is: <strong>{{ passphrase }}</strong></h4>
+      <h4>Your passphrase is: <strong>{{ passphrase }}</strong></h4>
       <p ng-show="additional">{{ additional }}</p>
     </div>
   </div>


### PR DESCRIPTION
Using the possessive “Your” rather than “You’re” in “Your passphrase
is:”