### PR TITLE
Combining Authority Key Identifier extension options in the schema.

### DIFF
--- a/lemur/schemas.py
+++ b/lemur/schemas.py
@@ -170,12 +170,9 @@ class BasicConstraintsSchema(BaseExtensionSchema):
     pass
 
 
-class AuthorityIdentifierSchema(BaseExtensionSchema):
-    use_authority_cert = fields.Boolean()
-
-
 class AuthorityKeyIdentifierSchema(BaseExtensionSchema):
     use_key_identifier = fields.Boolean()
+    use_authority_cert = fields.Boolean()
 
 
 class CertificateInfoAccessSchema(BaseExtensionSchema):
@@ -240,7 +237,6 @@ class ExtensionSchema(BaseExtensionSchema):
     extended_key_usage = fields.Nested(ExtendedKeyUsageSchema)
     subject_key_identifier = fields.Nested(SubjectKeyIdentifierSchema)
     sub_alt_names = fields.Nested(SubAltNamesSchema)
-    authority_identifier = fields.Nested(AuthorityIdentifierSchema)
     authority_key_identifier = fields.Nested(AuthorityKeyIdentifierSchema)
     certificate_info_access = fields.Nested(CertificateInfoAccessSchema)
     custom = fields.List(fields.Nested(CustomOIDSchema))

--- a/lemur/static/app/angular/certificates/certificate/options.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/options.tpl.html
@@ -184,15 +184,13 @@
           <div class="checkbox">
             <label tooltip-trigger="mouseenter" tooltip-placement="top"
                    uib-tooltip="Put Issuer's keyIdentifier in this extension">
-              <input type="checkbox" ng-model="certificate.extensions.authorityKeyIdentifier.useKeyIdentifier">Key
-              Identifier
+              <input type="checkbox" ng-model="certificate.extensions.authorityKeyIdentifier.useKeyIdentifier">Key Identifier
             </label>
           </div>
           <div class="checkbox">
             <label tooltip-trigger="mouseenter" tooltip-placement="top"
                    uib-tooltip="Put Issuer's Name and Serial number">
-              <input type="checkbox" ng-model="certificate.extensions.authorityIdentifier.useAuthorityCert">Authority
-              Certificate
+              <input type="checkbox" ng-model="certificate.extensions.authorityKeyIdentifier.useAuthorityCert">Authority Certificate
             </label>
           </div>
         </div>

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -65,27 +65,19 @@ def test_certificate_edit_schema(session):
     assert len(data['notifications']) == 3
 
 
-def test_authority_identifier_schema():
-    from lemur.schemas import AuthorityIdentifierSchema
-    input_data = {'useAuthorityCert': True}
-
-    data, errors = AuthorityIdentifierSchema().load(input_data)
-
-    assert data == {'use_authority_cert': True}
-    assert not errors
-
-    data, errors = AuthorityIdentifierSchema().dumps(data)
-    assert not errors
-    assert data == json.dumps(input_data)
-
-
 def test_authority_key_identifier_schema():
     from lemur.schemas import AuthorityKeyIdentifierSchema
-    input_data = {'useKeyIdentifier': True}
+    input_data = {
+        'useKeyIdentifier': True,
+        'useAuthorityCert': True
+    }
 
     data, errors = AuthorityKeyIdentifierSchema().load(input_data)
 
-    assert data == {'use_key_identifier': True}
+    assert data == {
+        'useKeyIdentifier': True,
+        'useAuthorityCert': True
+    }
     assert not errors
 
     data, errors = AuthorityKeyIdentifierSchema().dumps(data)

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -75,7 +75,7 @@ def test_authority_key_identifier_schema():
     data, errors = AuthorityKeyIdentifierSchema().load(input_data)
 
     assert data == {
-        'use_key_identifer': True,
+        'use_key_identifier': True,
         'use_authority_cert': True
     }
     assert not errors

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -75,8 +75,8 @@ def test_authority_key_identifier_schema():
     data, errors = AuthorityKeyIdentifierSchema().load(input_data)
 
     assert data == {
-        'useKeyIdentifier': True,
-        'useAuthorityCert': True
+        'use_key_identifer': True,
+        'use_authority_cert': True
     }
     assert not errors
 


### PR DESCRIPTION
This makes processing them in the cert/csr generation stage make more sense because they are two options in the same x.509 extension. They were already in the same part of the schema for authorities, but this makes the certificates follow the same pattern, and it allows them to share the same schema/validation layout.

Please see issue #650 for more detail.