### PR TITLE
Fix the Java export default password generator

### DIFF
--- a/lemur/plugins/lemur_java/plugin.py
+++ b/lemur/plugins/lemur_java/plugin.py
@@ -178,7 +178,7 @@ class JavaTruststoreExportPlugin(ExportPlugin):
         if self.get_option('passphrase', options):
             passphrase = self.get_option('passphrase', options)
         else:
-            passphrase = Fernet.generate_key()
+            passphrase = Fernet.generate_key().decode('utf-8')
 
         with mktemppath() as jks_tmp:
             create_truststore(body, chain, jks_tmp, alias, passphrase)
@@ -228,7 +228,7 @@ class JavaKeystoreExportPlugin(ExportPlugin):
         if self.get_option('passphrase', options):
             passphrase = self.get_option('passphrase', options)
         else:
-            passphrase = Fernet.generate_key()
+            passphrase = Fernet.generate_key().decode('utf-8')
 
         if self.get_option('alias', options):
             alias = self.get_option('alias', options)

--- a/lemur/plugins/lemur_java/tests/test_java.py
+++ b/lemur/plugins/lemur_java/tests/test_java.py
@@ -1,21 +1,60 @@
 import pytest
+import six
+
 from lemur.tests.vectors import INTERNAL_CERTIFICATE_A_STR, INTERNAL_PRIVATE_KEY_A_STR
 
 
-def test_export_certificate_to_jks(app):
+def test_export_truststore(app):
     from lemur.plugins.base import plugins
+
     p = plugins.get('java-truststore-jks')
     options = [{'name': 'passphrase', 'value': 'test1234'}]
-    raw = p.export(INTERNAL_CERTIFICATE_A_STR, "", "", options)
-    assert raw != b""
+    actual = p.export(INTERNAL_CERTIFICATE_A_STR, "", "", options)
+
+    assert actual[0] == 'jks'
+    assert actual[1] == 'test1234'
+    assert isinstance(actual[2], bytes)
+
+
+def test_export_truststore_default_password(app):
+    from lemur.plugins.base import plugins
+
+    p = plugins.get('java-truststore-jks')
+    options = []
+    actual = p.export(INTERNAL_CERTIFICATE_A_STR, "", "", options)
+
+    assert actual[0] == 'jks'
+    assert isinstance(actual[1], str)
+    assert isinstance(actual[2], bytes)
 
 
 def test_export_keystore(app):
     from lemur.plugins.base import plugins
+
     p = plugins.get('java-keystore-jks')
     options = [{'name': 'passphrase', 'value': 'test1234'}]
+
     with pytest.raises(Exception):
         p.export(INTERNAL_CERTIFICATE_A_STR, "", "", options)
 
-    raw = p.export(INTERNAL_CERTIFICATE_A_STR, "", INTERNAL_PRIVATE_KEY_A_STR, options)
-    assert raw != b""
+    actual = p.export(INTERNAL_CERTIFICATE_A_STR, "", INTERNAL_PRIVATE_KEY_A_STR, options)
+
+    assert actual[0] == 'jks'
+    assert actual[1] == 'test1234'
+    assert isinstance(actual[2], bytes)
+
+
+def test_export_keystore_default_password(app):
+    from lemur.plugins.base import plugins
+
+    p = plugins.get('java-keystore-jks')
+    options = []
+
+    with pytest.raises(Exception):
+        p.export(INTERNAL_CERTIFICATE_A_STR, "", "", options)
+
+    actual = p.export(INTERNAL_CERTIFICATE_A_STR, "", INTERNAL_PRIVATE_KEY_A_STR, options)
+
+    assert actual[0] == 'jks'
+    assert isinstance(actual[1], six.string_types)
+    assert isinstance(actual[2], bytes)


### PR DESCRIPTION
When exporting a certificate to a Java Keystore or Java Truststore, the password is an optional parameter. When a password is not supplied by the caller, a default password is generated by the export method. The generation library creates the random password as a bytes object. The bytes object raises an error in the '`keytool`' command used to export the certificate. The `keytool` is expecting the password to be a str object.

The fix is to decode the generated password from a bytes object to a str object.

The associated Java plugin tests have been updated to verify the export method returns the password as a str object. In addition, the tests have been updated to correctly test the export methods response object. The original tests treated the response as a single object. The current export methods return a tuple of data (type, password, data).

In order to make the tests compatible with both Python2 and Python3, the 'six' library was used to test the password is in fact a string.
