### PR TITLE
feat(certificates): add support for restricted domains

### DIFF
--- a/lemur/common/validators.py
+++ b/lemur/common/validators.py
@@ -1,5 +1,6 @@
 
 import arrow
+from flask import current_app
 from marshmallow.exceptions import ValidationError
 
 from cryptography import x509
@@ -43,11 +44,12 @@ def sensitive_domain(domain):
     :param domain:
     :return:
     """
+    restricted_domains = current_app.config['LEMUR_RESTRICTED_DOMAINS']
     domains = domain_service.get_by_name(domain)
     for domain in domains:
         # we only care about non-admins
         if not SensitiveDomainPermission().can():
-            if domain.sensitive:
+            if domain.sensitive or any([re.match(pattern, domain.name) for pattern in restricted_domains]):
                 raise ValidationError(
                     'Domain {0} has been marked as sensitive, contact and administrator \
                     to issue the certificate.'.format(domain))


### PR DESCRIPTION
Lemur's documentation already mentions LEMUR_RESTRICTED_DOMAINS, a list
of regular expressions matching domains only administrators can issue
certificates for. An option to mark domains as sensitive existed in the
API, however the configuration option was not implemented.

Now both ways of sensitivity are checked in the same place.