### PR TITLE
fix python2.x branch of get_rsa_public_key (auth/service.py)

### DIFF
--- a/lemur/auth/service.py
+++ b/lemur/auth/service.py
@@ -44,8 +44,8 @@ def get_rsa_public_key(n, e):
         n = int(binascii.hexlify(jwt.utils.base64url_decode(bytes(n, 'utf-8'))), 16)
         e = int(binascii.hexlify(jwt.utils.base64url_decode(bytes(e, 'utf-8'))), 16)
     else:
-        n = int(binascii.hexlify(jwt.utils.base64url_decode(n)), 16)
-        e = int(binascii.hexlify(jwt.utils.base64url_decode(e, 'utf-8')), 16)
+        n = int(binascii.hexlify(jwt.utils.base64url_decode(str(n))), 16)
+        e = int(binascii.hexlify(jwt.utils.base64url_decode(str(e))), 16)
 
     pub = RSAPublicNumbers(e, n).public_key(default_backend())
     return pub.public_bytes(


### PR DESCRIPTION
Two issues are present
1. The value returned by the json is utf-8 and base64url_decode requires a string. An explicit conversion is needed. (lines 47 and 48)
2. The base64url_decode function takes a single paramters not two as in python 3 (lines 48)
