### PR TITLE
Show only roles that the user is a member of, in list view, for other…

### DIFF
--- a/lemur/roles/views.py
+++ b/lemur/roles/views.py
@@ -7,7 +7,7 @@
 .. moduleauthor:: Kevin Glisson <kglisson@netflix.com>
 
 """
-from flask import Blueprint
+from flask import Blueprint, g
 from flask import make_response, jsonify
 from flask.ext.restful import reqparse, Api
 
@@ -83,6 +83,8 @@ class RolesList(AuthenticatedResource):
         parser.add_argument('id', type=str, location='args')
 
         args = parser.parse_args()
+        if not g.current_user.is_admin:
+            args['user_id'] = g.current_user.id
         return service.render(args)
 
     @admin_permission.require(http_exception=403)

--- a/lemur/tests/test_roles.py
+++ b/lemur/tests/test_roles.py
@@ -91,6 +91,7 @@ def test_role_put_with_data_and_user(client, session):
     from lemur.auth.service import create_token
     user = UserFactory()
     role = RoleFactory(users=[user])
+    role1 = RoleFactory()
     user1 = UserFactory()
     session.commit()
 
@@ -101,13 +102,15 @@ def test_role_put_with_data_and_user(client, session):
 
     data = {
         'users': [
-            {'id': user1.id}
+            {'id': user1.id},
+            {'id': user.id}
         ],
         'id': role.id,
         'name': role.name
     }
 
     assert client.put(api.url_for(Roles, role_id=role.id), data=json.dumps(data), headers=headers).status_code == 200
+    assert client.get(api.url_for(RolesList), data={}, headers=headers).json['total'] == 1
 
 
 @pytest.mark.parametrize("token,status", [


### PR DESCRIPTION
… views show all roles such that certificates and authorities can be shared across teams/groups.