### PR TITLE
Don't write files from the test suite

### DIFF
--- a/lemur/plugins/lemur_email/tests/test_email.py
+++ b/lemur/plugins/lemur_email/tests/test_email.py
@@ -19,19 +19,15 @@ def test_render(certificate, endpoint):
 
     template = env.get_template('{}.html'.format('expiration'))
 
-    with open(os.path.join(dir_path, 'expiration-rendered.html'), 'w') as f:
-        body = template.render(dict(message=data, hostname='lemur.test.example.com'))
-        f.write(body)
+    body = template.render(dict(message=data, hostname='lemur.test.example.com'))
 
     template = env.get_template('{}.html'.format('rotation'))
 
     certificate.endpoints.append(endpoint)
 
-    with open(os.path.join(dir_path, 'rotation-rendered.html'), 'w') as f:
-        body = template.render(
-            dict(
-                certificate=certificate_notification_output_schema.dump(certificate).data,
-                hostname='lemur.test.example.com'
-            )
+    body = template.render(
+        dict(
+            certificate=certificate_notification_output_schema.dump(certificate).data,
+            hostname='lemur.test.example.com'
         )
-        f.write(body)
+    )


### PR DESCRIPTION
The lemur_email.tests.test_render test would fail when running unittests
from a read-only source tree.

Feel free to reject this PR if writing these files served some useful purpose for you. I could also rewrite this and write to some temporary directory. What do you think?
