### PR TITLE
Many fixes to authority/certificate extensions pages

### DIFF
--- a/lemur/schemas.py
+++ b/lemur/schemas.py
@@ -194,7 +194,8 @@ class KeyUsageSchema(BaseExtensionSchema):
     use_key_encipherment = fields.Boolean()
     use_digital_signature = fields.Boolean()
     use_non_repudiation = fields.Boolean()
-
+    use_key_agreement = fields.Boolean()
+    use_key_cert_sign = fields.Boolean()
 
 class ExtendedKeyUsageSchema(BaseExtensionSchema):
     use_server_authentication = fields.Boolean()
@@ -202,9 +203,10 @@ class ExtendedKeyUsageSchema(BaseExtensionSchema):
     use_eap_over_lan = fields.Boolean()
     use_eap_over_ppp = fields.Boolean()
     use_ocsp_signing = fields.Boolean()
-    use_smart_card_authentication = fields.Boolean()
+    use_smart_card_logon = fields.Boolean()
     use_timestamping = fields.Boolean()
-
+    use_code_signing = fields.Boolean()
+    use_email_protection = fields.Boolean()
 
 class SubjectKeyIdentifierSchema(BaseExtensionSchema):
     include_ski = fields.Boolean()

--- a/lemur/schemas.py
+++ b/lemur/schemas.py
@@ -197,6 +197,7 @@ class KeyUsageSchema(BaseExtensionSchema):
     use_key_agreement = fields.Boolean()
     use_key_cert_sign = fields.Boolean()
 
+
 class ExtendedKeyUsageSchema(BaseExtensionSchema):
     use_server_authentication = fields.Boolean()
     use_client_authentication = fields.Boolean()
@@ -207,6 +208,7 @@ class ExtendedKeyUsageSchema(BaseExtensionSchema):
     use_timestamping = fields.Boolean()
     use_code_signing = fields.Boolean()
     use_email_protection = fields.Boolean()
+
 
 class SubjectKeyIdentifierSchema(BaseExtensionSchema):
     include_ski = fields.Boolean()

--- a/lemur/static/app/angular/authorities/authority/extensions.tpl.html
+++ b/lemur/static/app/angular/authorities/authority/extensions.tpl.html
@@ -55,16 +55,11 @@
       </div>
       <div class="checkbox">
         <label>
-          <input type="checkbox" ng-model="authority.extensions.keyUsage.useKeyAgreement">Key Agreement
+          <input type="checkbox" ng-model="authority.extensions.keyUsage.useKeyCertSign">Key Certificate Signature
         </label>
       </div>
     </div>
     <div class="col-sm-3">
-      <div class="checkbox">
-        <label>
-          <input type="checkbox" ng-model="authority.extensions.keyUsage.useKeyCertSign">Key Certificate Signature
-        </label>
-      </div>
       <div class="checkbox">
         <label>
           <input type="checkbox" ng-model="authority.extensions.keyUsage.useCRLSign">CRL Sign
@@ -72,14 +67,19 @@
       </div>
       <div class="checkbox">
         <label>
+          <input type="checkbox" ng-model="authority.extensions.keyUsage.useKeyAgreement">Key Agreement
+         </label>
+      </div>
+       <div class="checkbox">
+         <label>
           <input type="checkbox" ng-model="authority.extensions.keyUsage.useEncipherOnly">Encipher Only
-        </label>
-      </div>
-      <div class="checkbox">
-        <label>
+         </label>
+       </div>
+       <div class="checkbox">
+         <label>
           <input type="checkbox" ng-model="authority.extensions.keyUsage.useDecipherOnly">Decipher Only
-        </label>
-      </div>
+         </label>
+       </div>
     </div>
   </div>
   <div class="form-group">
@@ -94,21 +94,31 @@
       </div>
       <div class="checkbox">
         <label>
-          <input type="checkbox" ng-model="authority.extensions.extendedKeyUsage.useEmail">Email
+          <input type="checkbox" ng-model="authority.extensions.extendedKeyUsage.useClientAuthentication">Client Authentication
+        </label>
+      </div>
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" ng-model="authority.extensions.extendedKeyUsage.useEmailProtection">Email Protection
         </label>
       </div>
       <div class="checkbox">
         <label>
           <input type="checkbox" ng-model="authority.extensions.extendedKeyUsage.useTimestamping">Timestamping
         </label>
-        <div class="checkbox">
-          <label>
-            <input type="checkbox" ng-model="authority.extensions.extendedKeyUsage.useEapOverLAN">EAP Over LAN
-          </label>
-        </div>
+      </div>
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" ng-model="authority.extensions.extendedKeyUsage.useCodeSigning">Code Signing
+        </label>
       </div>
     </div>
     <div class="col-sm-3">
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" ng-model="authority.extensions.extendedKeyUsage.useEapOverLAN">EAP Over LAN
+        </label>
+      </div>
       <div class="checkbox">
         <label>
           <input type="checkbox" ng-model="authority.extensions.extendedKeyUsage.useEapOverPPP">EAP Over PPP
