### PR TITLE
Update psycopg2 to 2.7.3.2 for glibc 2.26 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ install_requires = [
     'SQLAlchemy-Utils==0.32.21',
     'requests==2.11.1',
     'ndg-httpsclient==0.4.2',
-    'psycopg2==2.7.3',
+    'psycopg2==2.7.3.2',
     'arrow==0.12.0',
     'six==1.11.0',
     'marshmallow-sqlalchemy==0.13.1',


### PR DESCRIPTION
Respectfully request to update psycopg2 to make it work with Ubuntu 17.10 and Archlinux (which use glibc 2.26).  
On Ubuntu 17.10, `lemur init` or `lemur db create` will fail with a backtrace, unless psycopg2 is upgraded with pip.