### PR TITLE
Target Individuals for Certificates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,12 +9,11 @@ Lemur
     :target: https://lemur.readthedocs.org
     :alt: Latest Docs
 
+.. image:: https://img.shields.io/badge/NetflixOSS-active-brightgreen.svg
+
 .. image:: https://travis-ci.org/Netflix/lemur.svg
     :target: https://travis-ci.org/Netflix/lemur
 
-.. image:: https://requires.io/github/Netflix/lemur/requirements.svg?branch=master
-    :target: https://requires.io/github/Netflix/lemur/requirements/?branch=master
-    :alt: Requirements Status
 
 Lemur manages TLS certificate creation. While not able to issue certificates itself, Lemur acts as a broker between CAs
 and environments providing a central portal for developers to issue TLS certificates with 'sane' defaults.

--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -97,6 +97,7 @@ class Login(Resource):
             # Tell Flask-Principal the identity changed
             identity_changed.send(current_app._get_current_object(),
                                   identity=Identity(user.id))
+
             metrics.send('successful_login', 'counter', 1)
             return dict(token=create_token(user))
 
@@ -190,9 +191,9 @@ class Ping(Resource):
                 role = role_service.create(group, description='This is a google group based role created by Lemur')
             roles.append(role)
 
-        role = role_service.get_by_name(user.email)
+        role = role_service.get_by_name(profile['email'])
         if not role:
-            role = role_service.create(user.email, description='This is a user specific role')
+            role = role_service.create(profile['email'], description='This is a user specific role')
         roles.append(role)
 
         # if we get an sso user create them an account

--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -190,6 +190,11 @@ class Ping(Resource):
                 role = role_service.create(group, description='This is a google group based role created by Lemur')
             roles.append(role)
 
+        role = role_service.get_by_name(user.email)
+        if not role:
+            role = role_service.create(user.email, description='This is a user specific role')
+        roles.append(role)
+
         # if we get an sso user create them an account
         if not user:
             # every user is an operator (tied to a default role)


### PR DESCRIPTION
We needed the ability to quickly target an individual. This adds a role to an incoming user ensuring that they have a role attached to them that matches their username. This role can then be used to restrict access of a certificate to a particular user. 