### PR TITLE
Allow Lemur "start" to use the global config. 

### DIFF
--- a/lemur/common/managers.py
+++ b/lemur/common/managers.py
@@ -60,11 +60,14 @@ class InstanceManager(object):
                     results.append(cls())
                 else:
                     results.append(cls)
+
             except InvalidConfiguration as e:
                 current_app.logger.warning("Plugin '{0}' may not work correctly. {1}".format(class_name, e))
+
             except Exception as e:
                 current_app.logger.exception("Unable to import {0}. Reason: {1}".format(cls_path, e))
                 continue
+
         self.cache = results
 
         return results

--- a/lemur/factory.py
+++ b/lemur/factory.py
@@ -92,6 +92,7 @@ def configure_app(app, config=None):
     """
     # respect the config first
     if config and config != 'None':
+        app.config['CONFIG_PATH'] = config
         app.config.from_object(from_file(config))
     else:
         try:
@@ -102,6 +103,9 @@ def configure_app(app, config=None):
                 app.config.from_object(from_file(os.path.expanduser("~/.lemur/lemur.conf.py")))
             else:
                 app.config.from_object(from_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'default.conf.py')))
+
+    # we don't use this
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 
 def configure_extensions(app):

--- a/lemur/manage.py
+++ b/lemur/manage.py
@@ -356,9 +356,6 @@ class LemurServer(Command):
         options = []
         for setting, klass in settings.items():
             if klass.cli:
-                if klass.name == 'config':
-                    continue
-
                 if klass.action:
                     if klass.action == 'store_const':
                         options.append(Option(*klass.cli, const=klass.const, action=klass.action))

--- a/lemur/manage.py
+++ b/lemur/manage.py
@@ -119,7 +119,6 @@ LOG_FILE = "lemur.log"
 # modify this if you are not using a local database
 SQLALCHEMY_DATABASE_URI = 'postgresql://lemur:lemur@localhost:5432/lemur'
 
-
 # AWS
 
 #LEMUR_INSTANCE_PROFILE = 'Lemur'
@@ -357,6 +356,9 @@ class LemurServer(Command):
         options = []
         for setting, klass in settings.items():
             if klass.cli:
+                if klass.name == 'config':
+                    continue
+
                 if klass.action:
                     if klass.action == 'store_const':
                         options.append(Option(*klass.cli, const=klass.const, action=klass.action))
@@ -373,10 +375,9 @@ class LemurServer(Command):
         app = WSGIApplication()
 
         # run startup tasks on a app like object
-        pre_app = create_app(kwargs.get('config'))
-        validate_conf(pre_app, REQUIRED_VARIABLES)
+        validate_conf(current_app, REQUIRED_VARIABLES)
 
-        app.app_uri = 'lemur:create_app(config="{0}")'.format(kwargs.get('config'))
+        app.app_uri = 'lemur:create_app(config="{0}")'.format(current_app.config.get('CONFIG_PATH'))
 
         return app.run()
 


### PR DESCRIPTION
Closes #588 

When a config is passed via the command line we set a var in the current app for this configuration's path. As there is no way to pass an app factory to the WSGIApplication itself we use this path and then pass it through to the WSGI application again.