### PR TITLE
Issue #703 bugfix

### DIFF
--- a/lemur/plugins/lemur_cryptography/plugin.py
+++ b/lemur/plugins/lemur_cryptography/plugin.py
@@ -157,7 +157,7 @@ def normalize_extensions(csr):
 
     # Remove original san extension from CSR and add new SAN extension
     extensions = list(filter(filter_san_extensions, csr.extensions._extensions))
-    if not san_extension is None and len(san_extension.value._general_names) > 0:
+    if san_extension is not None and len(san_extension.value._general_names) > 0:
         extensions.append(san_extension)
 
     return extensions

--- a/lemur/plugins/lemur_cryptography/plugin.py
+++ b/lemur/plugins/lemur_cryptography/plugin.py
@@ -131,14 +131,13 @@ def normalize_extensions(csr):
         san_extension = csr.extensions.get_extension_for_oid(x509.oid.ExtensionOID.SUBJECT_ALTERNATIVE_NAME)
         san_dnsnames = san_extension.value.get_values_for_type(x509.DNSName)
     except x509.extensions.ExtensionNotFound:
-        current_app.logger.info("extensionnotfound")
         san_dnsnames = []
         san_extension = x509.Extension(x509.oid.ExtensionOID.SUBJECT_ALTERNATIVE_NAME, True, x509.SubjectAlternativeName(san_dnsnames))
 
     common_name = csr.subject.get_attributes_for_oid(x509.oid.NameOID.COMMON_NAME)
     common_name = common_name[0].value
 
-    if not (common_name in san_dnsnames and " " in common_name):
+    if common_name not in san_dnsnames and " " not in common_name:
         # CommonName isn't in SAN and CommonName has no spaces that will cause idna errors
         # Create new list of GeneralNames for including in the SAN extension
         general_names = []

--- a/lemur/plugins/lemur_cryptography/plugin.py
+++ b/lemur/plugins/lemur_cryptography/plugin.py
@@ -89,8 +89,6 @@ def issue_certificate(csr, options, private_key=None):
                     aki = x509.AuthorityKeyIdentifier(authority_key_identifier_subject.digest, None, None)
                 else:
                     aki = x509.AuthorityKeyIdentifier.from_issuer_public_key(authority_key_identifier_public)
-            if authority_key_identifier and authority_identifier:
-                aki = x509.AuthorityKeyIdentifier(aki.key_identifier, [x509.DirectoryName(authority_key_identifier_issuer)], authority_key_identifier_serial)
             elif authority_identifier:
                 aki = x509.AuthorityKeyIdentifier(None, [x509.DirectoryName(authority_key_identifier_issuer)], authority_key_identifier_serial)
             builder = builder.add_extension(aki, critical=False)

--- a/lemur/plugins/lemur_cryptography/tests/test_cryptography.py
+++ b/lemur/plugins/lemur_cryptography/tests/test_cryptography.py
@@ -30,6 +30,7 @@ def test_issue_certificate(authority):
     from lemur.plugins.lemur_cryptography.plugin import issue_certificate
 
     options = {
+        'common_name': 'Example.com',
         'authority': authority,
         'validity_start': arrow.get('2016-12-01').datetime,
         'validity_end': arrow.get('2016-12-02').datetime

--- a/lemur/static/app/angular/certificates/services.js
+++ b/lemur/static/app/angular/certificates/services.js
@@ -107,10 +107,15 @@ angular.module('lemur')
           });
         },
         useTemplate: function () {
-          var saveSubAltNames = {};
-          if (this.extensions && this.extensions.subAltNames) {
-            saveSubAltNames = this.extensions.subAltNames;
+          if (this.extensions === undefined) {
+            this.extensions = {};
           }
+
+          if (this.extensions.subAltNames === undefined) {
+            this.extensions.subAltNames = {'names': []};
+          }
+
+          var saveSubAltNames = this.extensions.subAltNames;
           this.extensions = this.template.extensions;
           this.extensions.subAltNames = saveSubAltNames;
         },


### PR DESCRIPTION
These fixes resolve the concerns in https://github.com/Netflix/lemur/issues/703.

1. If the SAN extension does not contain the CN part of the subject, it will be added as a DNSName. The side effect here is that you can never have an empty SAN extension.
1. Found a bug in creating certificates where the subAltNames tracked in the web UI were getting dropped. If you added SANs on the first page, then changed the template drop-down on the second page, you'd lose the SANs.
1. I also removed the allowance lemur_cryptography used to have where you could have both types of AuthorityKeyIdentifier (keyid and serial/issuer) at once. I have been unable to make a certificate validate there, and the RFC does suggest it should be one or the other.