### PR TITLE
Minor documentation fixes/tweaks

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -415,7 +415,7 @@ The following configuration properties are required to use the Digicert issuer p
 CFSSL Issuer Plugin
 ^^^^^^^^^^^^^^^^^^^
 
-The following configuration properties are required to use the the CFSSL issuer plugin.
+The following configuration properties are required to use the CFSSL issuer plugin.
 
 .. data:: CFSSL_URL
     :noindex:
@@ -489,7 +489,7 @@ STS-AssumeRole
 
 
 
-Next we will create the the Lemur IAM role.
+Next we will create the Lemur IAM role.
 
 .. note::
 
@@ -739,7 +739,7 @@ and to get help on sub-commands
 Upgrading Lemur
 ===============
 
-To upgrade Lemur to the newest release you will need to ensure you have the lastest code and have run any needed
+To upgrade Lemur to the newest release you will need to ensure you have the latest code and have run any needed
 database migrations.
 
 To get the latest code from github run
@@ -947,7 +947,7 @@ Identity and Access Management
 
 Lemur uses a Role Based Access Control (RBAC) mechanism to control which users have access to which resources. When a
 user is first created in Lemur they can be assigned one or more roles. These roles are typically dynamically created
-depending on a external identity provider (Google, LDAP, etc.,) or are hardcoded within Lemur and associated with special
+depending on an external identity provider (Google, LDAP, etc.), or are hardcoded within Lemur and associated with special
 meaning.
 
 Within Lemur there are three main permissions: AdminPermission, CreatorPermission, OwnerPermission. Sub-permissions such

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -48,7 +48,7 @@ of Lemur. You'll want to make sure you have a few things on your local system fi
 * pip
 * virtualenv (ideally virtualenvwrapper)
 * node.js (for npm and building css/javascript)
-* (Optional) Potgresql
+* (Optional) PostgreSQL
 
 Once you've got all that, the rest is simple:
 
@@ -156,7 +156,7 @@ This is accomplished with a Gulp task:
 The gulp task compiles all the JS/CSS/HTML files and opens the Lemur welcome page in your default browsers. Additionally any changes to made to the JS/CSS/HTML with be reloaded in your browsers.
 
 Developing with Flask
-----------------------
+---------------------
 
 Because Lemur is just Flask, you can use all of the standard Flask functionality. The only difference is you'll be accessing commands that would normally go through manage.py using the ``lemur`` CLI helper instead.
 
@@ -175,7 +175,7 @@ Schema changes should always introduce the new schema in a commit, and then intr
 
 Removing columns and tables requires a slightly more painful flow, and should resemble the follow multi-commit flow:
 
