### PR TITLE
Disable unused Flask Principal sessions

### DIFF
--- a/lemur/extensions.py
+++ b/lemur/extensions.py
@@ -13,7 +13,7 @@ from flask_bcrypt import Bcrypt
 bcrypt = Bcrypt()
 
 from flask_principal import Principal
-principal = Principal()
+principal = Principal(use_sessions=False)
 
 from flask_mail import Mail
 smtp_mail = Mail()


### PR DESCRIPTION
Lemur uses its own auth token for authentication; logging out doesn't
properly dispose of the Flask Principal session.