### PR TITLE
Using UTC time in JWT token creation

### DIFF
--- a/lemur/auth/service.py
+++ b/lemur/auth/service.py
@@ -75,8 +75,8 @@ def create_token(user):
     expiration_delta = timedelta(days=int(current_app.config.get('LEMUR_TOKEN_EXPIRATION', 1)))
     payload = {
         'sub': user.id,
-        'iat': datetime.now(),
-        'exp': datetime.now() + expiration_delta
+        'iat': datetime.utcnow(),
+        'exp': datetime.utcnow() + expiration_delta
     }
     token = jwt.encode(payload, current_app.config['LEMUR_TOKEN_SECRET'])
     return token.decode('unicode_escape')


### PR DESCRIPTION
As stated in PyJWT's documentation [1] and JWT specification [2][3], UTC
times must be used. This commit fixes JWT decoding in servers not using
UTC time.

[1] https://pypi.python.org/pypi/PyJWT/1.4.0
[2] https://tools.ietf.org/html/rfc7519#section-4.1.6
[3] https://tools.ietf.org/html/rfc7519#section-2