### PR TITLE
Add log message on creation or update of certificate.

### DIFF
--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -269,7 +269,9 @@ class CertificatesList(AuthenticatedResource):
 
         if authority_permission.can():
             data['creator'] = g.user
-            return service.create(**data)
+            cert = service.create(**data)
+            log_service.create(g.user, 'create_cert', certificate=cert)
+            return cert
 
         return dict(message="You are not authorized to use the authority: {0}".format(data['authority'].name)), 403
 
@@ -644,7 +646,9 @@ class Certificates(AuthenticatedResource):
                         )
                     ), 400
 
-        return service.update(certificate_id, **data)
+        cert = service.update(certificate_id, **data)
+        log_service.create(g.current_user, 'update_cert', certificate=cert)
+        return cert
 
 
 class NotificationCertificatesList(AuthenticatedResource):

--- a/lemur/logs/models.py
+++ b/lemur/logs/models.py
@@ -18,6 +18,6 @@ class Log(db.Model):
     __tablename__ = 'logs'
     id = Column(Integer, primary_key=True)
     certificate_id = Column(Integer, ForeignKey('certificates.id'))
-    log_type = Column(Enum('key_view', name='log_type'), nullable=False)
+    log_type = Column(Enum('key_view', 'create_cert', 'update_cert', name='log_type'), nullable=False)
     logged_at = Column(ArrowType(), PassiveDefault(func.now()), nullable=False)
     user_id = Column(Integer, ForeignKey('users.id'), nullable=False)


### PR DESCRIPTION
We would like to be able to put audit logs out of band of the lemur servers, so this PR will create a log entry when a cert is created or updated. This in turn will log an entry to the logs which will go to a central logging point.