### PR TITLE
Create signal hooks and handler for dumping CSR and certificate details

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -120,6 +120,12 @@ Basic Configuration
         LEMUR_ENCRYPTION_KEYS = ['1YeftooSbxCiX2zo8m1lXtpvQjy27smZcUUaGmffhMY=', 'LAfQt6yrkLqOK5lwpvQcT4jf2zdeTQJV1uYeh9coT5s=']
 
 
+.. data:: DEBUG_DUMP
+    :noindex:
+
+        Dump all imported or generated CSR and certificate details to stdout using OpenSSL. (default: `False`)
+
+
 Certificate Default Options
 ---------------------------
 

--- a/lemur/certificates/hooks.py
+++ b/lemur/certificates/hooks.py
@@ -1,0 +1,38 @@
+"""
+Debugging hooks for dumping imported or generated CSR and certificate details to stdout via OpenSSL.
+
+.. module: lemur.certificates.hooks
+    :platform: Unix
+    :copyright: (c) 2016-2017 by Marti Raudsepp, see AUTHORS for more
+    :license: Apache, see LICENSE for more details.
+
+.. moduleauthor:: Marti Raudsepp <marti@juffo.org>
+"""
+import subprocess
+
+from flask import current_app
+
+from lemur.certificates.service import csr_created, csr_imported, certificate_issued, certificate_imported
+
+
+def csr_dump_handler(sender, csr, **kwargs):
+    try:
+        subprocess.run(['openssl', 'req', '-text', '-noout', '-reqopt', 'no_sigdump,no_pubkey'],
+                       input=csr.encode('utf8'))
+    except Exception as err:
+        current_app.logger.warning("Error inspecting CSR: %s", err)
+
+
+def cert_dump_handler(sender, certificate, **kwargs):
+    try:
+        subprocess.run(['openssl', 'x509', '-text', '-noout', '-certopt', 'no_sigdump,no_pubkey'],
+                       input=certificate.body.encode('utf8'))
+    except Exception as err:
+        current_app.logger.warning("Error inspecting certificate: %s", err)
+
+
+def activate_debug_dump():
+    csr_created.connect(csr_dump_handler)
+    csr_imported.connect(csr_dump_handler)
+    certificate_issued.connect(cert_dump_handler)
+    certificate_imported.connect(cert_dump_handler)

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -15,7 +15,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 
 from lemur import database
-from lemur.extensions import metrics
+from lemur.extensions import metrics, signals
 from lemur.plugins.base import plugins
 from lemur.common.utils import generate_private_key
 
@@ -29,6 +29,12 @@ from lemur.notifications.models import Notification
 from lemur.certificates.schemas import CertificateOutputSchema, CertificateInputSchema
 
 from lemur.roles import service as role_service
+
+
+csr_created = signals.signal('csr_created', "CSR generated")
+csr_imported = signals.signal('csr_imported', "CSR imported from external source")
+certificate_issued = signals.signal('certificate_issued', "Authority issued a certificate")
+certificate_imported = signals.signal('certificate_imported', "Certificate imported from external source")
 
 
 def get(cert_id):
@@ -168,9 +174,11 @@ def mint(**kwargs):
     # allow the CSR to be specified by the user
     if not kwargs.get('csr'):
         csr, private_key = create_csr(**kwargs)
+        csr_created.send(authority=authority, csr=csr)
     else:
         csr = str(kwargs.get('csr'))
         private_key = None
+        csr_imported.send(authority=authority, csr=csr)
 
     cert_body, cert_chain = issuer.create_certificate(csr, kwargs)
     return cert_body, private_key, cert_chain,
@@ -216,7 +224,10 @@ def upload(**kwargs):
     cert = database.create(cert)
 
     kwargs['creator'].certificates.append(cert)
-    return database.update(cert)
+
+    cert = database.update(cert)
+    certificate_imported.send(certificate=cert, authority=cert.authority)
+    return cert
 
 
 def create(**kwargs):
@@ -239,6 +250,8 @@ def create(**kwargs):
 
     kwargs['creator'].certificates.append(cert)
     cert.authority = kwargs['authority']
+    certificate_issued.send(certificate=cert, authority=cert.authority)
+
     database.commit()
 
     metrics.send('certificate_issued', 'counter', 1, metric_tags=dict(owner=cert.owner, issuer=cert.issuer))

--- a/lemur/extensions.py
+++ b/lemur/extensions.py
@@ -23,3 +23,6 @@ metrics = Metrics()
 
 from raven.contrib.flask import Sentry
 sentry = Sentry()
+
+from blinker import Namespace
+signals = Namespace()

--- a/lemur/factory.py
+++ b/lemur/factory.py
@@ -18,6 +18,8 @@ from logging import Formatter, StreamHandler
 from logging.handlers import RotatingFileHandler
 
 from flask import Flask
+
+from lemur.certificates.hooks import activate_debug_dump
 from lemur.common.health import mod as health
 from lemur.extensions import db, migrate, principal, smtp_mail, metrics, sentry
 
@@ -156,6 +158,9 @@ def configure_logging(app):
     stream_handler = StreamHandler()
     stream_handler.setLevel(app.config.get('LOG_LEVEL', 'DEBUG'))
     app.logger.addHandler(stream_handler)
+
+    if app.config.get('DEBUG_DUMP', False):
+        activate_debug_dump()
 
 
 def install_plugins(app):


### PR DESCRIPTION
This has been quite useful for debugging various Lemur integrations and CA configuration: who sends/requests what and how the certificate looks like in the end. Since it shows more information than Lemur itself.

I don't know if you want to merge this whole. Alternatively you I could only submit the signals part and I can refactor the rest out into a plugin for myself.