### PR TITLE
lemur create_config: Remove non-ASCII character 

### DIFF
--- a/lemur/common/defaults.py
+++ b/lemur/common/defaults.py
@@ -10,7 +10,7 @@ from lemur.constants import SAN_NAMING_TEMPLATE, DEFAULT_NAMING_TEMPLATE
 def text_to_slug(value):
     """Normalize a string to a "slug" value, stripping character accents and removing non-alphanum characters."""
 
-    # Strip all character accents (ä => a): decompose Unicode characters and then drop combining chars.
+    # Strip all character accents: decompose Unicode characters and then drop combining chars.
     value = ''.join(c for c in unicodedata.normalize('NFKD', value) if not unicodedata.combining(c))
 
     # Replace all remaining non-alphanumeric characters with '-'. Multiple characters get collapsed into a single dash.


### PR DESCRIPTION
Running the `lemur create_config` fails with the error message:
```
SyntaxError: Non-ASCII character '\xc3' in file /var/www/lemur/lemur/common/defaults.py on line 13, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```

The transgressing line is actually a comment:
```
# Strip all character accents (ä => a): decompose Unicode characters and then drop combining chars.
```

[Solution per PEP-0263](https://github.com/Netflix/lemur/pull/1096) failed encoding tests.

**Fix:** Removed special character.