### PR TITLE
Implement a CFSSL issuer plugin

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -51,7 +51,7 @@ Basic Configuration
         CORS = False
 
 
-.. data:: SQLACHEMY_DATABASE_URI
+.. data:: SQLALCHEMY_DATABASE_URI
     :noindex:
 
         If you have ever used sqlalchemy before this is the standard connection string used. Lemur uses a postgres database and the connection string would look something like:
@@ -60,6 +60,11 @@ Basic Configuration
 
         SQLALCHEMY_DATABASE_URI = 'postgresql://<user>:<password>@<hostname>:5432/lemur'
 
+
+.. data:: LEMUR_ALLOW_WEEKEND_EXPIRATION
+    :noindex:
+
+        Specifies whether to allow certificates created by Lemur to expire on weekends. Default is True.
 
 .. data:: LEMUR_RESTRICTED_DOMAINS
     :noindex:
@@ -355,6 +360,26 @@ for those plugins.
 
         This is the root to be used for your CA chain
 
+
+CFSSL Issuer Plugin
+^^^^^^^^^^^^^^^^^^^
+
+The following configuration properties are required to use the the CFSSL issuer plugin.
+
+.. data:: CFSSL_URL
+    :noindex:
+
+        This is the URL for the CFSSL API
+
+.. data:: CFSSL_ROOT
+    :noindex:
+
+        This is the root to be used for your CA chain
+
+.. data:: CFSSL_INTERMEDIATE
+    :noindex:
+
+        This is the intermediate to be used for your CA chain
 
 
 AWS Source/Destination Plugin
@@ -831,6 +856,17 @@ Openssl
     Leverages Openssl to support additional export formats (pkcs12)
 
 
+CFSSL
+-----
+
+:Authors:
+    Charles Hendrie <chad.hendrie@thomsonreuters.com>
+:Type:
+    Issuer
+:Description:
+    Basic support for generating certificates from the private certificate authority CFSSL
+
+
 3rd Party Plugins
 =================
 
@@ -881,4 +917,3 @@ These permissions are applied to the user upon login and refreshed on every requ
 .. seealso::
 
     `Flask-Principal <https://pythonhosted.org/Flask-Principal>`_
-

--- a/docs/developer/internals/lemur.plugins.lemur_cfssl.rst
+++ b/docs/developer/internals/lemur.plugins.lemur_cfssl.rst
@@ -1,0 +1,20 @@
+lemur_cfssl Package
+===================
+
+:mod:`lemur_cfssl` Package
+--------------------------
+
+.. automodule:: lemur.plugins.lemur_cfssl
+    :noindex:
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+:mod:`plugin` Module
+--------------------
+
+.. automodule:: lemur.plugins.lemur_cfssl.plugin
+    :noindex:
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/developer/internals/lemur.plugins.rst
+++ b/docs/developer/internals/lemur.plugins.rst
@@ -27,5 +27,6 @@ Subpackages
     lemur.plugins.base
     lemur.plugins.bases
     lemur.plugins.lemur_aws
+    lemur.plugins.lemur_cfssl
     lemur.plugins.lemur_email
     lemur.plugins.lemur_verisign

--- a/lemur/plugins/lemur_cfssl/__init__.py
+++ b/lemur/plugins/lemur_cfssl/__init__.py
@@ -1,0 +1,5 @@
+try:
+    VERSION = __import__('pkg_resources') \
+        .get_distribution(__name__).version
+except Exception as e:
+    VERSION = 'unknown'

