### PR TITLE
lemur_digicert: Do not truncate valid_to anymore

### DIFF
--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -157,7 +157,7 @@ def map_cis_fields(options, csr):
         "csr": csr,
         "signature_hash": signature_hash(options.get('signing_algorithm')),
         "validity": {
-            "valid_to": options['validity_end'].format('YYYY-MM-DD')
+            "valid_to": options['validity_end'].format('YYYY-MM-DDTHH:MM:SSZ')
         },
         "organization": {
             "name": options['organization'],


### PR DESCRIPTION
The valid_to field for Digicert supports YYYY-MM-DDTHH:MM:SSZ so we should stop truncating

This closes #1072 