### PR TITLE
set ses email content type to utf-8 instead of string

### DIFF
--- a/lemur/plugins/lemur_email/plugin.py
+++ b/lemur/plugins/lemur_email/plugin.py
@@ -63,12 +63,12 @@ def send_via_ses(subject, body, targets):
         Message={
             'Subject': {
                 'Data': subject,
-                'Charset': 'string'
+                'Charset': 'UTF-8'
             },
             'Body': {
                 'Html': {
                     'Data': body,
-                    'Charset': 'string'
+                    'Charset': 'UTF-8'
                 }
             }
         }


### PR DESCRIPTION
I was testing SES notification and hit this error...

```
Traceback (most recent call last):
  File "/opt/app/lemur/lemur/notifications/messaging.py", line 97, in send_notification
    notification.plugin.send(event_type, data, targets, notification.options)
  File "/opt/app/lemur/lemur/plugins/lemur_email/plugin.py", line 115, in send
    send_via_ses(subject, body, targets)
  File "/opt/app/lemur/lemur/plugins/lemur_email/plugin.py", line 71, in send_via_ses
    'Charset': 'string'
  File "/usr/local/lib/python3.5/site-packages/botocore/client.py", line 310, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.5/site-packages/botocore/client.py", line 599, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (InvalidParameterValue) when calling the SendEmail operation: Unsupported charset 'string'.
Finished notifying subscribers about expiring certificates! Sent: 0 Failed: 2
```
In the email plugin, it looks like Charset is set to the value 'string', whereas SES needs an actual charset.


So I think the safest might be to use UTF-8 for now. I set it to this and my notifications then worked.
