### PR TITLE
UI adjustments for mutually exclusive (radio button version) encipher/decipher-only Key Usage #664 

### DIFF
--- a/lemur/common/fields.py
+++ b/lemur/common/fields.py
@@ -162,6 +162,9 @@ class KeyUsageExtension(Field):
             elif k == 'useCRLSign':
                 keyusages['crl_sign'] = v
 
+            elif k == 'useKeyAgreement':
+                keyusages['key_agreement'] = v
+
             elif k == 'useEncipherOnly' and v:
                 keyusages['encipher_only'] = True
                 keyusages['key_agreement'] = True

--- a/lemur/static/app/angular/authorities/authority/extensions.tpl.html
+++ b/lemur/static/app/angular/authorities/authority/extensions.tpl.html
@@ -67,17 +67,17 @@
       </div>
       <div class="checkbox">
         <label>
-          <input type="checkbox" ng-model="authority.extensions.keyUsage.useKeyAgreement">Key Agreement
+          <input type="checkbox" ng-model="authority.extensions.keyUsage.useKeyAgreement" ng-checked="authority.extensions.keyUsage.useEncipherOnly||authority.extensions.keyUsage.useDecipherOnly">Key Agreement
          </label>
       </div>
        <div class="checkbox">
          <label>
-          <input type="checkbox" ng-model="authority.extensions.keyUsage.useEncipherOnly">Encipher Only
+          <input type="checkbox" ng-model="authority.extensions.keyUsage.useEncipherOnly" ng-disabled="authority.extensions.keyUsage.useDecipherOnly">Encipher Only
          </label>
        </div>
        <div class="checkbox">
          <label>
-          <input type="checkbox" ng-model="authority.extensions.keyUsage.useDecipherOnly">Decipher Only
+          <input type="checkbox" ng-model="authority.extensions.keyUsage.useDecipherOnly" ng-disabled="authority.extensions.keyUsage.useEncipherOnly">Decipher Only
          </label>
        </div>
     </div>

--- a/lemur/static/app/angular/authorities/authority/extensions.tpl.html
+++ b/lemur/static/app/angular/authorities/authority/extensions.tpl.html
@@ -68,7 +68,7 @@
       <div class="checkbox">
         <label>
           <input type="checkbox" ng-model="authority.extensions.keyUsage.useKeyAgreement" ng-checked="authority.extensions.keyUsage.useEncipherOnly||authority.extensions.keyUsage.useDecipherOnly">Key Agreement
-         </label>
+        </label>
       </div>
        <div class="checkbox">
          <label>

--- a/lemur/static/app/angular/authorities/authority/extensions.tpl.html
+++ b/lemur/static/app/angular/authorities/authority/extensions.tpl.html
@@ -67,19 +67,19 @@
       </div>
       <div class="checkbox">
         <label>
-          <input type="checkbox" ng-model="authority.extensions.keyUsage.useKeyAgreement" ng-checked="authority.extensions.keyUsage.useEncipherOnly||authority.extensions.keyUsage.useDecipherOnly">Key Agreement
+          <input type="checkbox" ng-model="authority.extensions.keyUsage.useKeyAgreement">Key Agreement
         </label>
       </div>
-       <div class="checkbox">
-         <label>
-          <input type="checkbox" ng-model="authority.extensions.keyUsage.useEncipherOnly" ng-disabled="authority.extensions.keyUsage.useDecipherOnly">Encipher Only
-         </label>
-       </div>
-       <div class="checkbox">
-         <label>
-          <input type="checkbox" ng-model="authority.extensions.keyUsage.useDecipherOnly" ng-disabled="authority.extensions.keyUsage.useEncipherOnly">Decipher Only
-         </label>
-       </div>
+      <div class="radio">
+        <label>
+          <input type="radio" name="encipherOrDecipher" ng-model="authority.encipherOrDecipher" value="useEncipherOnly" ng-click="authority.setEncipherOrDecipher('useEncipherOnly')">Encipher Only
+        </label>
+      </div>
+      <div class="radio">
+        <label>
+          <input type="radio" name="encipherOrDecipher" ng-model="authority.encipherOrDecipher" value="useDecipherOnly" ng-click="authority.setEncipherOrDecipher('useDecipherOnly')">Decipher Only
+        </label>
+      </div>
     </div>
   </div>
   <div class="form-group">

