### PR TITLE
Return correct intermediate certificate on digicert creation.

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -450,12 +450,6 @@ The following configuration properties are required to use the Digicert issuer p
             This is the Digicert organization ID tied to your API key
 
 
-.. data:: DIGICERT_INTERMEDIATE
-    :noindex:
-
-            This is the intermediate to be used for your CA chain
-
-
 .. data:: DIGICERT_ROOT
     :noindex:
 

--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -241,7 +241,6 @@ class DigiCertSourcePlugin(SourcePlugin):
             'DIGICERT_URL',
             'DIGICERT_ORG_ID',
             'DIGICERT_ROOT',
-            'DIGICERT_INTERMEDIATE'
         ]
         validate_conf(current_app, required_vars)
 
@@ -279,7 +278,6 @@ class DigiCertIssuerPlugin(IssuerPlugin):
             'DIGICERT_URL',
             'DIGICERT_ORG_ID',
             'DIGICERT_ROOT',
-            'DIGICERT_INTERMEDIATE'
         ]
 
         validate_conf(current_app, required_vars)
@@ -317,10 +315,10 @@ class DigiCertIssuerPlugin(IssuerPlugin):
 
         certificate_id = get_certificate_id(self.session, base_url, order_id)
 
-        # retrieve ceqrtificate
+        # retrieve certificate
         certificate_url = "{0}/services/v2/certificate/{1}/download/format/pem_all".format(base_url, certificate_id)
         end_entity, intermediate, root = pem.parse(self.session.get(certificate_url).content)
-        return "\n".join(str(end_entity).splitlines()), "\n".join(str(end_entity).splitlines())
+        return "\n".join(str(end_entity).splitlines()), "\n".join(str(intermediate).splitlines())
 
     @staticmethod
     def create_authority(options):

--- a/lemur/plugins/lemur_digicert/tests/test_digicert.py
+++ b/lemur/plugins/lemur_digicert/tests/test_digicert.py
@@ -1,5 +1,6 @@
 import pytest
 import arrow
+import json
 from freezegun import freeze_time
 
 from lemur.tests.vectors import CSR_STR
@@ -146,3 +147,32 @@ def test_signature_hash(app):
 
     with pytest.raises(Exception):
         signature_hash('sdfdsf')
+
+
+def test_issuer_plugin_create_certificate():
+    import requests_mock
+    from lemur.plugins.lemur_digicert.plugin import DigiCertIssuerPlugin
+
+    pem_fixture = """\
+-----BEGIN CERTIFICATE-----
+abc
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+def
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+ghi
+-----END CERTIFICATE-----
+"""
+
+    subject = DigiCertIssuerPlugin()
+    adapter = requests_mock.Adapter()
+    adapter.register_uri('POST', 'mock://www.digicert.com/services/v2/order/certificate/ssl', text=json.dumps({'id': 'id123'}))
+    adapter.register_uri('GET', 'mock://www.digicert.com/services/v2/order/certificate/id123', text=json.dumps({'status': 'issued', 'certificate': {'id': 'cert123'}}))
+    adapter.register_uri('GET', 'mock://www.digicert.com/services/v2/certificate/cert123/download/format/pem_all', text=pem_fixture)
+    subject.session.mount('mock', adapter)
+
+    cert, intermediate = subject.create_certificate("", {'common_name': 'test.com'})
+
+    assert cert == "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----"
+    assert intermediate == "-----BEGIN CERTIFICATE-----\ndef\n-----END CERTIFICATE-----"

--- a/lemur/tests/conf.py
+++ b/lemur/tests/conf.py
@@ -68,11 +68,10 @@ LEMUR_INSTANCE_PROFILE = 'Lemur'
 # CLOUDCA_DEFAULT_VALIDITY = 2
 
 
-DIGICERT_URL = 'https://www.digicert.com'
+DIGICERT_URL = 'mock://www.digicert.com'
 DIGICERT_API_KEY = 'api-key'
 DIGICERT_ORG_ID = 111111
 DIGICERT_ROOT = "ROOT"
-DIGICERT_INTERMEDIATE = "INTERMEDIATE"
 
 
 VERISIGN_URL = 'http://example.com'

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,8 @@ tests_require = [
     'factory-boy==2.8.1',
     'fake-factory==0.7.2',
     'pytest-flask==0.10.0',
-    'freezegun==0.3.8'
+    'freezegun==0.3.8',
+    'requests-mock==1.3.0'
 ]
 
 docs_require = [


### PR DESCRIPTION
At the moment when we create a new cert through the digicert plugin, the export created has the created certificate twice rather than the certificate and intermediate. This commit corrects the return value of the plugin for digicert.

This commit also removes the unused DIGICERT_INTERMEDIATE env
var as it is not used.