### PR TITLE
Fix test certificates module hanging issue

### DIFF
--- a/lemur/tests/conftest.py
+++ b/lemur/tests/conftest.py
@@ -141,7 +141,7 @@ def issuer_plugin():
 
 
 @pytest.yield_fixture(scope="function")
-def logged_in_user(app):
+def logged_in_user(session, app):
     with app.test_request_context():
         identity_changed.send(current_app._get_current_object(), identity=Identity(1))
         yield

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -340,7 +340,7 @@ def test_create_csr():
     assert private_key
 
 
-def test_import(logged_in_user):
+def test_import(session):
     from lemur.certificates.service import import_certificate
     cert = import_certificate(body=INTERNAL_VALID_LONG_STR, chain=INTERNAL_VALID_SAN_STR, private_key=PRIVATE_KEY_STR)
     assert str(cert.not_after) == '2040-01-01 20:30:52'
@@ -352,7 +352,7 @@ def test_import(logged_in_user):
     assert cert.name == 'ACustomName2'
 
 
-def test_upload(logged_in_user):
+def test_upload(session):
     from lemur.certificates.service import upload
     cert = upload(body=INTERNAL_VALID_LONG_STR, chain=INTERNAL_VALID_SAN_STR, private_key=PRIVATE_KEY_STR, owner='joe@example.com')
     assert str(cert.not_after) == '2040-01-01 20:30:52'

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -340,7 +340,7 @@ def test_create_csr():
     assert private_key
 
 
-def test_import(session):
+def test_import(logged_in_user):
     from lemur.certificates.service import import_certificate
     cert = import_certificate(body=INTERNAL_VALID_LONG_STR, chain=INTERNAL_VALID_SAN_STR, private_key=PRIVATE_KEY_STR)
     assert str(cert.not_after) == '2040-01-01 20:30:52'
@@ -352,7 +352,7 @@ def test_import(session):
     assert cert.name == 'ACustomName2'
 
 
-def test_upload(session):
+def test_upload(logged_in_user):
     from lemur.certificates.service import upload
     cert = upload(body=INTERNAL_VALID_LONG_STR, chain=INTERNAL_VALID_SAN_STR, private_key=PRIVATE_KEY_STR, owner='joe@example.com')
     assert str(cert.not_after) == '2040-01-01 20:30:52'


### PR DESCRIPTION
As part of a new Lemur plugin project, I am planning to add addition unit tests to the lemur/tests/test_certificates.py module. 

When executing the test_certificates.py tests, all tests are executed, but the test process appears to hang and never completes with the results for the tests.

The hanging issue is traced to the two test methods in the module: test_import(logged_in_user) and test_upload(logged_in_user). The issue has to do with the test methods using the logged_in_user fixture from the conftest.py module as their method parameters.

The test methods at issue require the session, db, and app fixtures to be initialized for the tests to complete successfully. The logged_in_user() fixture only initializes the app fixture. Updating the test_import() and test_upload() methods parameters to be the "session" fixture fixes the hanging issue and the tests complete successfully when executed.

Here is the command being used to execute the certificate tests...

$ py.test -s -v lemur/tests/test_certificates.py