### PR TITLE
Use the local bower instead of the global one.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "postinstall": "bower install --allow-root --config.interactive=false",
+    "postinstall": "node_modules/.bin/bower install --allow-root --config.interactive=false",
     "pretest": "npm install && npm run build_static",
     "build_static": "gulp build",
     "prelint": "npm install",


### PR DESCRIPTION
This change updates package.json's postinstall command to use the locally installed bower, rather than the global bower which might not exist or might not be in the current user's PATH. This addresses issue #224. 