### PR TITLE
Removed unknown DEAULT_CONFIG reference from pre-commit module

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -17,13 +17,12 @@ if 'VIRTUAL_ENV' in os.environ:
 
 
 def py_lint(files_modified):
-    from flake8.main import DEFAULT_CONFIG
     from flake8.engine import get_style_guide
 
     # remove non-py files and files which no longer exist
     files_modified = filter(lambda x: x.endswith('.py'), files_modified)
 
-    flake8_style = get_style_guide(parse_argv=True, config_file=DEFAULT_CONFIG)
+    flake8_style = get_style_guide(parse_argv=True)
     report = flake8_style.check_files(files_modified)
 
     return report.total_errors != 0


### PR DESCRIPTION
The pre-commit module's reference to the flake8.main variable DEFAULT_CONFIG does not exist in the version of flake8 packaged with Lemur. This is raising an error when a "git commit" is executed. The flake8 2.6.2 version packaged with project has been refactored to set the local flake8 config file in the flake8/main.py module and the DEFAULT_CONFIG variable has been removed in a previous version of flake8.

With this change, I am able to successfully execute the pre-commit hook to commit changes into my git branch.
