### PR TITLE
Hexify cert serial

### DIFF
--- a/lemur/certificates/schemas.py
+++ b/lemur/certificates/schemas.py
@@ -6,7 +6,7 @@
 .. moduleauthor:: Kevin Glisson <kglisson@netflix.com>
 """
 from flask import current_app
-from marshmallow import fields, validate, validates_schema, post_load, pre_load
+from marshmallow import fields, validate, validates_schema, post_load, pre_load, post_dump
 from marshmallow.exceptions import ValidationError
 
 from lemur.schemas import AssociatedAuthoritySchema, AssociatedDestinationSchema, AssociatedCertificateSchema, \
@@ -197,6 +197,12 @@ class CertificateOutputSchema(LemurOutputSchema):
     roles = fields.Nested(RoleNestedOutputSchema, many=True)
     endpoints = fields.Nested(EndpointNestedOutputSchema, many=True, missing=[])
     replaced_by = fields.Nested(CertificateNestedOutputSchema, many=True, attribute='replaced')
+
+    @post_dump
+    def convert_serial_to_hex(self, data):
+        if data:
+            data['serial'] = hex(int(data['serial']))[2:].upper()
+        return data
 
 
 class CertificateUploadInputSchema(CertificateCreationSchema):

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -364,6 +364,11 @@ def test_certificate_get(client, token, status):
     assert client.get(api.url_for(Certificates, certificate_id=1), headers=token).status_code == status
 
 
+def test_certificate_get_body(client):
+    response_body = client.get(api.url_for(Certificates, certificate_id=1), headers=VALID_USER_HEADER_TOKEN).json
+    assert response_body['serial'] == "3e9"
+
+
 @pytest.mark.parametrize("token,status", [
     (VALID_USER_HEADER_TOKEN, 405),
     (VALID_ADMIN_HEADER_TOKEN, 405),

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -73,14 +73,14 @@ def test_authority_key_identifier_schema():
 
     data, errors = AuthorityKeyIdentifierSchema().load(input_data)
 
-    assert data == {
+    assert sorted(data) == sorted({
         'use_key_identifier': True,
         'use_authority_cert': True
-    }
+    })
     assert not errors
 
     data, errors = AuthorityKeyIdentifierSchema().dumps(data)
-    assert data == json.dumps(input_data)
+    assert sorted(data) == sorted(json.dumps(input_data))
     assert not errors
 
 
@@ -366,7 +366,7 @@ def test_certificate_get(client, token, status):
 
 def test_certificate_get_body(client):
     response_body = client.get(api.url_for(Certificates, certificate_id=1), headers=VALID_USER_HEADER_TOKEN).json
-    assert response_body['serial'] == "3e9"
+    assert response_body['serial'] == "3E9"
 
 
 @pytest.mark.parametrize("token,status", [


### PR DESCRIPTION
It seems as though majority of CA's represent the serial as a hex value rather than a decimal value as does the `openssl` command. I suspect this is due to readability. This PR hexifies the serial at the serialization layer so that it's represented in the UI the same way it is within the CA UI. The reason I've done it at the serialization layer is this allows for reconciliation of certificate serials via the API if needed. I didn't update the serial in the database as it's nice to keep the original intended value.

Other changes:
- Fix for flakey test, the ordering of the keys is random so by sorting we remove the randomness.