### PR TITLE
specify python3 when creating virtualenv

### DIFF
--- a/docs/quickstart/index.rst
+++ b/docs/quickstart/index.rst
@@ -59,7 +59,7 @@ Create the virtual environment, activate it and enter the Lemur's directory:
 
 .. code-block:: bash
 
-    $ virtualenv lemur
+    $ virtualenv -p python3 lemur
     $ source /www/lemur/bin/activate
     $ cd lemur
 


### PR DESCRIPTION
Lemur is developed against Python3.5. If you do not specify the Python version it is possible the virtualenv will be built on a different version.