--- a/lemur/plugins/lemur_cfssl/plugin.py
+++ b/lemur/plugins/lemur_cfssl/plugin.py
@@ -1,0 +1,64 @@
+"""
+.. module: lemur.plugins.lemur_cfssl.cfssl
+    :platform: Unix
+    :synopsis: This module is responsible for communicating with the CFSSL private CA.
+    :copyright: (c) 2016 by Thomson Reuters
+    :license: Apache, see LICENSE for more details.
+
+.. moduleauthor:: Charles Hendrie <chad.hendrie@tr.com>
+"""
+
+import json
+import requests
+
+from flask import current_app
+
+from lemur.plugins.bases import IssuerPlugin
+from lemur.plugins import lemur_cfssl as cfssl
+
+
+class CfsslIssuerPlugin(IssuerPlugin):
+    title = 'CFSSL'
+    slug = 'cfssl-issuer'
+    description = 'Enables the creation of certificates by CFSSL private CA'
+    version = cfssl.VERSION
+
+    author = 'Charles Hendrie'
+    author_url = 'https://github.com/netflix/lemur.git'
+
+    def __init__(self, *args, **kwargs):
+        self.session = requests.Session()
+        super(CfsslIssuerPlugin, self).__init__(*args, **kwargs)
+
+    def create_certificate(self, csr, issuer_options):
+        """
+        Creates a CFSSL certificate.
+
+        :param csr:
+        :param issuer_options:
+        :return:
+        """
+        current_app.logger.info("Requesting a new cfssl certificate with csr: {0}".format(csr))
+
+        url = "{0}{1}".format(current_app.config.get('CFSSL_URL'), '/api/v1/cfssl/sign')
+
+        data = {'certificate_request': csr.decode('utf_8')}
+        data = json.dumps(data)
+
+        response = self.session.post(url, data=data.encode(encoding='utf_8', errors='strict'))
+        response_json = json.loads(response.content.decode('utf_8'))
+        cert = response_json['result']['certificate']
+
+        return cert, current_app.config.get('CFSSL_INTERMEDIATE'),
+
+    @staticmethod
+    def create_authority(options):
+        """
+        Creates an authority, this authority is then used by Lemur to allow a user
+        to specify which Certificate Authority they want to sign their certificate.
+
+        :param options:
+        :return:
+        """
+        role = {'username': '', 'password': '', 'name': 'cfssl'}
+        return current_app.config.get('CFSSL_ROOT'), "", [role]

--- a/lemur/plugins/lemur_cfssl/plugin.py
+++ b/lemur/plugins/lemur_cfssl/plugin.py
@@ -1,5 +1,5 @@
 """
-.. module: lemur.plugins.lemur_cfssl.cfssl
+.. module: lemur.plugins.lemur_cfssl.plugin
     :platform: Unix
     :synopsis: This module is responsible for communicating with the CFSSL private CA.
     :copyright: (c) 2016 by Thomson Reuters

--- a/lemur/plugins/lemur_cfssl/tests/conftest.py
+++ b/lemur/plugins/lemur_cfssl/tests/conftest.py
@@ -1,0 +1,1 @@
+from lemur.tests.conftest import *  # noqa

--- a/lemur/plugins/lemur_cfssl/tests/test_cfssl.py
+++ b/lemur/plugins/lemur_cfssl/tests/test_cfssl.py
@@ -1,0 +1,6 @@
+
+def test_get_certificates(app):
+    from lemur.plugins.base import plugins
+
+    p = plugins.get('cfssl-issuer')
+    assert p

--- a/setup.py
+++ b/setup.py
@@ -183,6 +183,7 @@ setup(
             'atlas_metric = lemur.plugins.lemur_atlas.plugin:AtlasMetricPlugin',
             'kubernetes_destination = lemur.plugins.lemur_kubernetes.plugin:KubernetesDestinationPlugin',
             'cryptography_issuer = lemur.plugins.lemur_cryptography.plugin:CryptographyIssuerPlugin',
+            'cfssl_issuer = lemur.plugins.lemur_cfssl.plugin:CfsslIssuerPlugin',
         ],
     },
     classifiers=[


### PR DESCRIPTION
As part of our adoption of Lemur as our certificate manager, we are planning to use CFSSL (https://github.com/cloudflare/cfssl) as our internal certificate authority.

The new plugin interacts with CFSSL through the CFSSL REST API. The CFSSL configuration is defined in the lemur.conf.py property file using property names prefixed with "CFSSL_". The CFSSL certificates have been successfully created and tested using both python 2.7 and 3.5.

Please review and let us know if you see any issues with the plugin.
