### PR TITLE
Update the private key regex validation

### DIFF
--- a/lemur/static/app/angular/certificates/certificate/upload.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/upload.tpl.html
@@ -60,7 +60,7 @@
 
                 <div class="col-sm-10">
                 <textarea name="privateKey" ng-model="certificate.privateKey" placeholder="PEM encoded string..."
-                          class="form-control" ng-pattern="/^-----BEGIN RSA PRIVATE KEY-----/"></textarea>
+                          class="form-control" ng-pattern="/^(-----BEGIN RSA PRIVATE KEY-----|-----BEGIN PRIVATE KEY-----)/"></textarea>
 
                     <p ng-show="uploadForm.privateKey.$invalid && !uploadForm.privateKey.$pristine" class="help-block">Enter
                         a valid certificate.</p>

--- a/lemur/static/app/angular/certificates/certificate/upload.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/upload.tpl.html
@@ -60,7 +60,7 @@
 
                 <div class="col-sm-10">
                 <textarea name="privateKey" ng-model="certificate.privateKey" placeholder="PEM encoded string..."
-                          class="form-control" ng-pattern="/^(-----BEGIN RSA PRIVATE KEY-----|-----BEGIN PRIVATE KEY-----)/"></textarea>
+                          class="form-control" ng-pattern="/(^-----BEGIN PRIVATE KEY-----[\S\s]*-----END PRIVATE KEY-----)|(^-----BEGIN RSA PRIVATE KEY-----[\S\s]*-----END RSA PRIVATE KEY-----)/"></textarea>
 
                     <p ng-show="uploadForm.privateKey.$invalid && !uploadForm.privateKey.$pristine" class="help-block">Enter
                         a valid certificate.</p>


### PR DESCRIPTION
We have a need to import Let's Encrypt certificates into Lemur. The private keys provided by the Let's Encrypt certificate authority as part of their certificate bundle fail the import/upload certificate private key validation in the UI. The validation is looking for a specific character sequence at the begin of the private key.

In order to support valid Let's Encrypt private keys, we would like to updated the private key regex validation to check for both the existing character sequence and the Let's Encrypt character sequence.

Examples

Existing: -----BEGIN RSA PRIVATE KEY-----

Let's Encrypt: -----BEGIN PRIVATE KEY-----
