### PR TITLE
Extension error handling

### DIFF
--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -292,6 +292,9 @@ class Certificate(db.Model):
                     current_app.logger.warning('Custom OIDs not yet supported for clone operation.')
         except InvalidCodepoint as e:
             current_app.logger.warning('Unable to parse extensions due to underscore in dns name')
+        except ValueError as e:
+            current_app.logger.warning('Unable to parse')
+            current_app.logger.exception(e)
 
         return return_extensions
 


### PR DESCRIPTION
Sometimes we run into issues iterating over extensions where certificates might not have been issued in adherence with basic constraints. Here we log these errors instead of failing outright.