### PR TITLE
Fixing some confusion between 401 vs 403 error codes.

### DIFF
--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -164,17 +164,17 @@ class Ping(Resource):
                 algo = header_data['alg']
                 break
         else:
-            return dict(message='Key not found'), 403
+            return dict(message='Key not found'), 401
 
         # validate your token based on the key it was signed with
         try:
             jwt.decode(id_token, secret.decode('utf-8'), algorithms=[algo], audience=args['clientId'])
         except jwt.DecodeError:
-            return dict(message='Token is invalid'), 403
+            return dict(message='Token is invalid'), 401
         except jwt.ExpiredSignatureError:
-            return dict(message='Token has expired'), 403
+            return dict(message='Token has expired'), 401
         except jwt.InvalidTokenError:
-            return dict(message='Token is invalid'), 403
+            return dict(message='Token is invalid'), 401
 
         user_params = dict(access_token=access_token, schema='profile')
 

--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -271,7 +271,7 @@ class CertificatesList(AuthenticatedResource):
             data['creator'] = g.user
             return service.create(**data)
 
-        return dict(message="You are not authorized to use {0}".format(data['authority'].name)), 403
+        return dict(message="You are not authorized to use the authority: {0}".format(data['authority'].name)), 403
 
 
 class CertificatesUpload(AuthenticatedResource):

--- a/lemur/static/app/angular/app.js
+++ b/lemur/static/app/angular/app.js
@@ -106,7 +106,7 @@
 
       // handle situation where our token has become invalid.
       RestangularConfigurer.setErrorInterceptor(function (response) {
-        if (response.status === 403) {
+        if (response.status === 401) {
           $auth.logout();
           $location.path('/login');
           return false;


### PR DESCRIPTION
401 indicates that the user should attempt to authenticate again. Where as 403 indicates the user is authenticated but not allowed to complete an action.

Closes #767