-- Remove all references to the column or table (but dont remove the Model itself)
+- Remove all references to the column or table (but don't remove the Model itself)
 - Remove the model code
 - Remove the table or column
 

--- a/docs/developer/plugins/index.rst
+++ b/docs/developer/plugins/index.rst
@@ -154,20 +154,20 @@ that can be used to help define sub-destinations.
 For example, if we look at the aws-destination plugin we can see that it defines an `accountNumber` option::
 
     options = [
-      {
-          'name': 'accountNumber',
-          'type': 'int',
-          'required': True,
-          'validation': '/^[0-9]{12,12}$/',
-          'helpMessage': 'Must be a valid AWS account number!',
-      }
+        {
+            'name': 'accountNumber',
+            'type': 'int',
+            'required': True,
+            'validation': '/^[0-9]{12,12}$/',
+            'helpMessage': 'Must be a valid AWS account number!',
+        }
     ]
 
 By defining an `accountNumber` we can make this plugin handle many N number of AWS accounts instead of just one.
 
 The schema for defining plugin options are pretty straightforward:
 
-  - **Name**: name of the variable you wish to present the user, snake case (snakeCase) is preferrred as Lemur
+  - **Name**: name of the variable you wish to present the user, snake case (snakeCase) is preferred as Lemur
     will parse these and create pretty variable titles
   - **Type** there are currently four supported variable types
       - **Int** creates an html integer box for the user to enter integers into
@@ -200,7 +200,7 @@ You would also then need to build additional code to trigger the new notificatio
 
 The second is `ExpirationNotificationPlugin`, this object inherits from `NotificationPlugin` object.
 You will most likely want to base your plugin on, if you want to add new channels for expiration notices (Slack, Hipcat, Jira, etc.). It adds default options that are required by
-by all expiration notifications (interval, unit). This interface expects for the child to define the following function::
+all expiration notifications (interval, unit). This interface expects for the child to define the following function::
 
     def send(self):
         #  request.post("some alerting infrastructure")
@@ -210,10 +210,10 @@ Source
 ------
 
 When building Lemur we realized that although it would be nice if every certificate went through Lemur to get issued, but this is not
-always be the case. Often times there are third parties that will issue certificates on your behalf and these can get deployed
+always be the case. Oftentimes there are third parties that will issue certificates on your behalf and these can get deployed
 to infrastructure without any interaction with Lemur. In an attempt to combat this and try to track every certificate, Lemur has a notion of
 certificate **Sources**. Lemur will contact the source at periodic intervals and attempt to **sync** against the source. This means downloading or discovering any
-certificate Lemur does not know about and adding the certificate to it's inventory to be tracked and alerted on.
+certificate Lemur does not know about and adding the certificate to its inventory to be tracked and alerted on.
 
 The `SourcePlugin` object has one default option of `pollRate`. This controls the number of seconds which to get new certificates.
 
@@ -230,7 +230,7 @@ The `SourcePlugin` object requires implementation of one function::
 
 
 .. note::
-    Often times to facilitate code re-use it makes sense put source and destination plugins into one package.
+    Oftentimes to facilitate code re-use it makes sense put source and destination plugins into one package.
 
 
 Export
@@ -270,9 +270,9 @@ Augment your setup.py to ensure at least the following:
 
    setup(
        # ...
-      install_requires=[
+       install_requires=[
           'lemur',
-      ]
+       ]
    )
 
 

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -18,7 +18,7 @@ that Lemur can then manage.
 
 .. figure:: create_authority.png
 
-    Enter a authority name and short description about the authority. Enter an owner,
+    Enter an authority name and short description about the authority. Enter an owner,
     and certificate common name. Depending on the authority and the authority/issuer plugin
     these values may or may not be used.
 
@@ -56,7 +56,7 @@ Import an Existing Certificate
 
 .. figure:: upload_certificate.png
 
-    Enter a owner, short description and public certificate. If there are intermediates and private keys
+    Enter an owner, short description and public certificate. If there are intermediates and private keys
     Lemur will track them just as it does if the certificate were created through Lemur. Lemur generates
     a certificate name but you can override that by passing a value to the `Custom Name` field.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,7 +54,7 @@ Doing a Release
     doing-a-release
 
 FAQ
-----
+---
 
 .. toctree::
     :maxdepth: 1

--- a/docs/production/index.rst
+++ b/docs/production/index.rst
@@ -37,13 +37,13 @@ Entropy
 -------
 
 Lemur generates private keys for the certificates it creates. This means that it is vitally important that Lemur has enough entropy to draw from. To generate private keys Lemur uses the python library `Cryptography <https://cryptography.io>`_. In turn Cryptography uses OpenSSL bindings to generate
-keys just like you might from the OpenSSL command line. OpenSSL draws it's initial entropy from system during startup and uses PRNGs to generate a stream of random bytes (as output by /dev/urandom) whenever it needs to do a cryptographic operation.
+keys just like you might from the OpenSSL command line. OpenSSL draws its initial entropy from system during startup and uses PRNGs to generate a stream of random bytes (as output by /dev/urandom) whenever it needs to do a cryptographic operation.
 
 What does all this mean? Well in order for the keys
 that Lemur generates to be strong, the system needs to interact with the outside world. This is typically accomplished through the systems hardware (thermal, sound, video user-input, etc.) since the physical world is much more "random" than the computer world.
 
-If you are running Lemur on its own server with its own hardware "bare metal" then the entropy of the system is typically "good enough" for generating keys. If however you are using an VM on shared hardware there is a potential that your initial seed data (data that was initially
-fed to the PRNG) is not very good. What's more VMs have been known to be unable to inject more entropy into the system once it has been started. This is because there is typically very little interaction with the server once it has been started.
+If you are running Lemur on its own server with its own hardware "bare metal" then the entropy of the system is typically "good enough" for generating keys. If however you are using a VM on shared hardware there is a potential that your initial seed data (data that was initially
+fed to the PRNG) is not very good. What's more, VMs have been known to be unable to inject more entropy into the system once it has been started. This is because there is typically very little interaction with the server once it has been started.
 
 The amount of effort you wish to expend ensuring that Lemur has good entropy to draw from is up to your specific risk tolerance and how Lemur is configured.
 
@@ -72,7 +72,7 @@ Nginx is a very popular choice to serve a Python project:
 Nginx doesn't run any Python process, it only serves requests from outside to
 the Python server.
 
-Therefore there are two steps:
+Therefore, there are two steps:
 
 - Run the Python process.
 - Run Nginx.
@@ -223,7 +223,7 @@ Also included in the configurations above are several best practices when it com
 HSTS, disabling vulnerable ciphers are all good ideas when it comes to deploying Lemur into a production environment.
 
 .. note::
-    This is a rather incomplete apache config for running Lemur (needs mod_wsgi etc.,), if you have a working apache config please let us know!
+    This is a rather incomplete apache config for running Lemur (needs mod_wsgi etc.), if you have a working apache config please let us know!
 
 .. seealso::
     `Mozilla SSL Configuration Generator <https://mozilla.github.io/server-side-tls/ssl-config-generator/>`_

--- a/docs/quickstart/index.rst
+++ b/docs/quickstart/index.rst
@@ -16,7 +16,7 @@ Some basic prerequisites which you'll need in order to run Lemur:
 * PostgreSQL 9.4 or greater
 * Nginx
 
-.. note:: Lemur was built with in AWS in mind. This means that things such as databases (RDS), mail (SES), and TLS (ELB), are largely handled for us.  Lemur does **not** require AWS to function. Our guides and documentation try to be be as generic as possible and are not intended to document every step of launching Lemur into a given environment.
+.. note:: Lemur was built with in AWS in mind. This means that things such as databases (RDS), mail (SES), and TLS (ELB), are largely handled for us.  Lemur does **not** require AWS to function. Our guides and documentation try to be as generic as possible and are not intended to document every step of launching Lemur into a given environment.
 
 
 Installing Build Dependencies
@@ -105,7 +105,7 @@ Update your configuration
 
 Once created, you will need to update the configuration file with information about your environment, such as which database to talk to, where keys are stored etc.
 
-.. note:: If you are unfamiliar with with the SQLALCHEMY_DATABASE_URI string it can be broken up like so:
+.. note:: If you are unfamiliar with the SQLALCHEMY_DATABASE_URI string it can be broken up like so:
       ``postgresql://userame:password@<database-fqdn>:<database-port>/<database-name>``
 
 
@@ -134,7 +134,7 @@ Next, we will create our new database:
 .. _InitializingLemur:
 
 .. note::
-    For this guide we assume you will use the `postgres` user to connect to your database, when deploying to a VM or container this is often all you will need. If you have a shared database it is recommend you give Lemur it's own user.
+    For this guide we assume you will use the `postgres` user to connect to your database, when deploying to a VM or container this is often all you will need. If you have a shared database it is recommend you give Lemur its own user.
 
 .. note::
     Postgres 9.4 or greater is required as Lemur relies advanced data columns (e.g. JSON Column type)

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -60,7 +60,7 @@ and public disclosure may be shortened considerably.
 
 The list of people and organizations who receives advanced notification of
 security issues is not, and will not, be made public. This list generally
-consists of high profile downstream distributors and is entirely at the
+consists of high-profile downstream distributors and is entirely at the
 discretion of the ``lemur`` team.
 
 .. _`master`: https://github.com/Netflix/lemur

--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -108,7 +108,7 @@ class Login(Resource):
 class Ping(Resource):
     """
     This class serves as an example of how one might implement an SSO provider for use with Lemur. In
-    this example we use a OpenIDConnect authentication flow, that is essentially OAuth2 underneath. If you have an
+    this example we use an OpenIDConnect authentication flow, that is essentially OAuth2 underneath. If you have an
     OAuth2 provider you want to use Lemur there would be two steps:
 
     1. Define your own class that inherits from :class:`flask.ext.restful.Resource` and create the HTTP methods the \

--- a/lemur/authorities/models.py
+++ b/lemur/authorities/models.py
@@ -1,7 +1,7 @@
 """
 .. module: lemur.authorities.models
     :platform: unix
-    :synopsis: This module contains all of the models need to create a authority within Lemur.
+    :synopsis: This module contains all of the models need to create an authority within Lemur.
     :copyright: (c) 2015 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.
 .. moduleauthor:: Kevin Glisson <kglisson@netflix.com>

--- a/lemur/authorities/service.py
+++ b/lemur/authorities/service.py
@@ -18,7 +18,7 @@ from lemur.certificates.service import upload
 
 def update(authority_id, description=None, owner=None, active=None, roles=None):
     """
-    Update a an authority with new values.
+    Update an authority with new values.
 
     :param authority_id:
     :param roles: roles that are allowed to use this authority
@@ -178,7 +178,7 @@ def render(args):
         else:
             query = database.filter(query, Authority, terms)
 
-    # we make sure that a user can only use an authority they either own are are a member of - admins can see all
+    # we make sure that a user can only use an authority they either own are a member of - admins can see all
     if not args['user'].is_admin:
         authority_ids = []
         for authority in args['user'].authorities:

--- a/lemur/authorities/views.py
+++ b/lemur/authorities/views.py
@@ -95,7 +95,7 @@ class AuthoritiesList(AuthenticatedResource):
               }
 
            :query sortBy: field to sort on
-           :query sortDir: acs or desc
+           :query sortDir: asc or desc
            :query page: int default is 1
            :query filter: key value pair. format is k;v
            :query count: count number default is 10
@@ -285,7 +285,7 @@ class Authorities(AuthenticatedResource):
         """
         .. http:put:: /authorities/1
 
-           Update a authority
+           Update an authority
 
            **Example request**:
 

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -32,7 +32,7 @@ from lemur.roles import service as role_service
 
 def get(cert_id):
     """
-    Retrieves certificate by it's ID.
+    Retrieves certificate by its ID.
 
     :param cert_id:
     :return:
@@ -42,7 +42,7 @@ def get(cert_id):
 
 def get_by_name(name):
     """
-    Retrieves certificate by it's Name.
+    Retrieves certificate by its Name.
 
     :param name:
     :return:

--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -111,7 +111,7 @@ class CertificatesList(AuthenticatedResource):
               }
 
            :query sortBy: field to sort on
