### PR TITLE
Separating CC from CIS logic

### DIFF
--- a/lemur/plugins/lemur_digicert/tests/test_digicert.py
+++ b/lemur/plugins/lemur_digicert/tests/test_digicert.py
@@ -36,8 +36,7 @@ def test_map_fields_with_validity_end_and_start(app):
             'signature_hash': 'sha256'
         },
         'organization': {'id': 111111},
-        'custom_expiration_date': arrow.get(2017, 5, 7).format('YYYY-MM-DD'),
-        'validity_years': 1
+        'custom_expiration_date': arrow.get(2017, 5, 7).format('YYYY-MM-DD')
     }
 
 
@@ -107,34 +106,34 @@ def test_map_cis_fields(app):
         'profile_name': None
     }
 
-
-def test_issuance():
-    from lemur.plugins.lemur_digicert.plugin import get_issuance
+    options = {
+        'common_name': 'example.com',
+        'owner': 'bob@example.com',
+        'description': 'test certificate',
+        'extensions': {
+            'sub_alt_names': {
+                'names': [x509.DNSName(x) for x in names]
+            }
+        },
+        'organization': 'Example, Inc.',
+        'organizational_unit': 'Example Org',
+        'validity_years': 2
+    }
 
     with freeze_time(time_to_freeze=arrow.get(2016, 11, 3).datetime):
-        options = {
-            'validity_end': arrow.get(2018, 5, 7),
-            'validity_start': arrow.get(2016, 10, 30)
+        data = map_cis_fields(options, CSR_STR)
+
+        assert data == {
+            'common_name': 'example.com',
+            'csr': CSR_STR,
+            'additional_dns_names': names,
+            'signature_hash': 'sha256',
+            'organization': {'name': 'Example, Inc.', 'units': ['Example Org']},
+            'validity': {
+                'valid_to': arrow.get(2018, 11, 3).format('YYYY-MM-DD')
+            },
+            'profile_name': None
         }
-
-        new_options = get_issuance(options)
-        assert new_options['validity_years'] == 2
-
-        options = {
-            'validity_end': arrow.get(2017, 5, 7),
-            'validity_start': arrow.get(2016, 10, 30)
-        }
-
-        new_options = get_issuance(options)
-        assert new_options['validity_years'] == 1
-
-        options = {
-            'validity_end': arrow.get(2020, 5, 7),
-            'validity_start': arrow.get(2016, 10, 30)
-        }
-
-        with pytest.raises(Exception):
-            period = get_issuance(options)
 
 
 def test_signature_hash(app):


### PR DESCRIPTION
Splitting out the default date issuance logic for CIS and CC. CIS assumes years is converted to validity_end while CC prefers validity_years over validity_end. This is a modification of #742. 

cc @treacher 