### PR TITLE
fix unit and interval transposition in schemas.py (#752)

### DIFF
--- a/lemur/schemas.py
+++ b/lemur/schemas.py
@@ -38,13 +38,13 @@ def validate_options(options):
     if not interval and not unit:
         return
 
-    if interval == 'month':
-        unit *= 30
+    if unit == 'month':
+        interval *= 30
 
-    elif interval == 'week':
-        unit *= 7
+    elif unit == 'week':
+        interval *= 7
 
-    if unit > 90:
+    if interval > 90:
         raise ValidationError('Notification cannot be more than 90 days into the future.')
 
 


### PR DESCRIPTION
I found the same error as in #752 when trying to add a new slack notification.
**interval** and **unit** appear to be transposed in validate_options.
I've tested briefly; after this fix I could successfully add a certificate to a notification, as well as add the new slack notification.