### PR TITLE
Support for pushing PEM certificates to S3

### DIFF
--- a/lemur/plugins/lemur_aws/sts.py
+++ b/lemur/plugins/lemur_aws/sts.py
@@ -7,15 +7,29 @@
 """
 import boto
 import boto.ec2.elb
-
+import os
 from flask import current_app
 
 
-def assume_service(account_number, service, region=None):
-    conn = boto.connect_sts()
+class Credentials(object):
+    access_key = os.environ.get('AWS_ACCESS_KEY_ID')
+    secret_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
+    session_token = None
 
-    role = conn.assume_role('arn:aws:iam::{0}:role/{1}'.format(
-        account_number, current_app.config.get('LEMUR_INSTANCE_PROFILE', 'Lemur')), 'blah')
+
+class Role(object):
+    credentials = Credentials()
+
+
+def assume_service(account_number, service, region=None):
+    try:
+        conn = boto.connect_sts()
+        role = conn.assume_role('arn:aws:iam::{0}:role/{1}'.format(
+            account_number, current_app.config.get('LEMUR_INSTANCE_PROFILE', 'Lemur')), 'blah')
+    except:
+        current_app.logger.warn('Could not connect to STS, reading credentials from environment')
+        role = Role()
+        pass
 
     if service in 'iam':
         return boto.connect_iam(
@@ -32,6 +46,13 @@ def assume_service(account_number, service, region=None):
 
     elif service in 'vpc':
         return boto.connect_vpc(
+            aws_access_key_id=role.credentials.access_key,
+            aws_secret_access_key=role.credentials.secret_key,
+            security_token=role.credentials.session_token)
+
+    elif service in 's3':
+        return boto.s3.connect_to_region(
+            region,
             aws_access_key_id=role.credentials.access_key,
             aws_secret_access_key=role.credentials.secret_key,
             security_token=role.credentials.session_token)

--- a/lemur/plugins/lemur_s3/__init__.py
+++ b/lemur/plugins/lemur_s3/__init__.py
@@ -1,0 +1,5 @@
+try:
+    VERSION = __import__('pkg_resources') \
+        .get_distribution(__name__).version
+except Exception as e:
+    VERSION = 'unknown'

--- a/lemur/plugins/lemur_s3/plugin.py
+++ b/lemur/plugins/lemur_s3/plugin.py
@@ -1,0 +1,119 @@
+"""
+.. module: lemur.plugins.lemur_s3
+    :platform: Unix
+    :copyright: (c) 2016 by Netflix Inc., see AUTHORS for more
+    :license: Apache, see LICENSE for more details.
+
+.. moduleauthor:: Harm Weites <harm@weites.com>
+"""
+import os
+import tempfile
+from boto.exception import S3CreateError
+from boto.s3.key import Key
+from flask import current_app
+from lemur.plugins.bases import DestinationPlugin
+from lemur.plugins import lemur_s3 as s3
+from lemur.plugins.lemur_aws.sts import assume_service
+
+
+def find_value(name, options):
+    for o in options:
+        if o['name'] == name:
+            return o['value']
+
+
+class S3DestinationPlugin(DestinationPlugin):
+    title = 'S3'
+    slug = 's3-destination'
+    description = 'Allows uploading certificates to Amazon S3'
+    version = s3.VERSION
+
+    author = 'Harm Weites'
+    author_url = 'https://github.com/netflix/lemur'
+
+    options = [
+        {
+            'name': 'accountNumber',
+            'type': 'int',
+            'required': True,
+            'validation': '/^[0-9]{12,12}$/',
+            'helpMessage': 'A valid AWS account number with permission to access S3',
+        }, {
+            'name': 'bucket',
+            'type': 'str',
+            'default': 'certificate-store',
+            'required': True,
+            'validation': '/^\w+$/',
+            'helpMessage': 'The name of your bucket',
+        }, {
+            'name': 'region',
+            'type': 'str',
+            'default': 'eu-west-1',
+            'required': False,
+            'validation': '/^\w+-\w+-\d+$/',
+            'helpMessage': 'Availability zone to use',
+        }
+    ]
+
+    """
+    Outputs the certificate data to a local file and returns its name.
+    """
+    def createPemFile(self, cert, key, chain):
+        tmpfile = tempfile.NamedTemporaryFile(dir='/tmp/', prefix='_tmp', delete=False)
+        current_app.logger.debug('PEM file created as %s' % tmpfile.name)
+        os.chmod(tmpfile.name, 0o600)
+
+        with tmpfile.file as pem:
+            pem.write(key + '\n' + cert + '\n' + chain + '\n')
+
+        return tmpfile.name
+
+    def upload(self, name, body, private_key, cert_chain, options, **kwargs):
+        current_app.logger.info("Preparing to upload %s to S3" % name)
+
+        if private_key:
+            try:
+                pemfile = self.createPemFile(body, private_key, cert_chain)
+            except Exception as error:
+                current_app.logger.error(error)
+                raise
+
+            bucket_name = find_value('bucket', options)
+            try:
+                conn = assume_service(find_value('accountNumber', options), 's3', find_value('region', options))
+            except Exception as error:
+                current_app.logger.error("Could not connect to S3 for bucket %s: %s" % (bucket_name, error))
+                raise
+
+            if conn is None:
+                current_app.logger.error("Failed to connect to AWS")
+                raise
+
+            bucket = conn.lookup(bucket_name)
+            if bucket is None:
+                try:
+                    bucket = conn.create_bucket(bucket_name, location=find_value('region', options))
+                except S3CreateError as err:
+                    current_app.logger.error("Failed to create bucket %s in region %s: %s" % (bucket_name, find_value('region', options), err))
+                raise
+
+            current_app.logger.debug("Connected to S3 bucket %s in region %s" % (bucket_name, find_value('region', options)))
+
+            k = Key(bucket)
+            k.key = name + '.pem'
+            try:
+                k.set_contents_from_filename(pemfile, replace=True, encrypt_key=True)
+            except Exception as error:
+                current_app.logger.error("Uploading PEM file failed: %s" % error)
+                raise
+
+            current_app.logger.info("Uploading of %s to S3 bucket %s was succesful" % (name, bucket_name))
+
+            try:
+                os.remove(pemfile)
+            except Exception as error:
+                current_app.logger.error("Removing local file failed with: %s" % error)
+                raise
+
+        else:
+            raise Exception("Unable to create PEM file, private key is required")

--- a/setup.py
+++ b/setup.py
@@ -163,6 +163,7 @@ setup(
         'lemur.plugins': [
             'verisign_issuer = lemur.plugins.lemur_verisign.plugin:VerisignIssuerPlugin',
             'aws_destination = lemur.plugins.lemur_aws.plugin:AWSDestinationPlugin',
+            's3_destination = lemur.plugins.lemur_s3.plugin:S3DestinationPlugin',
             'aws_source = lemur.plugins.lemur_aws.plugin:AWSSourcePlugin',
             'email_notification = lemur.plugins.lemur_email.plugin:EmailNotificationPlugin',
             'java_truststore_export = lemur.plugins.lemur_java.plugin:JavaTruststoreExportPlugin',


### PR DESCRIPTION
**!! WIP !!** (although it does work fine)

This will add a new destination option: S3 buckets. The resulting file will be
stored using server-side encryption.

AWS access is done the usual way, and should that fail it's now also possible
to use plain old environment vars.

@kevgliss what are your thoughts on this one :smile: 