--- a/lemur/static/app/angular/authorities/services.js
+++ b/lemur/static/app/angular/authorities/services.js
@@ -64,6 +64,32 @@ angular.module('lemur')
         },
         removeCustom: function (index) {
           this.extensions.custom.splice(index, 1);
+        },
+        setEncipherOrDecipher: function (value) {
+          if (this.extensions === undefined) {
+            this.extensions = {};
+          }
+          if (this.extensions.keyUsage === undefined) {
+            this.extensions.keyUsage = {};
+          }
+          var existingValue = this.extensions.keyUsage[value];
+          if (existingValue) {
+            // Clicked on the already-selected value
+            this.extensions.keyUsage.useDecipherOnly = false;
+            this.extensions.keyUsage.useEncipherOnly = false;
+            // Uncheck both radio buttons
+            this.encipherOrDecipher = false;
+          } else {
+            // Clicked a different value
+            this.extensions.keyUsage.useKeyAgreement = true;
+            if (value === 'useEncipherOnly') {
+              this.extensions.keyUsage.useDecipherOnly = false;
+              this.extensions.keyUsage.useEncipherOnly = true;
+            } else {
+              this.extensions.keyUsage.useEncipherOnly = false;
+              this.extensions.keyUsage.useDecipherOnly = true;
+            }
+          }
         }
       });
     });

--- a/lemur/static/app/angular/certificates/certificate/options.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/options.tpl.html
@@ -75,17 +75,17 @@
           </div>
           <div class="checkbox">
             <label>
-              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useKeyAgreement">Key Agreement
+              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useKeyAgreement" ng-checked="certificate.extensions.keyUsage.useEncipherOnly||certificate.extensions.keyUsage.useDecipherOnly">Key Agreement
             </label>
           </div>
           <div class="checkbox">
             <label>
-              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useEncipherOnly">Encipher Only
+              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useEncipherOnly" ng-disabled="certificate.extensions.keyUsage.useDecipherOnly">Encipher Only
             </label>
           </div>
           <div class="checkbox">
             <label>
-              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useDecipherOnly">Decipher Only
+              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useDecipherOnly" ng-disabled="certificate.extensions.keyUsage.useEncipherOnly">Decipher Only
             </label>
           </div>
         </div>

--- a/lemur/static/app/angular/certificates/certificate/options.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/options.tpl.html
@@ -75,17 +75,17 @@
           </div>
           <div class="checkbox">
             <label>
-              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useKeyAgreement" ng-checked="certificate.extensions.keyUsage.useEncipherOnly||certificate.extensions.keyUsage.useDecipherOnly">Key Agreement
+              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useKeyAgreement">Key Agreement
             </label>
           </div>
-          <div class="checkbox">
+          <div class="radio">
             <label>
-              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useEncipherOnly" ng-disabled="certificate.extensions.keyUsage.useDecipherOnly">Encipher Only
+              <input type="radio" name="encipherOrDecipher" ng-model="certificate.encipherOrDecipher" value="useEncipherOnly" ng-click="certificate.setEncipherOrDecipher('useEncipherOnly')">Encipher Only
             </label>
           </div>
-          <div class="checkbox">
+          <div class="radio">
             <label>
-              <input type="checkbox" ng-model="certificate.extensions.keyUsage.useDecipherOnly" ng-disabled="certificate.extensions.keyUsage.useEncipherOnly">Decipher Only
+              <input type="radio" name="encipherOrDecipher" ng-model="certificate.encipherOrDecipher" value="useDecipherOnly" ng-click="certificate.setEncipherOrDecipher('useDecipherOnly')">Decipher Only
             </label>
           </div>
         </div>

--- a/lemur/static/app/angular/certificates/services.js
+++ b/lemur/static/app/angular/certificates/services.js
@@ -113,6 +113,32 @@ angular.module('lemur')
           }
           this.extensions = this.template.extensions;
           this.extensions.subAltNames = saveSubAltNames;
+        },
+        setEncipherOrDecipher: function (value) {
+          if (this.extensions === undefined) {
+            this.extensions = {};
+          }
+          if (this.extensions.keyUsage === undefined) {
+            this.extensions.keyUsage = {};
+          }
+          var existingValue = this.extensions.keyUsage[value];
+          if (existingValue) {
+            // Clicked on the already-selected value
+            this.extensions.keyUsage.useDecipherOnly = false;
+            this.extensions.keyUsage.useEncipherOnly = false;
+            // Uncheck both radio buttons
+            this.encipherOrDecipher = false;
+          } else {
+            // Clicked a different value
+            this.extensions.keyUsage.useKeyAgreement = true;
+            if (value === 'useEncipherOnly') {
+              this.extensions.keyUsage.useDecipherOnly = false;
+              this.extensions.keyUsage.useEncipherOnly = true;
+            } else {
+              this.extensions.keyUsage.useEncipherOnly = false;
+              this.extensions.keyUsage.useDecipherOnly = true;
+            }
+          }
         }
       });
     });


### PR DESCRIPTION
This is an alternate solution to https://github.com/Netflix/lemur/issues/663 using radio buttons instead of mutually exclusive checkboxes. This PR is an alternate to https://github.com/Netflix/lemur/pull/664. Both PRs cannot be accepted. I like this one more.

The code underlying them is a bit more complicated, but the UI should look more comfortably aligned with the options available for KeyUsage.