### PR TITLE
Adding support for private DigiCert certificates

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -466,6 +466,11 @@ The following configuration properties are required to use the Digicert issuer p
             This is the default validity (in years), if no end date is specified. (Default: 1)
 
 
+.. data:: DIGICERT_PRIVATE
+    :noindex:
+
+            This is whether or not to issue a private certificate. (Default: False)
+
 
 CFSSL Issuer Plugin
 ^^^^^^^^^^^^^^^^^^^

--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -126,6 +126,12 @@ def map_fields(options, csr):
     else:
         data['custom_expiration_date'] = options['validity_end'].format('YYYY-MM-DD')
 
+    if current_app.config.get('DIGICERT_PRIVATE', False):
+        if 'product' in data:
+            data['product']['type_hint'] = 'private'
+        else:
+            data['product'] = dict(type_hint='private')
+
     return data
 
 


### PR DESCRIPTION
Allow setting a new configuration variable (`DIGICERT_PRIVATE` (`bool`)), which when set will issue private certificates from DigiCert instead of production certificates.

This is highly useful for test environments that do not have permissions to issue live certificates. This value is not required, and will default to `False` if not set