### PR TITLE
Ensures we can get multiple endpoints.

### DIFF
--- a/lemur/endpoints/service.py
+++ b/lemur/endpoints/service.py
@@ -60,6 +60,16 @@ def get_by_dnsname(dnsname):
     return database.get(Endpoint, dnsname, field='dnsname')
 
 
+def get_by_dnsname_and_port(dnsname, port):
+    """
+    Retrieves and endpoint by it's dnsname and port.
+    :param dnsname:
+    :param port:
+    :return:
+    """
+    return Endpoint.query.filter(Endpoint.dnsname == dnsname).filter(Endpoint.port == port).scalar()
+
+
 def get_by_source(source_label):
     """
     Retrieves all endpoints for a given source.

--- a/lemur/plugins/lemur_aws/plugin.py
+++ b/lemur/plugins/lemur_aws/plugin.py
@@ -109,6 +109,8 @@ def get_elb_endpoints(account_number, region, elb_dict):
                                                          account_number=account_number, region=region)
             endpoint['policy'] = format_elb_cipher_policy(policy)
 
+        current_app.logger.debug("Found new endpoint. Endpoint: {}".format(endpoint))
+
         endpoints.append(endpoint)
 
     return endpoints

--- a/lemur/plugins/lemur_aws/sts.py
+++ b/lemur/plugins/lemur_aws/sts.py
@@ -22,8 +22,6 @@ def sts_client(service, service_type='client'):
                 current_app.config.get('LEMUR_INSTANCE_PROFILE', 'Lemur')
             )
 
-            current_app.logger.debug('Assuming Role. Role: {0}'.format(arn))
-
             # TODO add user specific information to RoleSessionName
             role = sts.assume_role(RoleArn=arn, RoleSessionName='lemur')
 

--- a/lemur/sources/service.py
+++ b/lemur/sources/service.py
@@ -72,7 +72,7 @@ def sync_endpoints(source):
         return new, updated
 
     for endpoint in endpoints:
-        exists = endpoint_service.get_by_dnsname(endpoint['dnsname'])
+        exists = endpoint_service.get_by_dnsname_and_port(endpoint['dnsname'], endpoint['port'])
 
         certificate_name = endpoint.pop('certificate_name')
 
@@ -99,7 +99,7 @@ def sync_endpoints(source):
             new += 1
 
         else:
-            current_app.logger.debug("Endpoint Updated: Name: {name}".format(name=endpoint['name']))
+            current_app.logger.debug("Endpoint Updated: {}".format(endpoint))
             endpoint_service.update(exists.id, **endpoint)
             updated += 1
 


### PR DESCRIPTION
There is currently an issue where we only look up endpoints by their DNS name, however we really need to track endpoints by their dnsname + port. 

This fix should ensure that we are capturing all possible endpoints. 