### PR TITLE
Check for default rotation policy before updating db

### DIFF
--- a/lemur/manage.py
+++ b/lemur/manage.py
@@ -251,12 +251,17 @@ class InitializeApp(Command):
         recipients = current_app.config.get('LEMUR_SECURITY_TEAM_EMAIL')
         notification_service.create_default_expiration_notifications("DEFAULT_SECURITY", recipients=recipients)
 
-        days = current_app.config.get("LEMUR_DEFAULT_ROTATION_INTERVAL", 30)
-        sys.stdout.write("[+] Creating default certificate rotation policy of {days} days before issuance.\n".format(
-            days=days
-        ))
+        _DEFAULT_ROTATION_INTERVAL = 'default'
+        default_rotation_interval = policy_service.get_by_name(_DEFAULT_ROTATION_INTERVAL)
 
-        policy_service.create(days=days, name='default')
+        if default_rotation_interval:
+            sys.stdout.write("[-] Default rotation interval policy already created, skipping...!\n")
+        else:
+            days = current_app.config.get("LEMUR_DEFAULT_ROTATION_INTERVAL", 30)
+            sys.stdout.write("[+] Creating default certificate rotation policy of {days} days before issuance.\n".format(
+                days=days))
+            policy_service.create(days=days, name=_DEFAULT_ROTATION_INTERVAL)
+
         sys.stdout.write("[/] Done!\n")
 
 

--- a/lemur/policies/service.py
+++ b/lemur/policies/service.py
@@ -18,6 +18,15 @@ def get(policy_id):
     return database.get(RotationPolicy, policy_id)
 
 
+def get_by_name(policy_name):
+    """
+    Retrieves policy by its name.
+    :param policy_name:
+    :return:
+    """
+    return database.get_all(RotationPolicy, policy_name, field='name').all()
+
+
 def delete(policy_id):
     """
     Delete a rotation policy.


### PR DESCRIPTION
Fixes #1046 

This PR adds a check for the default rotation policy before attempting to add it through `lemur init`.