### PR TITLE
lemur create_config: Non-ASCII character lemur/common/defaults.py

### DIFF
--- a/lemur/common/defaults.py
+++ b/lemur/common/defaults.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 import re
 import unicodedata
 


### PR DESCRIPTION
Running the `lemur create_config` fails with the error message:
```
SyntaxError: Non-ASCII character '\xc3' in file /var/www/lemur/lemur/common/defaults.py on line 13, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```

The transgressing line is actually a comment:
```
# Strip all character accents (ä => a): decompose Unicode characters and then drop combining chars.
```

Possible fix:
From PEP-0263 "...make the Python source code encoding both visible and changeable on a per-source file basis by using a special comment at the top of the file to declare the encoding."
```
# - *- coding: utf- 8 - *-
```
or
```
# coding: utf-8
```

I understand there's several ways to deal with this all subject to Lemur's design and code style.