### PR TITLE
adding url context path to html templates

### DIFF
--- a/docs/quickstart/index.rst
+++ b/docs/quickstart/index.rst
@@ -89,7 +89,7 @@ And then run:
 .. note:: This command will install npm dependencies as well as compile static assets.
 
 
-You may also run with the urlContextPath variable set. If this is set it will add the desired context path for subsequent calls back to lemur.
+You may also run with the urlContextPath variable set. If this is set it will add the desired context path for subsequent calls back to lemur. This will only edit the front end code for calls back to the server, you will have to make sure the server knows about these routes.
 ::
 
   Example:

--- a/gulp/build.js
+++ b/gulp/build.js
@@ -232,10 +232,16 @@ gulp.task('package:strip', function () {
 
 gulp.task('addUrlContextPath',['addUrlContextPath:revreplace'], function(){
   var urlContextPathExists = argv.urlContextPath ? true : false;
-  return gulp.src('lemur/static/dist/scripts/main*.js')
-    .pipe(gulpif(urlContextPathExists, replace('api/', argv.urlContextPath + '/api/')))
-    .pipe(gulpif(urlContextPathExists, replace('angular/', argv.urlContextPath + '/angular/')))
-    .pipe(gulp.dest('lemur/static/dist/scripts'))
+  ['lemur/static/dist/scripts/main*.js',
+  'lemur/static/dist/angular/**/*.html']
+  .forEach(function(file){
+    return gulp.src(file)
+      .pipe(gulpif(urlContextPathExists, replace('api/', argv.urlContextPath + '/api/')))
+      .pipe(gulpif(urlContextPathExists, replace('angular/', argv.urlContextPath + '/angular/')))
+      .pipe(gulp.dest(function(file){
+        return file.base;
+      }))
+  })
 });
 
 gulp.task('addUrlContextPath:revision', function(){


### PR DESCRIPTION
Something changed with how the pager.html was retrieved. This is a fix for the urlContextPath changes I put in a while ago. Also adding a clarification to the documentation.