### PR TITLE
Add DIGICERT_ORDER_TYPE to Digicert plugin

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -581,6 +581,12 @@ The following configuration properties are required to use the Digicert issuer p
             This is the url for the Digicert API (e.g. https://www.digicert.com)
 
 
+.. data:: DIGICERT_ORDER_TYPE
+    :noindex:
+
+            This is the type of certificate to order. (e.g. ssl_plus, ssl_ev_plus see: https://www.digicert.com/services/v2/documentation/order/overview-submit)
+
+
 .. data:: DIGICERT_API_KEY
     :noindex:
 

--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -271,6 +271,7 @@ class DigiCertIssuerPlugin(IssuerPlugin):
             'DIGICERT_API_KEY',
             'DIGICERT_URL',
             'DIGICERT_ORG_ID',
+            'DIGICERT_ORDER_TYPE',
             'DIGICERT_ROOT',
         ]
 
@@ -296,9 +297,10 @@ class DigiCertIssuerPlugin(IssuerPlugin):
         :return: :raise Exception:
         """
         base_url = current_app.config.get('DIGICERT_URL')
+        cert_type = current_app.config.get('DIGICERT_ORDER_TYPE')
 
         # make certificate request
-        determinator_url = "{0}/services/v2/order/certificate/ssl".format(base_url)
+        determinator_url = "{0}/services/v2/order/certificate/{1}".format(base_url, cert_type)
         data = map_fields(issuer_options, csr)
         response = self.session.post(determinator_url, data=json.dumps(data))
 

--- a/lemur/plugins/lemur_digicert/tests/test_digicert.py
+++ b/lemur/plugins/lemur_digicert/tests/test_digicert.py
@@ -166,7 +166,7 @@ ghi
 
     subject = DigiCertIssuerPlugin()
     adapter = requests_mock.Adapter()
-    adapter.register_uri('POST', 'mock://www.digicert.com/services/v2/order/certificate/ssl', text=json.dumps({'id': 'id123'}))
+    adapter.register_uri('POST', 'mock://www.digicert.com/services/v2/order/certificate/ssl_plus', text=json.dumps({'id': 'id123'}))
     adapter.register_uri('GET', 'mock://www.digicert.com/services/v2/order/certificate/id123', text=json.dumps({'status': 'issued', 'certificate': {'id': 'cert123'}}))
     adapter.register_uri('GET', 'mock://www.digicert.com/services/v2/certificate/cert123/download/format/pem_all', text=pem_fixture)
     subject.session.mount('mock', adapter)

--- a/lemur/tests/conf.py
+++ b/lemur/tests/conf.py
@@ -71,6 +71,7 @@ LEMUR_INSTANCE_PROFILE = 'Lemur'
 
 
 DIGICERT_URL = 'mock://www.digicert.com'
+DIGICERT_ORDER_TYPE = 'ssl_plus'
 DIGICERT_API_KEY = 'api-key'
 DIGICERT_ORG_ID = 111111
 DIGICERT_ROOT = "ROOT"


### PR DESCRIPTION
This allows lemur.conf.py to control which kind of certificate to
order.  User defined options are not currently supported in the the UI,
so we cannot create multiple Digicert authorities at runtime for
separate certificate types.