-           :query sortDir: acs or desc
+           :query sortDir: asc or desc
            :query page: int. default is 1
            :query filter: key value pair format is k;v
            :query count: count number. default is 10
@@ -296,10 +296,10 @@ class CertificatesUpload(AuthenticatedResource):
               Accept: application/json, text/javascript
 
               {
-                 "owner": "joe@exmaple.com",
-                 "publicCert": "---Begin Public...",
-                 "intermediateCert": "---Begin Public...",
-                 "privateKey": "---Begin Private..."
+                 "owner": "joe@example.com",
+                 "publicCert": "-----BEGIN CERTIFICATE-----...",
+                 "intermediateCert": "-----BEGIN CERTIFICATE-----...",
+                 "privateKey": "-----BEGIN RSA PRIVATE KEY-----..."
                  "destinations": [],
                  "notifications": [],
                  "replacements": [],
@@ -427,7 +427,7 @@ class CertificatePrivateKey(AuthenticatedResource):
               Content-Type: text/javascript
 
               {
-                 "key": "----Begin ...",
+                 "key": "-----BEGIN ...",
               }
 
            :reqheader Authorization: OAuth token to authenticate
@@ -732,7 +732,7 @@ class NotificationCertificatesList(AuthenticatedResource):
               }
 
            :query sortBy: field to sort on
