### PR TITLE
[fix] Pip imports for pip 10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,19 @@ import datetime
 
 from distutils import log
 from distutils.core import Command
-from pip.download import PipSession
-from pip.req import parse_requirements
 from setuptools.command.develop import develop
 from setuptools.command.install import install
 from setuptools.command.sdist import sdist
 from setuptools import setup, find_packages
 from subprocess import check_output
+
+import pip
+if tuple(map(int, pip.__version__.split('.'))) >= (10, 0, 0):
+    from pip._internal.download import PipSession
+    from pip._internal.req import parse_requirements
+else:
+    from pip.download import PipSession
+    from pip.req import parse_requirements
 
 ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__)))
 


### PR DESCRIPTION
Since [pip 10.0.0b1](https://pip.pypa.io/en/stable/news/#deprecations-and-removals)

> Move all of pip's APIs into the pip._internal package, properly reflecting the fact that pip does not currently have any public APIs. (#4696, #4700)

With an up to date pip, it is impossible to `pip install -e .` lemur, hence this PR.