@@ -116,7 +126,7 @@
       </div>
       <div class="checkbox">
         <label>
-          <input type="checkbox" ng-model="authority.extensions.extendedKeyUsage.useSmartCardLogon">Smartcard Logon
+          <input type="checkbox" ng-model="authority.extensions.extendedKeyUsage.useSmartCardLogon">Smart Card Logon
         </label>
       </div>
       <div class="checkbox">
@@ -150,7 +160,7 @@
     <div class="col-sm-10">
       <div class="checkbox">
         <label tooltip-trigger="mouseenter" tooltip-placement="top" uib-tooltip="Ask CA to include/not include AIA extension" >
-          <input type="checkbox" ng-model="authority.extensions.authorityInfoAccess.includeAIA">Include AIA
+          <input type="checkbox" ng-model="authority.extensions.certificateInfoAccess.includeAIA">Include AIA 
         </label>
       </div>
     </div>

--- a/lemur/static/app/angular/certificates/certificate/options.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/options.tpl.html
@@ -97,19 +97,19 @@
           </div>
           <div class="checkbox">
             <label>
-              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useKeyAgreement">Key Agreement
+              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useKeyCertSign">Key Certificate Signature
             </label>
           </div>
         </div>
         <div class="col-sm-3">
           <div class="checkbox">
             <label>
-              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useKeyCertSign">Key Certificate Signature
+              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useCRLSign">CRL Sign
             </label>
           </div>
           <div class="checkbox">
             <label>
-              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useCRLSign">CRL Sign
+              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useKeyAgreement">Key Agreement
             </label>
           </div>
           <div class="checkbox">
@@ -143,21 +143,26 @@
           </div>
           <div class="checkbox">
             <label>
-              <input type="checkbox" ng-model="certificate.extensions.extendedKeyUsage.useEmail">Email
+              <input type="checkbox" ng-model="certificate.extensions.extendedKeyUsage.useEmailProtection">Email Protection
             </label>
           </div>
           <div class="checkbox">
             <label>
               <input type="checkbox" ng-model="certificate.extensions.extendedKeyUsage.useTimestamping">Timestamping
             </label>
-            <div class="checkbox">
-              <label>
-                <input type="checkbox" ng-model="certificate.extensions.extendedKeyUsage.useEapOverLAN">EAP Over LAN
-              </label>
-            </div>
           </div>
+          <div class="checkbox">
+            <label>
+              <input type="checkbox" ng-model="certificate.extensions.extendedKeyUsage.useCodeSigning">Code Signing
+            </label>
+           </div>
         </div>
         <div class="col-sm-3">
+          <div class="checkbox">
+            <label>
+              <input type="checkbox" ng-model="certificate.extensions.extendedKeyUsage.useEapOverLAN">EAP Over LAN
+            </label>
+          </div>
           <div class="checkbox">
             <label>
               <input type="checkbox" ng-model="certificate.extensions.extendedKeyUsage.useEapOverPPP">EAP Over PPP
@@ -165,8 +170,7 @@
           </div>
           <div class="checkbox">
             <label>
-              <input type="checkbox" ng-model="certificate.extensions.extendedKeyUsage.useSmartCardLogon">Smartcard
-              Logon
+              <input type="checkbox" ng-model="certificate.extensions.extendedKeyUsage.useSmartCardLogon">Smart Card Logon
             </label>
           </div>
           <div class="checkbox">

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -315,8 +315,10 @@ def test_extended_key_usage_schema():
         'useEapOverLAN': True,
         'useEapOverPPP': True,
         'useOCSPSigning': True,
-        'useSmartCardAuthentication': True,
-        'useTimestamping': True
+        'useSmartCardLogon': True,
+        'useTimestamping': True,
+        'useCodeSigning': True,
+        'useEmailProtection': True
     }
 
     data, errors = ExtendedKeyUsageSchema().load(input_data)
@@ -328,8 +330,10 @@ def test_extended_key_usage_schema():
         'use_eap_over_lan': True,
         'use_eap_over_ppp': True,
         'use_ocsp_signing': True,
-        'use_smart_card_authentication': True,
-        'use_timestamping': True
+        'use_smart_card_logon': True,
+        'use_timestamping': True,
+        'use_code_signing': True,
+        'use_email_protection': True
     }
 
 


### PR DESCRIPTION
Aligning certificate creation between authority and certificate workflows

* Correctly missing and mis-named fields in schemas
* Re-ordering KeyUsage and ExtendedKeyUsage for consistency and clarity
* Adding client authentication to the authority options.

This should resolve the issues I documented in issue #658 