-           :query sortDir: acs or desc
+           :query sortDir: asc or desc
            :query page: int default is 1
            :query filter: key value pair format is k;v
            :query count: count number default is 10

--- a/lemur/defaults/views.py
+++ b/lemur/defaults/views.py
@@ -1,5 +1,5 @@
 """
-.. module: lemur.status.views
+.. module: lemur.defaults.views
     :copyright: (c) 2015 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.
 """

--- a/lemur/destinations/service.py
+++ b/lemur/destinations/service.py
@@ -56,7 +56,7 @@ def delete(destination_id):
 
 def get(destination_id):
     """
-    Retrieves an destination by it's lemur assigned ID.
+    Retrieves an destination by its lemur assigned ID.
 
     :param destination_id: Lemur assigned ID
     :rtype : Destination
@@ -67,7 +67,7 @@ def get(destination_id):
 
 def get_by_label(label):
     """
-    Retrieves a destination by it's label
+    Retrieves a destination by its label
 
     :param label:
     :return:

--- a/lemur/destinations/views.py
+++ b/lemur/destinations/views.py
@@ -82,7 +82,7 @@ class DestinationsList(AuthenticatedResource):
               }
 
            :query sortBy: field to sort on
-           :query sortDir: acs or desc
+           :query sortDir: asc or desc
            :query page: int. default is 1
            :query filter: key value pair format is k;v
            :query count: count number default is 10
