### PR TITLE
Check for unknown as status is no longer represented as a boolean

### DIFF
--- a/lemur/static/app/angular/certificates/view/view.tpl.html
+++ b/lemur/static/app/angular/certificates/view/view.tpl.html
@@ -117,7 +117,7 @@
                       class="list-group-item">
                       <strong>Validity</strong>
                       <span class="pull-right">
-                        <span ng-if="!certificate.status" class="label label-warning">Unknown</span>
+                        <span ng-if="certificate.status == 'unknown'" class="label label-warning">Unknown</span>
                         <span ng-if="certificate.status == 'revoked'" class="label label-danger">Revoked</span>
                         <span ng-if="certificate.status == 'valid'" class="label label-success">Valid</span>
                       </span>


### PR DESCRIPTION
This PR is in relation to https://github.com/Netflix/lemur/pull/778 it updates the view to represent 'unknown' correctly.