### PR TITLE
Plugin base classes: update method signatures & fix raise

### DIFF
--- a/docs/developer/plugins/index.rst
+++ b/docs/developer/plugins/index.rst
@@ -94,7 +94,7 @@ it can treat any issuer plugin as both a source of creating new certificates as 
 
 The `IssuerPlugin` exposes two functions::
 
-    def create_certificate(self, options):
+    def create_certificate(self, csr, issuer_options):
         # requests.get('a third party')
 
 Lemur will pass a dictionary of all possible options for certificate creation. Including a valid CSR, and the raw options associated with the request.
@@ -145,7 +145,7 @@ in the plugins base class like so::
 
 The DestinationPlugin requires only one function to be implemented::
 
-    def upload(self, cert, private_key, cert_chain, options, **kwargs):
+    def upload(self, name, body, private_key, cert_chain, options, **kwargs):
         # request.post('a third party')
 
 Additionally the DestinationPlugin allows the plugin author to add additional options
@@ -202,7 +202,7 @@ The second is `ExpirationNotificationPlugin`, this object inherits from `Notific
 You will most likely want to base your plugin on, if you want to add new channels for expiration notices (Slack, Hipcat, Jira, etc.). It adds default options that are required by
 all expiration notifications (interval, unit). This interface expects for the child to define the following function::
 
-    def send(self):
+    def send(self, notification_type, message, targets, options, **kwargs):
         #  request.post("some alerting infrastructure")
 
 
@@ -225,7 +225,7 @@ The `SourcePlugin` object has one default option of `pollRate`. This controls th
 
 The `SourcePlugin` object requires implementation of one function::
 
-      def get_certificates(self, **kwargs):
+      def get_certificates(self, options, **kwargs):
           #  request.get("some source of certificates")
 
 

--- a/lemur/plugins/bases/destination.py
+++ b/lemur/plugins/bases/destination.py
@@ -13,5 +13,5 @@ class DestinationPlugin(Plugin):
     type = 'destination'
     requires_key = True
 
-    def upload(self):
-        raise NotImplemented
+    def upload(self, name, body, private_key, cert_chain, options, **kwargs):
+        raise NotImplementedError

--- a/lemur/plugins/bases/export.py
+++ b/lemur/plugins/bases/export.py
@@ -17,5 +17,5 @@ class ExportPlugin(Plugin):
     type = 'export'
     requires_key = True
 
-    def export(self):
-        raise NotImplemented
+    def export(self, body, chain, key, options, **kwargs):
+        raise NotImplementedError

--- a/lemur/plugins/bases/issuer.py
+++ b/lemur/plugins/bases/issuer.py
@@ -16,8 +16,8 @@ class IssuerPlugin(Plugin):
     """
     type = 'issuer'
 
-    def create_certificate(self):
+    def create_certificate(self, csr, issuer_options):
         raise NotImplementedError
 
-    def create_authority(self):
-        raise NotImplemented
+    def create_authority(self, options):
+        raise NotImplementedError

--- a/lemur/plugins/bases/metric.py
+++ b/lemur/plugins/bases/metric.py
@@ -12,5 +12,5 @@ from lemur.plugins.base import Plugin
 class MetricPlugin(Plugin):
     type = 'metric'
 
-    def submit(self, *args, **kwargs):
-        raise NotImplemented
+    def submit(self, metric_name, metric_type, metric_value, metric_tags=None, options=None):
+        raise NotImplementedError

--- a/lemur/plugins/bases/source.py
+++ b/lemur/plugins/bases/source.py
@@ -22,14 +22,14 @@ class SourcePlugin(Plugin):
         }
     ]
 
-    def get_certificates(self):
-        raise NotImplemented
+    def get_certificates(self, options, **kwargs):
+        raise NotImplementedError
 
-    def get_endpoints(self):
-        raise NotImplemented
+    def get_endpoints(self, options, **kwargs):
+        raise NotImplementedError
 
-    def clean(self):
-        raise NotImplemented
+    def clean(self, options, **kwargs):
+        raise NotImplementedError
 
     @property
     def options(self):

--- a/lemur/sources/service.py
+++ b/lemur/sources/service.py
@@ -198,7 +198,7 @@ def clean(source):
 
     try:
         certificates = s.clean(source.options)
-    except NotImplemented:
+    except NotImplementedError:
         current_app.logger.warning("Cannot clean source: {0}, source plugin does not implement 'clean()'".format(
             source.label
         ))


### PR DESCRIPTION
This way IDEs can verify method overrides in subclasses, otherwise these
are flagged as erroneous.

Changed base classes to properly raise NotImplementedError; previously
they would cause "TypeError: exceptions must derive from BaseException"

Also fixed exception handling in sources.service.clean().