### PR TITLE
allow attributes to be excluded from a cert subject

### DIFF
--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -337,15 +337,15 @@ def create_csr(**csr_config):
     builder = x509.CertificateSigningRequestBuilder()
     name_list = [x509.NameAttribute(x509.OID_COMMON_NAME, csr_config['common_name']),
                  x509.NameAttribute(x509.OID_EMAIL_ADDRESS, csr_config['owner'])]
-    if 'organization' in csr_config and len(csr_config['organization'].strip()) > 0:
+    if 'organization' in csr_config and csr_config['organization'].strip():
         name_list.append(x509.NameAttribute(x509.OID_ORGANIZATION_NAME, csr_config['organization']))
-    if 'organizational_unit' in csr_config and len(csr_config['organizational_unit'].strip()) > 0:
+    if 'organizational_unit' in csr_config and csr_config['organizational_unit'].strip():
         name_list.append(x509.NameAttribute(x509.OID_ORGANIZATIONAL_UNIT_NAME, csr_config['organizational_unit']))
-    if 'country' in csr_config and len(csr_config['country'].strip()) > 0:
+    if 'country' in csr_config and csr_config['country'].strip():
         name_list.append(x509.NameAttribute(x509.OID_COUNTRY_NAME, csr_config['country']))
-    if 'state' in csr_config and len(csr_config['state'].strip()) > 0:
+    if 'state' in csr_config and csr_config['state'].strip():
         name_list.append(x509.NameAttribute(x509.OID_STATE_OR_PROVINCE_NAME, csr_config['state']))
-    if 'location' in csr_config and len(csr_config['location'].strip()) > 0:
+    if 'location' in csr_config and csr_config['location'].strip():
         name_list.append(x509.NameAttribute(x509.OID_LOCALITY_NAME, csr_config['location']))
     builder = builder.subject_name(x509.Name(name_list))
 

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -335,15 +335,19 @@ def create_csr(**csr_config):
     private_key = generate_private_key(csr_config.get('key_type'))
 
     builder = x509.CertificateSigningRequestBuilder()
-    builder = builder.subject_name(x509.Name([
-        x509.NameAttribute(x509.OID_COMMON_NAME, csr_config['common_name']),
-        x509.NameAttribute(x509.OID_ORGANIZATION_NAME, csr_config['organization']),
-        x509.NameAttribute(x509.OID_ORGANIZATIONAL_UNIT_NAME, csr_config['organizational_unit']),
-        x509.NameAttribute(x509.OID_COUNTRY_NAME, csr_config['country']),
-        x509.NameAttribute(x509.OID_STATE_OR_PROVINCE_NAME, csr_config['state']),
-        x509.NameAttribute(x509.OID_LOCALITY_NAME, csr_config['location']),
-        x509.NameAttribute(x509.OID_EMAIL_ADDRESS, csr_config['owner'])
-    ]))
+    name_list = [x509.NameAttribute(x509.OID_COMMON_NAME, csr_config['common_name']),
+                 x509.NameAttribute(x509.OID_EMAIL_ADDRESS, csr_config['owner'])]
+    if 'organization' in csr_config and len(csr_config['organization'].strip()) > 0:
+        name_list.append(x509.NameAttribute(x509.OID_ORGANIZATION_NAME, csr_config['organization']))
+    if 'organizational_unit' in csr_config and len(csr_config['organizational_unit'].strip()) > 0:
+        name_list.append(x509.NameAttribute(x509.OID_ORGANIZATIONAL_UNIT_NAME, csr_config['organizational_unit']))
+    if 'country' in csr_config and len(csr_config['country'].strip()) > 0:
+        name_list.append(x509.NameAttribute(x509.OID_COUNTRY_NAME, csr_config['country']))
+    if 'state' in csr_config and len(csr_config['state'].strip()) > 0:
+        name_list.append(x509.NameAttribute(x509.OID_STATE_OR_PROVINCE_NAME, csr_config['state']))
+    if 'location' in csr_config and len(csr_config['location'].strip()) > 0:
+        name_list.append(x509.NameAttribute(x509.OID_LOCALITY_NAME, csr_config['location']))
+    builder = builder.subject_name(x509.Name(name_list))
 
     extensions = csr_config.get('extensions', {})
     critical_extensions = ['basic_constraints', 'sub_alt_names', 'key_usage']


### PR DESCRIPTION
Currently when creating a certificate via the API, if a user omits or passes an empty string on an attribute like "location". The API returns errors even though a certificate does not require these attributes to be part of the subject.

I needed to be able to create certificates without certain NameAttributes in the subject. This PR allows users to specify empty strings for the `organization`, `organizational_unit`, `country`, `state`, `location` attributes via the API.