### PR TITLE
Avoid redundant key_view log entries

### DIFF
--- a/lemur/static/app/angular/certificates/view/view.js
+++ b/lemur/static/app/angular/certificates/view/view.js
@@ -55,6 +55,10 @@ angular.module('lemur')
     };
 
     $scope.loadPrivateKey = function (certificate) {
+      if (certificate.privateKey !== undefined) {
+        return;
+      }
+
       CertificateService.loadPrivateKey(certificate).then(
         function (response) {
           if (response.key === null) {


### PR DESCRIPTION
Don't re-request private key when it's already loaded in frontend.