### PR TITLE
Disallow issuing certificates from inactive authority

### DIFF
--- a/lemur/certificates/schemas.py
+++ b/lemur/certificates/schemas.py
@@ -85,6 +85,11 @@ class CertificateInputSchema(CertificateCreationSchema):
     extensions = fields.Nested(ExtensionSchema)
 
     @validates_schema
+    def validate_authority(self, data):
+        if not data['authority'].active:
+            raise ValidationError("The authority is inactive.", ['authority'])
+
+    @validates_schema
     def validate_dates(self, data):
         validators.dates(data)
 

--- a/lemur/static/app/angular/authorities/services.js
+++ b/lemur/static/app/angular/authorities/services.js
@@ -107,13 +107,7 @@ angular.module('lemur')
     AuthorityService.findActiveAuthorityByName = function (filterValue) {
       return AuthorityApi.getList({'filter[name]': filterValue})
         .then(function (authorities) {
-          var activeAuthorities = [];
-          _.each(authorities, function (authority) {
-              if (authority.active) {
-                activeAuthorities.push(authority);
-              }
-          });
-          return activeAuthorities;
+          return authorities.filter(function(authority) { return authority.active; });
         });
     };
 

--- a/lemur/static/app/angular/certificates/certificate/certificate.js
+++ b/lemur/static/app/angular/certificates/certificate/certificate.js
@@ -95,7 +95,7 @@ angular.module('lemur')
     };
 
     $scope.getAuthoritiesByName = function (value) {
-      return AuthorityService.findAuthorityByName(value).then(function (authorities) {
+      return AuthorityService.findActiveAuthorityByName(value).then(function (authorities) {
         $scope.authorities = authorities;
       });
     };

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -286,6 +286,26 @@ def test_certificate_allowed_names(client, authority, session, logged_in_user):
     assert not errors
 
 
+def test_certificate_incative_authority(client, authority, session, logged_in_user):
+    """Cannot issue certificates with an inactive authority."""
+    from lemur.certificates.schemas import CertificateInputSchema
+
+    authority.active = False
+    session.add(authority)
+
+    input_data = {
+        'commonName': 'foo.example.com',
+        'owner': 'jim@example.com',
+        'authority': {'id': authority.id},
+        'description': 'testtestest',
+        'validityStart': '2020-01-01T00:00:00',
+        'validityEnd': '2020-01-01T00:00:01',
+    }
+
+    data, errors = CertificateInputSchema().load(input_data)
+    assert errors['authority'][0] == "The authority is inactive."
+
+
 def test_certificate_disallowed_names(client, authority, session, logged_in_user):
     """The CN and SAN are disallowed by LEMUR_WHITELISTED_DOMAINS."""
     from lemur.certificates.schemas import CertificateInputSchema


### PR DESCRIPTION
It seems that this was the intent of the 'active' flag on authorities, but never actually implemented?
