### PR TITLE
Removing the ability to use spaces in custom names.

### DIFF
--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -27,6 +27,7 @@ from lemur.domains.models import Domain
 
 
 def get_or_increase_name(name):
+    name = '-'.join(name.strip().split(' '))
     count = Certificate.query.filter(Certificate.name.ilike('{0}%'.format(name))).count()
 
     if count >= 1:


### PR DESCRIPTION
Closes #432.

This change essentially disallow spaces in certificate names by replacing spaces with '-'.