### PR TITLE
Expensive notification query. 

### DIFF
--- a/lemur/notifications/schemas.py
+++ b/lemur/notifications/schemas.py
@@ -26,7 +26,6 @@ class NotificationOutputSchema(LemurOutputSchema):
     active = fields.Boolean()
     options = fields.List(fields.Dict())
     plugin = fields.Nested(PluginOutputSchema)
-    certificates = fields.Nested(AssociatedCertificateSchema, many=True, missing=[])
 
     @post_dump
     def fill_object(self, data):


### PR DESCRIPTION
It's too expensive to attempt to load all certificates associated with a given notification. Some queries such as `default` are associated with a large number of certificates. We have little control over when these objects are loaded, but when marshalled they are lazyloaded via SQLAlachemy. If a user needs to get all the certificates associated with a certificate they should use the /notifications/<id>/certificates endpoints that support pagination.