### PR TITLE
Gracefully handle importing certificates with missing data

### DIFF
--- a/lemur/certificates/verify.py
+++ b/lemur/certificates/verify.py
@@ -7,6 +7,7 @@
 """
 import requests
 import subprocess
+from requests.exceptions import ConnectionError
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 

--- a/lemur/common/defaults.py
+++ b/lemur/common/defaults.py
@@ -53,9 +53,12 @@ def common_name(cert):
     :param cert:
     :return: Common name or None
     """
-    return cert.subject.get_attributes_for_oid(
+    cn = cert.subject.get_attributes_for_oid(
         x509.OID_COMMON_NAME
-    )[0].value.strip()
+    )
+    if len(cn) == 0:
+        return None
+    return cn[0].value.strip()
 
 
 def organization(cert):

--- a/lemur/common/defaults.py
+++ b/lemur/common/defaults.py
@@ -70,7 +70,7 @@ def organization(cert):
     try:
         return cert.subject.get_attributes_for_oid(
             x509.OID_ORGANIZATION_NAME
-            )[0].value.strip()
+        )[0].value.strip()
     except Exception as e:
         current_app.logger.error("Unable to get organization! {0}".format(e))
 
@@ -84,7 +84,7 @@ def organizational_unit(cert):
     try:
         return cert.subject.get_attributes_for_oid(
             x509.OID_ORGANIZATIONAL_UNIT_NAME
-            )[0].value.strip()
+        )[0].value.strip()
     except Exception as e:
         current_app.logger.error("Unable to get organizational unit! {0}".format(e))
 
@@ -98,7 +98,7 @@ def country(cert):
     try:
         return cert.subject.get_attributes_for_oid(
             x509.OID_COUNTRY_NAME
-            )[0].value.strip()
+        )[0].value.strip()
     except Exception as e:
         current_app.logger.error("Unable to get country! {0}".format(e))
 
@@ -112,7 +112,7 @@ def state(cert):
     try:
         return cert.subject.get_attributes_for_oid(
             x509.OID_STATE_OR_PROVINCE_NAME
-            )[0].value.strip()
+        )[0].value.strip()
     except Exception as e:
         current_app.logger.error("Unable to get state! {0}".format(e))
 
@@ -126,7 +126,7 @@ def location(cert):
     try:
         return cert.subject.get_attributes_for_oid(
             x509.OID_LOCALITY_NAME
-            )[0].value.strip()
+        )[0].value.strip()
     except Exception as e:
         current_app.logger.error("Unable to get location! {0}".format(e))
 

--- a/lemur/common/defaults.py
+++ b/lemur/common/defaults.py
@@ -53,12 +53,12 @@ def common_name(cert):
     :param cert:
     :return: Common name or None
     """
-    cn = cert.subject.get_attributes_for_oid(
-        x509.OID_COMMON_NAME
-    )
-    if len(cn) == 0:
-        return None
-    return cn[0].value.strip()
+    try:
+        return cert.subject.get_attributes_for_oid(
+            x509.OID_COMMON_NAME
+        )[0].value.strip()
+    except Exception as e:
+        current_app.logger.error("Unable to get common name! {0}".format(e))
 
 
 def organization(cert):
@@ -67,9 +67,12 @@ def organization(cert):
     :param cert:
     :return:
     """
-    return cert.subject.get_attributes_for_oid(
-        x509.OID_ORGANIZATION_NAME
-    )[0].value.strip()
+    try:
+        return cert.subject.get_attributes_for_oid(
+            x509.OID_ORGANIZATION_NAME
+            )[0].value.strip()
+    except Exception as e:
+        current_app.logger.error("Unable to get organization! {0}".format(e))
 
 
 def organizational_unit(cert):
@@ -78,9 +81,12 @@ def organizational_unit(cert):
     :param cert:
     :return:
     """
-    return cert.subject.get_attributes_for_oid(
-        x509.OID_ORGANIZATIONAL_UNIT_NAME
-    )[0].value.strip()
+    try:
+        return cert.subject.get_attributes_for_oid(
+            x509.OID_ORGANIZATIONAL_UNIT_NAME
+            )[0].value.strip()
+    except Exception as e:
+        current_app.logger.error("Unable to get organizational unit! {0}".format(e))
 
 
 def country(cert):
@@ -89,9 +95,12 @@ def country(cert):
     :param cert:
     :return:
     """
-    return cert.subject.get_attributes_for_oid(
-        x509.OID_COUNTRY_NAME
-    )[0].value.strip()
+    try:
+        return cert.subject.get_attributes_for_oid(
+            x509.OID_COUNTRY_NAME
+            )[0].value.strip()
+    except Exception as e:
+        current_app.logger.error("Unable to get country! {0}".format(e))
 
 
 def state(cert):
@@ -100,9 +109,12 @@ def state(cert):
     :param cert:
     :return:
     """
-    return cert.subject.get_attributes_for_oid(
-        x509.OID_STATE_OR_PROVINCE_NAME
-    )[0].value.strip()
+    try:
+        return cert.subject.get_attributes_for_oid(
+            x509.OID_STATE_OR_PROVINCE_NAME
+            )[0].value.strip()
+    except Exception as e:
+        current_app.logger.error("Unable to get state! {0}".format(e))
 
 
 def location(cert):
@@ -111,9 +123,12 @@ def location(cert):
     :param cert:
     :return:
     """
-    return cert.subject.get_attributes_for_oid(
-        x509.OID_LOCALITY_NAME
-    )[0].value.strip()
+    try:
+        return cert.subject.get_attributes_for_oid(
+            x509.OID_LOCALITY_NAME
+            )[0].value.strip()
+    except Exception as e:
+        current_app.logger.error("Unable to get location! {0}".format(e))
 
 
 def domains(cert):


### PR DESCRIPTION
Some certificates we have, which are generated by CFSSL, are missing the common name attribute. 

This PR should allow for handling that case as well as other missing attributes.