@@ -392,7 +392,7 @@ class CertificateDestinations(AuthenticatedResource):
               }
 
            :query sortBy: field to sort on
-           :query sortDir: acs or desc
+           :query sortDir: asc or desc
            :query page: int default is 1
            :query filter: key value pair format is k;v
            :query count: count number default is 10

--- a/lemur/domains/service.py
+++ b/lemur/domains/service.py
@@ -34,7 +34,7 @@ def get_all():
 
 def get_by_name(name):
     """
-    Fetches domain by it's name
+    Fetches domain by its name
 
     :param name:
     :return:

--- a/lemur/domains/views.py
+++ b/lemur/domains/views.py
@@ -68,7 +68,7 @@ class DomainsList(AuthenticatedResource):
               }
 
            :query sortBy: field to sort on
-           :query sortDir: acs or desc
+           :query sortDir: asc or desc
            :query page: int default is 1
            :query filter: key value pair format is k;v
            :query count: count number. default is 10
@@ -115,7 +115,7 @@ class DomainsList(AuthenticatedResource):
               }
 
            :query sortBy: field to sort on
-           :query sortDir: acs or desc
+           :query sortDir: asc or desc
            :query page: int default is 1
            :query filter: key value pair format is k;v
            :query count: count number default is 10
@@ -255,7 +255,7 @@ class CertificateDomains(AuthenticatedResource):
               }
 
            :query sortBy: field to sort on
-           :query sortDir: acs or desc
+           :query sortDir: asc or desc
            :query page: int default is 1
            :query filter: key value pair format is k;v
            :query count: count number default is 10

--- a/lemur/endpoints/cli.py
+++ b/lemur/endpoints/cli.py
@@ -1,5 +1,5 @@
 """
-.. module: lemur.certificate.cli
+.. module: lemur.endpoints.cli
     :platform: Unix
     :copyright: (c) 2015 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.

--- a/lemur/endpoints/models.py
+++ b/lemur/endpoints/models.py
@@ -1,7 +1,7 @@
 """
 .. module: lemur.endpoints.models
     :platform: unix
-    :synopsis: This module contains all of the models need to create a authority within Lemur.
+    :synopsis: This module contains all of the models need to create an authority within Lemur.
     :copyright: (c) 2015 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.
 .. moduleauthor:: Kevin Glisson <kglisson@netflix.com>

--- a/lemur/endpoints/views.py
+++ b/lemur/endpoints/views.py
@@ -51,7 +51,7 @@ class EndpointsList(AuthenticatedResource):
 
 
            :query sortBy: field to sort on
-           :query sortDir: acs or desc
+           :query sortDir: asc or desc
            :query page: int default is 1
            :query filter: key value pair. format is k;v
            :query limit: limit number default is 10

--- a/lemur/logs/views.py
+++ b/lemur/logs/views.py
@@ -1,5 +1,5 @@
 """
-.. module: lemur.log.views
+.. module: lemur.logs.views
     :platform: Unix
     :copyright: (c) 2015 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.
