### PR TITLE
Added ability to set custom roles for users logging in via oauth provider

### DIFF
--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -345,8 +345,15 @@ class OAuth2(Resource):
         user = user_service.get_by_email(profile['email'])
         metrics.send('successful_login', 'counter', 1)
 
-        # update their google 'roles'
+        # update with roles sent by identity provider
         roles = []
+
+        if 'roles' in profile:
+            for group in profile['roles']:
+                role = role_service.get_by_name(group)
+                if not role:
+                    role = role_service.create(group, description='This is a group configured by identity provider')
+                roles.append(role)
 
         role = role_service.get_by_name(profile['email'])
         if not role:


### PR DESCRIPTION
So far it was not possible to set roles for lemur users via oauth when logging in. This pull requests adds the ability to add roles to a user on login via oauth.

The user gets assigned roles in case there is a claim "roles" in the users userinfo!