### PR TITLE
Fix for snake cased payloads

### DIFF
--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -73,14 +73,15 @@ def test_authority_key_identifier_schema():
 
     data, errors = AuthorityKeyIdentifierSchema().load(input_data)
 
-    assert data == {
+    assert sorted(data) == sorted({
         'use_key_identifier': True,
         'use_authority_cert': True
-    }
+    })
+
     assert not errors
 
     data, errors = AuthorityKeyIdentifierSchema().dumps(data)
-    assert data == json.dumps(input_data)
+    assert sorted(data) == sorted(json.dumps(input_data))
     assert not errors
 
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ install_requires = [
     'six==1.10.0',
     'marshmallow-sqlalchemy==0.13.1',
     'gunicorn==19.7.1',
-    'marshmallow==2.13.4',
+    'marshmallow==2.4.0',
     'cryptography==1.7',
     'pyjwt==1.4.2',
     'xmltodict==0.10.2',


### PR DESCRIPTION
Revert back to version 2.4.0 as there seem to be bugs with the later version where it no longer correctly triggers the post_dump

Other changes:

- Fix flakey test: The ordering of the keys can change so this change tests the sorted keys