### PR TITLE
Fix for Lemur should be able to revoke certs pulled in via a source plugin

### DIFF
--- a/lemur/sources/service.py
+++ b/lemur/sources/service.py
@@ -140,6 +140,8 @@ def sync_certificates(source, user):
             for e in exists:
                 if certificate.get('external_id'):
                     e.external_id = certificate['external_id']
+                if certificate.get('authority_id'):
+                    e.authority_id = certificate['authority_id']
                 certificate_update(e, source)
                 updated += 1
 


### PR DESCRIPTION
Fix for [Issue #1045](https://github.com/Netflix/lemur/issues/1045) by illegalhex (Thanks @illegalhex)