### PR TITLE
Fix for exception thrown when a certificate doesn't have any notifications

### DIFF
--- a/lemur/notifications/messaging.py
+++ b/lemur/notifications/messaging.py
@@ -131,10 +131,10 @@ def send_expiration_notifications(exclude):
             else:
                 failure += 1
 
-    if send_notification('expiration', security_data, security_email, notification):
-        success += 1
-    else:
-        failure += 1
+            if send_notification('expiration', security_data, security_email, notification):
+                success += 1
+            else:
+                failure += 1
 
     return success, failure
 

--- a/lemur/tests/test_messaging.py
+++ b/lemur/tests/test_messaging.py
@@ -75,6 +75,15 @@ def test_send_expiration_notification(certificate, notification, notification_pl
 
 
 @mock_ses
+def test_send_expiration_notification_with_no_notifications(certificate, notification, notification_plugin):
+    from lemur.notifications.messaging import send_expiration_notifications
+
+    delta = certificate.not_after - timedelta(days=10)
+    with freeze_time(delta.datetime):
+        assert send_expiration_notifications([]) == (0, 0)
+
+
+@mock_ses
 def test_send_rotation_notification(notification_plugin, certificate):
     from lemur.notifications.messaging import send_rotation_notification
     send_rotation_notification(certificate, notification_plugin=notification_plugin)


### PR DESCRIPTION
When trying to send notifications via the cron job I ran into the following error:
```
Traceback (most recent call last):
  File "/usr/local/bin/lemur", line 11, in <module>
    load_entry_point('lemur', 'console_scripts', 'lemur')()
  File "/opt/app/lemur/lemur/manage.py", line 534, in main
    manager.run()
  File "/usr/local/lib/python3.5/site-packages/flask_script/__init__.py", line 412, in run
    result = self.handle(sys.argv[0], sys.argv[1:])
  File "/usr/local/lib/python3.5/site-packages/flask_script/__init__.py", line 383, in handle
    res = handle(*args, **config)
  File "/usr/local/lib/python3.5/site-packages/flask_script/commands.py", line 216, in __call__
    return self.run(*args, **kwargs)
  File "/opt/app/lemur/lemur/notifications/cli.py", line 29, in expirations
    success, failed = send_expiration_notifications(exclude)
  File "/opt/app/lemur/lemur/notifications/messaging.py", line 134, in send_expiration_notifications
    if send_notification('expiration', security_data, security_email, notification):
UnboundLocalError: local variable 'notification' referenced before assignment
```

It seems the indentation may have been incorrect for:
```
if send_notification('expiration', security_data, security_email, notification):
  success += 1
else:
  failure += 1
````

After indenting it the same as:
```
if send_notification('expiration', notification_data, [owner], notification):
    success += 1
else:
    failure += 1
```

It resolves the problem I have above. I also added a test for making sure that if a certificate doesn't have any notifications it doesn't throw an exception.

Previously it was referencing `notification` which may in turn never be set if we never go into the loop. It would of also just of been taking the last Notification that was ever set which may not be the correct notification.