### PR TITLE
UI adjustments for mutually exclusive (checkbox version) encipher/decipher-only Key Usage

### DIFF
--- a/lemur/common/fields.py
+++ b/lemur/common/fields.py
@@ -162,6 +162,9 @@ class KeyUsageExtension(Field):
             elif k == 'useCRLSign':
                 keyusages['crl_sign'] = v
 
+            elif k == 'useKeyAgreement':
+                keyusages['key_agreement'] = v
+
             elif k == 'useEncipherOnly' and v:
                 keyusages['encipher_only'] = True
                 keyusages['key_agreement'] = True

--- a/lemur/static/app/angular/authorities/authority/extensions.tpl.html
+++ b/lemur/static/app/angular/authorities/authority/extensions.tpl.html
@@ -67,17 +67,17 @@
       </div>
       <div class="checkbox">
         <label>
-          <input type="checkbox" ng-model="authority.extensions.keyUsage.useKeyAgreement">Key Agreement
+          <input type="checkbox" ng-model="authority.extensions.keyUsage.useKeyAgreement" ng-checked="authority.extensions.keyUsage.useEncipherOnly||authority.extensions.keyUsage.useDecipherOnly">Key Agreement
          </label>
       </div>
        <div class="checkbox">
          <label>
-          <input type="checkbox" ng-model="authority.extensions.keyUsage.useEncipherOnly">Encipher Only
+          <input type="checkbox" ng-model="authority.extensions.keyUsage.useEncipherOnly" ng-disabled="authority.extensions.keyUsage.useDecipherOnly">Encipher Only
          </label>
        </div>
        <div class="checkbox">
          <label>
-          <input type="checkbox" ng-model="authority.extensions.keyUsage.useDecipherOnly">Decipher Only
+          <input type="checkbox" ng-model="authority.extensions.keyUsage.useDecipherOnly" ng-disabled="authority.extensions.keyUsage.useEncipherOnly">Decipher Only
          </label>
        </div>
     </div>

--- a/lemur/static/app/angular/authorities/authority/extensions.tpl.html
+++ b/lemur/static/app/angular/authorities/authority/extensions.tpl.html
@@ -68,7 +68,7 @@
       <div class="checkbox">
         <label>
           <input type="checkbox" ng-model="authority.extensions.keyUsage.useKeyAgreement" ng-checked="authority.extensions.keyUsage.useEncipherOnly||authority.extensions.keyUsage.useDecipherOnly">Key Agreement
-         </label>
+        </label>
       </div>
        <div class="checkbox">
          <label>

--- a/lemur/static/app/angular/certificates/certificate/options.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/options.tpl.html
@@ -75,17 +75,17 @@
           </div>
           <div class="checkbox">
             <label>
-              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useKeyAgreement">Key Agreement
+              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useKeyAgreement" ng-checked="certificate.extensions.keyUsage.useEncipherOnly||certificate.extensions.keyUsage.useDecipherOnly">Key Agreement
             </label>
           </div>
           <div class="checkbox">
             <label>
-              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useEncipherOnly">Encipher Only
+              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useEncipherOnly" ng-disabled="certificate.extensions.keyUsage.useDecipherOnly">Encipher Only
             </label>
           </div>
           <div class="checkbox">
             <label>
-              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useDecipherOnly">Decipher Only
+              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useDecipherOnly" ng-disabled="certificate.extensions.keyUsage.useEncipherOnly">Decipher Only
             </label>
           </div>
         </div>


### PR DESCRIPTION
UI adjustments to make Key Agreement, Encipher Only, and Decipher Only relationship more user-friendly. This contributes the UI half of issue #663.