### PR TITLE
Fixing handling of adding custom OIDs in UI

### DIFF
--- a/lemur/schemas.py
+++ b/lemur/schemas.py
@@ -232,6 +232,7 @@ class CustomOIDSchema(BaseExtensionSchema):
     oid = fields.String()
     encoding = fields.String(validate=validators.encoding)
     value = fields.String()
+    is_critical = fields.Boolean()
 
 
 class ExtensionSchema(BaseExtensionSchema):

--- a/lemur/static/app/angular/authorities/authority/extensions.tpl.html
+++ b/lemur/static/app/angular/authorities/authority/extensions.tpl.html
@@ -196,7 +196,7 @@
     <div class="col-sm-2">
       <div class="checkbox">
         <label>
-          <input type="checkbox" ng-model="authority.extensions.custom.isCritical">Critical
+          <input type="checkbox" ng-model="authority.customIsCritical">Critical
         </label>
       </div>
     </div>
@@ -208,7 +208,7 @@
           <td>{{ custom.oid }}</td>
           <td>{{ custom.encoding }}</td>
           <td>{{ custom.value }}</td>
-          <td>{{ custom.isCritical}}</td>
+          <td>{{ custom.isCritical ? "critical" : "" }}</td>
           <td>
             <button type="button" ng-click="authority.removeCustom($index)" class="btn btn-danger btn-sm pull-right">Remove</button>
           </td>

--- a/lemur/static/app/angular/authorities/services.js
+++ b/lemur/static/app/angular/authorities/services.js
@@ -41,7 +41,7 @@ angular.module('lemur')
             this.extensions.custom.push(
               {
                 'oid': this.customOid,
-                'isCritical': this.customIsCritical,
+                'isCritical': this.customIsCritical || false,
                 'encoding': this.customEncoding,
                 'value': this.customValue
               }

--- a/lemur/static/app/angular/certificates/certificate/options.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/options.tpl.html
@@ -259,7 +259,7 @@
         <div class="col-sm-2">
           <div class="checkbox">
             <label>
-              <input type="checkbox" ng-model="certificate.extensions.custom.isCritical">Critical
+              <input type="checkbox" ng-model="certificate.customIsCritical">Critical
             </label>
           </div>
         </div>
@@ -272,7 +272,7 @@
             <td>{{ custom.oid }}</td>
             <td>{{ custom.encoding }}</td>
             <td>{{ custom.value }}</td>
-            <td>{{ custom.isCritical }}</td>
+            <td>{{ custom.isCritical ? "critical" : "" }}</td>
             <td>
               <button type="button" ng-click="certificate.removeCustom($index)"
                       class="btn btn-danger btn-sm pull-right">Remove

--- a/lemur/static/app/angular/certificates/services.js
+++ b/lemur/static/app/angular/certificates/services.js
@@ -56,7 +56,7 @@ angular.module('lemur')
             this.extensions.custom.push(
               {
                 'oid': this.customOid,
-                'isCritical': this.customIsCritical,
+                'isCritical': this.customIsCritical || false,
                 'encoding': this.customEncoding,
                 'value': this.customValue
               }


### PR DESCRIPTION
* is_critical wasn't in the schema, so was getting dropped.
* isCritical in the Javascript wasn't getting assigned if it was unchecked. Now, it will be assumed false if missing.
* The display of critical or not in the list of added custom OIDs was unclear when it was just true/false with no heading. Now it will be displayed as critical or nothing instead.
* The namespace for the checkbox for isCritical was wrong, and didn't get processed with the oid/type/value variables.

See Issue #652 for details.