### PR TITLE
Fix check for sensitive and restricted domains

### DIFF
--- a/lemur/common/validators.py
+++ b/lemur/common/validators.py
@@ -42,20 +42,20 @@ def private_key(key):
 
 def sensitive_domain(domain):
     """
-    Determines if domain has been marked as sensitive.
+    Determines if domain has been marked as sensitive or matches restricted patterns.
     :param domain:
     :return:
     """
+    if SensitiveDomainPermission().can():
+        # User has permission, no need to check anything
+        return
+
     restricted_domains = current_app.config.get('LEMUR_RESTRICTED_DOMAINS', [])
-    if restricted_domains:
-        domains = domain_service.get_by_name(domain)
-        for domain in domains:
-            # we only care about non-admins
-            if not SensitiveDomainPermission().can():
-                if domain.sensitive or any([re.match(pattern, domain.name) for pattern in restricted_domains]):
-                    raise ValidationError(
-                        'Domain {0} has been marked as sensitive, contact and administrator \
-                        to issue the certificate.'.format(domain))
+    if any(re.match(pattern, domain) for pattern in restricted_domains) or \
+            any(d.sensitive for d in domain_service.get_by_name(domain)):
+        raise ValidationError(
+            'Domain {0} has been marked as sensitive or restricted, contact and administrator '
+            'to issue the certificate.'.format(domain))
 
 
 def encoding(oid_encoding):


### PR DESCRIPTION
This is a fix for a potential security issue. Fix submitted as a pull request per discussion with @kevgliss.

There was much wrong with this code:
* If there were no matches in the Domain table then
  LEMUR_RESTRICTED_DOMAINS was ignored.
* If there were multiple Domain matches, the LEMUR_RESTRICTED_DOMAINS
  checks were ran multiple times.
* It's unnecessary to query Domain rows if the user is an admin.
* If a domain failed the check, the error would say
  "Domain Domain(name=example.org) has been marked as sensitive ..."