@@ -57,7 +57,7 @@ class LogsList(AuthenticatedResource):
               }
 
            :query sortBy: field to sort on
-           :query sortDir: acs or desc
+           :query sortDir: asc or desc
            :query page: int default is 1
            :query filter: key value pair format is k;v
            :query count: count number default is 10

--- a/lemur/manage.py
+++ b/lemur/manage.py
@@ -372,7 +372,7 @@ class LemurServer(Command):
 
         app = WSGIApplication()
 
-        # run startup tasks on a app like object
+        # run startup tasks on an app like object
         pre_app = create_app(kwargs.get('config'))
         validate_conf(pre_app, REQUIRED_VARIABLES)
 

--- a/lemur/notifications/service.py
+++ b/lemur/notifications/service.py
@@ -127,7 +127,7 @@ def delete(notification_id):
 
 def get(notification_id):
     """
-    Retrieves an notification by it's lemur assigned ID.
+    Retrieves an notification by its lemur assigned ID.
 
     :param notification_id: Lemur assigned ID
     :rtype : Notification
@@ -138,7 +138,7 @@ def get(notification_id):
 
 def get_by_label(label):
     """
-    Retrieves a notification by it's label
+    Retrieves a notification by its label
 
     :param label:
     :return:

--- a/lemur/notifications/views.py
+++ b/lemur/notifications/views.py
@@ -95,7 +95,7 @@ class NotificationsList(AuthenticatedResource):
                }
 
            :query sortBy: field to sort on
-           :query sortDir: acs or desc
+           :query sortDir: asc or desc
            :query page: int default is 1
            :query filter: key value pair format is k;v
            :query count: count number default is 10
@@ -419,7 +419,7 @@ class CertificateNotifications(AuthenticatedResource):
                }
 
            :query sortBy: field to sort on
-           :query sortDir: acs or desc
+           :query sortDir: asc or desc
            :query page: int default is 1
            :query filter: key value pair format is k;v
            :query count: count number default is 10

--- a/lemur/plugins/bases/destination.py
+++ b/lemur/plugins/bases/destination.py
@@ -1,5 +1,5 @@
 """
-.. module: lemur.bases.destination
+.. module: lemur.plugins.bases.destination
     :platform: Unix
     :copyright: (c) 2015 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.

--- a/lemur/plugins/bases/export.py
+++ b/lemur/plugins/bases/export.py
@@ -1,5 +1,5 @@
 """
-.. module: lemur.bases.export
+.. module: lemur.plugins.bases.export
     :platform: Unix
     :copyright: (c) 2015 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.

--- a/lemur/plugins/bases/issuer.py
+++ b/lemur/plugins/bases/issuer.py
@@ -1,5 +1,5 @@
 """
-.. module: lemur.bases.issuer
+.. module: lemur.plugins.bases.issuer
     :platform: Unix
     :copyright: (c) 2015 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.

--- a/lemur/plugins/bases/metric.py
+++ b/lemur/plugins/bases/metric.py
@@ -1,5 +1,5 @@
 """
-.. module: lemur.bases.metric
+.. module: lemur.plugins.bases.metric
     :platform: Unix
     :copyright: (c) 2015 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.

--- a/lemur/plugins/bases/notification.py
+++ b/lemur/plugins/bases/notification.py
@@ -1,5 +1,5 @@
 """
-.. module: lemur.bases.notification
+.. module: lemur.plugins.bases.notification
     :platform: Unix
     :copyright: (c) 2015 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.

--- a/lemur/plugins/bases/source.py
+++ b/lemur/plugins/bases/source.py
@@ -1,5 +1,5 @@
 """
-.. module: lemur.bases.source
+.. module: lemur.plugins.bases.source
     :platform: Unix
     :copyright: (c) 2015 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.

--- a/lemur/plugins/lemur_acme/plugin.py
+++ b/lemur/plugins/lemur_acme/plugin.py
@@ -1,7 +1,7 @@
 """
-.. module: lemur.plugins.lemur_acme.acme
+.. module: lemur.plugins.lemur_acme.plugin
     :platform: Unix
-    :synopsis: This module is responsible for communicating with a ACME CA.
+    :synopsis: This module is responsible for communicating with an ACME CA.
     :copyright: (c) 2015 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.
 
@@ -179,7 +179,7 @@ class ACMEIssuerPlugin(IssuerPlugin):
 
     def create_certificate(self, csr, issuer_options):
         """
