### PR TITLE
Don’t set ‘custom_expiration_date’ if validity years is set in the UI.

### DIFF
--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -89,11 +89,18 @@ def get_issuance(options):
     :param options:
     :return:
     """
-    if not options.get('validity_end'):
-        options['validity_end'] = arrow.utcnow().replace(years=current_app.config.get('DIGICERT_DEFAULT_VALIDITY', 1))
 
-    options['validity_years'] = determine_validity_years(options['validity_end'])
-    return options
+    validity_years = options.get('validity_years')
+
+    if validity_years:
+        options['validity_end'] = None
+        return options
+    else:
+        if not options.get('validity_end'):
+            options['validity_end'] = arrow.utcnow().replace(years=current_app.config.get('DIGICERT_DEFAULT_VALIDITY', 1))
+
+        options['validity_years'] = determine_validity_years(options['validity_end'])
+        return options
 
 
 def get_additional_names(options):
@@ -131,7 +138,11 @@ def map_fields(options, csr):
     })
 
     data['certificate']['dns_names'] = get_additional_names(options)
-    data['custom_expiration_date'] = options['validity_end'].format('YYYY-MM-DD')
+
+    if options.get('validity_end'):
+        data['custom_expiration_date'] = options['validity_end'].format('YYYY-MM-DD')
+
+    data['validity_years'] = options.get('validity_years')
 
     return data
 

--- a/lemur/plugins/lemur_digicert/tests/test_digicert.py
+++ b/lemur/plugins/lemur_digicert/tests/test_digicert.py
@@ -10,7 +10,7 @@ from cryptography import x509
 def test_map_fields_with_validity_end_and_start(app):
     from lemur.plugins.lemur_digicert.plugin import map_fields
 
-    names = [u"one.example.com", u"two.example.com", u"three.example.com"]
+    names = [u'one.example.com', u'two.example.com', u'three.example.com']
 
     options = {
         'common_name': 'example.com',

--- a/lemur/plugins/lemur_digicert/tests/test_digicert.py
+++ b/lemur/plugins/lemur_digicert/tests/test_digicert.py
@@ -7,10 +7,10 @@ from lemur.tests.vectors import CSR_STR
 from cryptography import x509
 
 
-def test_map_fields(app):
+def test_map_fields_with_validity_end_and_start(app):
     from lemur.plugins.lemur_digicert.plugin import map_fields
 
-    names = ['one.example.com', 'two.example.com', 'three.example.com']
+    names = [u"one.example.com", u"two.example.com", u"three.example.com"]
 
     options = {
         'common_name': 'example.com',
@@ -35,14 +35,47 @@ def test_map_fields(app):
             'signature_hash': 'sha256'
         },
         'organization': {'id': 111111},
-        'custom_expiration_date': arrow.get(2017, 5, 7).format('YYYY-MM-DD')
+        'custom_expiration_date': arrow.get(2017, 5, 7).format('YYYY-MM-DD'),
+        'validity_years': 1
+    }
+
+
+def test_map_fields_with_validity_years(app):
+    from lemur.plugins.lemur_digicert.plugin import map_fields
+
+    names = [u'one.example.com', u'two.example.com', u'three.example.com']
+
+    options = {
+        'common_name': 'example.com',
+        'owner': 'bob@example.com',
+        'description': 'test certificate',
+        'extensions': {
+            'sub_alt_names': {
+                'names': [x509.DNSName(x) for x in names]
+            }
+        },
+        'validity_years': 2,
+        'validity_end': arrow.get(2017, 10, 30)
+    }
+
+    data = map_fields(options, CSR_STR)
+
+    assert data == {
+        'certificate': {
+            'csr': CSR_STR,
+            'common_name': 'example.com',
+            'dns_names': names,
+            'signature_hash': 'sha256'
+        },
+        'organization': {'id': 111111},
+        'validity_years': 2
     }
 
 
 def test_map_cis_fields(app):
     from lemur.plugins.lemur_digicert.plugin import map_cis_fields
 
-    names = ['one.example.com', 'two.example.com', 'three.example.com']
+    names = [u'one.example.com', u'two.example.com', u'three.example.com']
 
     options = {
         'common_name': 'example.com',


### PR DESCRIPTION
This PR is for updating the Digicert Plugin so that when you define `validity_years` in the UI it no longer sets the `custom_expiration_date`. The reason for this is because not every digicert account allows for you to define a `custom_expiration_date` as it's a restriction on the account, it's also not required if you don't need a custom expiration date on your cert.

Other small changes:
- Explicitly set the `sub_alt_names` in the tests to be unicode (this is to fix a breaking test)
- Always define `validity_years` in `map_fields` as it's required in the [Digicert API](https://www.digicert.com/services/v2/documentation/order/order-ssl-determinator)
- Unset `validity_end` as it's no longer required if `validity_years` is already defined, by default `validity_end` seems to be getting set upstream, doing this makes it easier to determine whether or not to use `custom_expiration_date`.

This PR is in relation to this issue: https://github.com/Netflix/lemur/issues/741

Is it possible to also cherry-pick the following commit into `0.4.x` as well as it causes issues when spinning up a stack:  https://github.com/Netflix/lemur/commit/d68b2b22e067066b010885b615d6e06ebab3933c