### PR TITLE
Active S3 destination plugin

### DIFF
--- a/lemur/common/utils.py
+++ b/lemur/common/utils.py
@@ -40,4 +40,4 @@ def parse_certificate(body):
         if isinstance(body, bytes):
             return x509.load_pem_x509_certificate(body, default_backend())
         return x509.load_pem_x509_certificate(bytes(body, 'utf8'), default_backend())
-    return x509.load_pem_x509_certificate(str(body), default_backend())
+    return x509.load_pem_x509_certificate(body.encode('utf-8'), default_backend())

--- a/lemur/plugins/lemur_aws/plugin.py
+++ b/lemur/plugins/lemur_aws/plugin.py
@@ -210,7 +210,7 @@ class S3DestinationPlugin(DestinationPlugin):
         },
         {
             'name': 'accountNumber',
-            'type': 'int',
+            'type': 'str',
             'required': True,
             'validation': '/^[0-9]{12,12}$/',
             'helpMessage': 'A valid AWS account number with permission to access S3',
@@ -257,7 +257,7 @@ class S3DestinationPlugin(DestinationPlugin):
         super(S3DestinationPlugin, self).__init__(*args, **kwargs)
 
     def upload(self, name, body, private_key, cert_chain, options, **kwargs):
-        account_number = self.get_option('accountId', options)
+        account_number = self.get_option('accountNumber', options)
         encrypt = self.get_option('encrypt', options)
         bucket = self.get_option('bucket', options)
         key = self.get_option('key', options)

--- a/lemur/plugins/lemur_aws/tests/test_plugin.py
+++ b/lemur/plugins/lemur_aws/tests/test_plugin.py
@@ -1,0 +1,6 @@
+
+def test_get_certificates(app):
+    from lemur.plugins.base import plugins
+
+    p = plugins.get('aws-s3')
+    assert p

--- a/setup.py
+++ b/setup.py
@@ -174,6 +174,7 @@ setup(
             'acme_issuer = lemur.plugins.lemur_acme.plugin:ACMEIssuerPlugin',
             'aws_destination = lemur.plugins.lemur_aws.plugin:AWSDestinationPlugin',
             'aws_source = lemur.plugins.lemur_aws.plugin:AWSSourcePlugin',
+            'aws_s3 = lemur.plugins.lemur_aws.plugin:S3DestinationPlugin',
             'email_notification = lemur.plugins.lemur_email.plugin:EmailNotificationPlugin',
             'slack_notification = lemur.plugins.lemur_slack.plugin:SlackNotificationPlugin',
             'java_truststore_export = lemur.plugins.lemur_java.plugin:JavaTruststoreExportPlugin',


### PR DESCRIPTION
As part of a larger set of work to create a new Lemur plugin, we would like to activate the S3 destination plugin. Currently, the plugin is not included in the list of plugins in the ./setup.py module.

In testing the plugin using the existing import certificate process, we uncovered two issues (and the fixes are included in this pull request):

1. Account numbers starting with one or more zeros are not processed correctly - the zeros are dropped which produces an invalid account number. Also, the account number option is incorrectly reference when retrieved for processing.

2. The body certificate validation does not encode the certificate correctly for python3.
