### PR TITLE
Fixing KeyError on error handling in DigiCert plugin

### DIFF
--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -169,7 +169,7 @@ def handle_response(response):
     :return:
     """
     if response.status_code > 399:
-        raise Exception(response.json()['message'])
+        raise Exception(response.json()['errors'][0]['message'])
 
     return response.json()
 
@@ -297,7 +297,7 @@ class DigiCertIssuerPlugin(IssuerPlugin):
         response = self.session.post(determinator_url, data=json.dumps(data))
 
         if response.status_code > 399:
-            raise Exception(response.json()['message'])
+            raise Exception(response.json()['errors'][0]['message'])
 
         order_id = response.json()['id']
 


### PR DESCRIPTION
If an error occurs during the certificate request, the error handling code will currently raise a KeyError

```
[2017-06-12 22:51:53,742] ERROR in schema: 'message'
Traceback (most recent call last):
  File "/opt/lemur/lemur/common/schema.py", line 158, in decorated_function
    resp = f(*args, **kwargs)
  File "/opt/lemur/lemur/certificates/views.py", line 272, in post
    return service.create(**data)
  File "/opt/lemur/lemur/certificates/service.py", line 232, in create
    cert_body, private_key, cert_chain = mint(**kwargs)
  File "/opt/lemur/lemur/certificates/service.py", line 181, in mint
    cert_body, cert_chain = issuer.create_certificate(csr, kwargs)
  File "/opt/lemur/lemur/plugins/lemur_digicert/plugin.py", line 307, in create_certificate
    raise Exception(response.json()['message'])
KeyError: 'message'

'message'
Traceback (most recent call last):
  File "/opt/lemur/lemur/common/schema.py", line 158, in decorated_function
    resp = f(*args, **kwargs)
  File "/opt/lemur/lemur/certificates/views.py", line 272, in post
    return service.create(**data)
  File "/opt/lemur/lemur/certificates/service.py", line 232, in create
    cert_body, private_key, cert_chain = mint(**kwargs)
  File "/opt/lemur/lemur/certificates/service.py", line 181, in mint
    cert_body, cert_chain = issuer.create_certificate(csr, kwargs)
  File "/opt/lemur/lemur/plugins/lemur_digicert/plugin.py", line 307, in create_certificate
    raise Exception(response.json()['message'])
KeyError: 'message'
```