### PR TITLE
EntryPoints digicert_cis_source missing comma

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -197,8 +197,8 @@ setup(
             'cfssl_issuer = lemur.plugins.lemur_cfssl.plugin:CfsslIssuerPlugin',
             'digicert_issuer = lemur.plugins.lemur_digicert.plugin:DigiCertIssuerPlugin',
             'digicert_cis_issuer = lemur.plugins.lemur_digicert.plugin:DigiCertCISIssuerPlugin',
-            'digicert_cis_source = lemur.plugins.lemur_digicert.plugin:DigiCertCISSourcePlugin'
-            'csr_export = lemur.plugins.lemur_csr.plugin:CSRExportPlugin',
+            'digicert_cis_source = lemur.plugins.lemur_digicert.plugin:DigiCertCISSourcePlugin',
+            'csr_export = lemur.plugins.lemur_csr.plugin:CSRExportPlugin'
         ],
     },
     classifiers=[


### PR DESCRIPTION
Simple typo, missing comma for EntryPoints `digicert_cis_source` and extra comma on `csr_export`.