### PR TITLE
Fix DigiCert issuer plugin revoke URL

### DIFF
--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -319,7 +319,7 @@ class DigiCertIssuerPlugin(IssuerPlugin):
         base_url = current_app.config.get('DIGICERT_URL')
 
         # make certificate revoke request
-        create_url = '{0}/certificate/{1}/revoke'.format(base_url, certificate.external_id)
+        create_url = '{0}/services/v2/certificate/{1}/revoke'.format(base_url, certificate.external_id)
         metrics.send('digicert_revoke_certificate', 'counter', 1)
         response = self.session.put(create_url, data=json.dumps({'comments': comments}))
         return handle_response(response)


### PR DESCRIPTION
The URL for revoking DigiCert certificates was incorrect.

See: https://www.digicert.com/services/v2/documentation/certificate/revoke