### PR TITLE
Add pyldap mock for readthedocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,11 +13,23 @@
 # serve to show the default.
 import sys
 import os
+from unittest.mock import MagicMock
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
+
+# Mock packages that cannot be installed on rtd
+on_rtd = os.environ.get('READTHEDOCS') == 'True'
+if on_rtd:
+    class Mock(MagicMock):
+        @classmethod
+        def __getattr__(cls, name):
+            return MagicMock()
+
+    MOCK_MODULES = ['ldap']
+    sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -28,7 +28,7 @@ tabulate==0.7.7
 pem==17.1.0
 raven[flask]==6.1.0
 jinja2==2.9.6
-pyldap==2.4.37  # required by ldap auth provider
+# pyldap==2.4.37  # cannot be installed on rtd - required by ldap auth provider
 paramiko==2.2.1  # required for lemur_linuxdst plugin
 sphinx
 sphinxcontrib-httpdomain


### PR DESCRIPTION
After #910 the readthedocs [build failed](https://readthedocs.org/projects/lemur/builds/5956411/), `pyldap` requires C modules which are not installed in rtd.

According to their [docs](https://docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules) the solution is to mock the packages so that autodoc is able to import the modules.