### PR TITLE
AWS: allow AssumeRole or already assumed Role

### DIFF
--- a/lemur/plugins/lemur_aws/sts.py
+++ b/lemur/plugins/lemur_aws/sts.py
@@ -47,17 +47,57 @@ def assume_service(account_number, service, region='us-east-1'):
             security_token=role.credentials.session_token)
 
 
+def construct_role_arn(role_type='role', **kwargs):
+    account_number = kwargs.get('account_number') or \
+        current_app.config.get('AWS_DEFAULT_ACCOUNT_NUMBER') or \
+        boto3.client('sts').get_caller_identity().get('Account')
+    arn_data = {
+        'num': account_number,
+        'role_type': role_type,
+        'name': current_app.config.get('LEMUR_INSTANCE_PROFILE', 'Lemur')
+    }
+    arn_data['service'] = 'sts' if role_type == 'assumed-role' else 'iam'
+
+    return 'arn:aws:{service}::{num}:{role_type}/{name}'.format(**arn_data)
+
+
+def already_assumed_target_role(**kwargs):
+    target_arn = construct_role_arn('assumed-role', **kwargs)
+    current_arn = boto3.client('sts').get_caller_identity().get('Arn')
+    return current_arn.startswith(target_arn)
+
+
+def _current_session_region():
+    _s = boto3._get_default_session()
+    return _s.region_name
+
+
+def _current_session_credentials_dict():
+    _c = boto3._get_default_session().get_credentials()
+    return {
+        'AccessKeyId': _c.access_key,
+        'SecretAccessKey': _c.secret_key,
+        'SessionToken': _c.token
+    }
+
+
 def sts_client(service, service_type='client'):
     def decorator(f):
         @wraps(f)
         def decorated_function(*args, **kwargs):
             sts = boto3.client('sts')
-            arn = 'arn:aws:iam::{0}:role/{1}'.format(
-                kwargs.pop('account_number'),
-                current_app.config.get('LEMUR_INSTANCE_PROFILE', 'Lemur')
-            )
-            # TODO add user specific information to RoleSessionName
-            role = sts.assume_role(RoleArn=arn, RoleSessionName='lemur')
+
+            region_name = kwargs.get('region') or _current_session_region()
+            role = None
+
+            if already_assumed_target_role(**kwargs):
+                role = {'Credentials': _current_session_credentials_dict()}
+            else:
+                role = sts.assume_role(
+                    RoleArn=construct_role_arn(**kwargs),
+                    # TODO add user specific information to RoleSessionName
+                    RoleSessionName='lemur'
+                )
 
             if service_type == 'client':
                 client = boto3.client(

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ install_requires = [
     'inflection==0.3.1',
     'future==0.15.2',
     'boto==2.38.0',  # we might make this optional
-    'boto3==1.3.0',
+    'boto3==1.4.0',
     'acme==0.1.0',
     'retrying==1.3.3',
     'tabulate==0.7.5'


### PR DESCRIPTION
I am running Lemur in a docker container. 
I had set up https://github.com/swipely/iam-docker already to have the
whole container assume the appropriate role.

I didn't realize until later that lemur itself wanted to trigger
the role change.

This patch makes that optional for people like me, while also addressing
an issue for my next PR, namely the lack of an account_number value along
the ACME route53 path

With this refactor it would be an easy patch to also accept an expected
instance-profile

bumps version of boto3 to 1.4 ; 
though the changes that needed that ( for `boto3.session.Session#get_credentials()`)
could be factored out
