### PR TITLE
Add docker setup for running tests on a docker enabled dev environment.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.5
+RUN apt-get update
+RUN apt-get install -y make python-software-properties curl
+RUN curl -sL https://deb.nodesource.com/setup_7.x | bash -
+RUN apt-get update
+RUN apt-get install -y nodejs
+RUN pip install -U setuptools
+RUN pip install coveralls bandit
+WORKDIR /app
+COPY . /app/
+RUN pip install -e .
+RUN pip install "file://`pwd`#egg=lemur[dev]"
+RUN pip install "file://`pwd`#egg=lemur[tests]"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+---
+version: '2.0'
+services:
+  test:
+    build: .
+    volumes:
+      - ".:/app"
+    links:
+      - postgres
+    command: make test
+    environment:
+      SQLALCHEMY_DATABASE_URI: postgresql://lemur:lemur@postgres:5432/lemur
+
+  postgres:
+    image: postgres:9.4
+    environment:
+      POSTGRES_USER: lemur
+      POSTGRES_PASSWORD: lemur

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -89,6 +89,12 @@ You'll likely want to make some changes to the default configuration (we recomme
 .. note:: The ``upgrade`` shortcut is simply a shortcut to Alembic's upgrade command.
 
 
+Running tests with Docker and docker-compose
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Alternatively you can use Docker and docker-compose for running the tests with ``docker-compose run test``.
+
+
 Coding Standards
 ----------------
 

--- a/lemur/tests/conf.py
+++ b/lemur/tests/conf.py
@@ -49,7 +49,7 @@ LEMUR_ALLOW_WEEKEND_EXPIRATION = False
 # Database
 
 # modify this if you are not using a local database
-SQLALCHEMY_DATABASE_URI = 'postgresql://lemur:lemur@localhost:5432/lemur'
+SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI', 'postgresql://lemur:lemur@localhost:5432/lemur')
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 # AWS


### PR DESCRIPTION
We use docker and docker-compose for development. This PR adds the requisite files to enable development without needing to install python, node, postgres. It should not alter a non-docker dev workflow, but merely enable docker dev as an option if that is your thing.