-        Creates a ACME certificate.
+        Creates an ACME certificate.
 
         :param csr:
         :param issuer_options:

--- a/lemur/plugins/lemur_aws/ec2.py
+++ b/lemur/plugins/lemur_aws/ec2.py
@@ -1,5 +1,5 @@
 """
-.. module: lemur.plugins.lemur_aws.elb
+.. module: lemur.plugins.lemur_aws.ec2
     :synopsis: Module contains some often used and helpful classes that
     are used to deal with ELBs
 

--- a/lemur/plugins/lemur_aws/plugin.py
+++ b/lemur/plugins/lemur_aws/plugin.py
@@ -1,5 +1,5 @@
 """
-.. module: lemur.plugins.lemur_aws.aws
+.. module: lemur.plugins.lemur_aws.plugin
     :platform: Unix
     :copyright: (c) 2015 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.

--- a/lemur/plugins/lemur_aws/sts.py
+++ b/lemur/plugins/lemur_aws/sts.py
@@ -1,5 +1,5 @@
 """
-.. module: lemur.common.services.aws.sts
+.. module: lemur.plugins.lemur_aws.sts
     :platform: Unix
     :copyright: (c) 2015 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.

--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -1,5 +1,5 @@
 """
-.. module: lemur.plugins.lemur_digicert.digicert
+.. module: lemur.plugins.lemur_digicert.plugin
     :platform: Unix
     :synopsis: This module is responsible for communicating with the DigiCert '
     Advanced API.

--- a/lemur/plugins/lemur_kubernetes/plugin.py
+++ b/lemur/plugins/lemur_kubernetes/plugin.py
@@ -1,5 +1,5 @@
 """
-.. module: lemur.plugins.lemur_kubernetes.aws
+.. module: lemur.plugins.lemur_kubernetes.plugin
     :platform: Unix
     :copyright: (c) 2015 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.

--- a/lemur/plugins/lemur_slack/plugin.py
+++ b/lemur/plugins/lemur_slack/plugin.py
@@ -1,5 +1,5 @@
 """
-.. module: lemur.plugins.lemur_slack.slack
+.. module: lemur.plugins.lemur_slack.plugin
     :platform: Unix
     :copyright: (c) 2015 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.

--- a/lemur/plugins/lemur_verisign/plugin.py
+++ b/lemur/plugins/lemur_verisign/plugin.py
@@ -1,5 +1,5 @@
 """
-.. module: lemur.plugins.lemur_verisign.verisign
+.. module: lemur.plugins.lemur_verisign.plugin
     :platform: Unix
     :synopsis: This module is responsible for communicating with the VeriSign VICE 2.0 API.
     :copyright: (c) 2015 by Netflix Inc., see AUTHORS for more
@@ -196,7 +196,7 @@ class VerisignIssuerPlugin(IssuerPlugin):
 
     def get_available_units(self):
         """
-        Uses the Verisign to fetch the number of available unit's left. This can be used to get tabs
+        Uses the Verisign to fetch the number of available units left. This can be used to get tabs
         on the number of certificates that can be issued.
 
         :return:

--- a/lemur/plugins/views.py
+++ b/lemur/plugins/views.py
@@ -79,7 +79,7 @@ class PluginsList(AuthenticatedResource):
 
 
 class Plugins(AuthenticatedResource):
-    """ Defines the the 'plugins' endpoint """
+    """ Defines the 'plugins' endpoint """
     def __init__(self):
         super(Plugins, self).__init__()
 

--- a/lemur/roles/service.py
+++ b/lemur/roles/service.py
@@ -63,7 +63,7 @@ def get(role_id):
 
 def get_by_name(role_name):
     """
-    Retrieve a role by it's name
+    Retrieve a role by its name
 
     :param role_name:
     :return:

--- a/lemur/roles/views.py
+++ b/lemur/roles/views.py
@@ -70,7 +70,7 @@ class RolesList(AuthenticatedResource):
               }
 
            :query sortBy: field to sort on
-           :query sortDir: acs or desc
+           :query sortDir: asc or desc
            :query page: int default is 1
            :query filter: key value pair format is k;v
            :query count: count number default is 10
@@ -353,7 +353,7 @@ class UserRolesList(AuthenticatedResource):
               }
 
            :query sortBy: field to sort on
-           :query sortDir: acs or desc
+           :query sortDir: asc or desc
            :query page: int default is 1
            :query filter: key value pair format is k;v
            :query count: count number default is 10
@@ -412,7 +412,7 @@ class AuthorityRolesList(AuthenticatedResource):
               }
 
            :query sortBy: field to sort on
-           :query sortDir: acs or desc
+           :query sortDir: asc or desc
            :query page: int default is 1
            :query filter: key value pair format is k;v
            :query count: count number default is 10

--- a/lemur/sources/service.py
+++ b/lemur/sources/service.py
@@ -257,7 +257,7 @@ def delete(source_id):
 
 def get(source_id):
     """
-    Retrieves an source by it's lemur assigned ID.
+    Retrieves an source by its lemur assigned ID.
 
     :param source_id: Lemur assigned ID
     :rtype : Source
@@ -268,7 +268,7 @@ def get(source_id):
 
 def get_by_label(label):
     """
-    Retrieves a source by it's label
+    Retrieves a source by its label
 
     :param label:
     :return:

--- a/lemur/sources/views.py
+++ b/lemur/sources/views.py
@@ -75,7 +75,7 @@ class SourcesList(AuthenticatedResource):
               }
 
            :query sortBy: field to sort on
-           :query sortDir: acs or desc
+           :query sortDir: asc or desc
            :query page: int default is 1
            :query filter: key value pair format is k;v
            :query count: count number default is 10
@@ -331,7 +331,7 @@ class CertificateSources(AuthenticatedResource):
               }
 
            :query sortBy: field to sort on
-           :query sortDir: acs or desc
+           :query sortDir: asc or desc
            :query page: int default is 1
            :query filter: key value pair format is k;v
            :query count: count number default is 10

--- a/lemur/users/views.py
+++ b/lemur/users/views.py
@@ -1,5 +1,5 @@
 """
-.. module: lemur.user.views
+.. module: lemur.users.views
     :platform: Unix
     :copyright: (c) 2015 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.
@@ -55,27 +55,27 @@ class UsersList(AuthenticatedResource):
               Content-Type: text/javascript
 
               {
-                "items": [
+                 "items": [
                     {
-                      "id": 2,
-                      "active": True,
-                      "email": "user2@example.com",
-                      "username": "user2",
-                      "profileImage": null
+                       "id": 2,
+                       "active": True,
+                       "email": "user2@example.com",
+                       "username": "user2",
+                       "profileImage": null
                     },
                     {
-                      "id": 1,
-                      "active": False,
-                      "email": "user1@example.com",
-                      "username": "user1",
-                      "profileImage": null
+                       "id": 1,
+                       "active": False,
+                       "email": "user1@example.com",
+                       "username": "user1",
+                       "profileImage": null
                     }
-                  ]
-                "total": 2
+                 ]
+                 "total": 2
               }
 
            :query sortBy: field to sort on
-           :query sortDir: acs or desc
+           :query sortDir: asc or desc
            :query page: int default is 1
            :query filter: key value pair format is k;v
            :query count: count number default is 10

--- a/lemur/utils.py
+++ b/lemur/utils.py
@@ -70,7 +70,7 @@ class Vault(types.TypeDecorator):
     """
     A custom SQLAlchemy column type that transparently handles encryption.
 
-    This uses the MultiFernet from the cryptography package to faciliate
+    This uses the MultiFernet from the cryptography package to facilitate
     key rotation. That class handles encryption and signing.
 
     Fernet uses AES in CBC mode with 128-bit keys and PKCS7 padding. It


### PR DESCRIPTION
Mostly typos, grammar errors and inconsistent indentation in code
examples.

Some errors detected using Topy (https://github.com/intgr/topy), all
changes verified by hand.