### PR TITLE
Use serial_number instead of serial

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,10 @@ Lemur
 .. image:: https://travis-ci.org/Netflix/lemur.svg
     :target: https://travis-ci.org/Netflix/lemur
 
+.. image:: https://coveralls.io/repos/github/Netflix/lemur/badge.svg?branch=master
+    :target: https://coveralls.io/github/Netflix/lemur?branch=master
+
+
 
 Lemur manages TLS certificate creation. While not able to issue certificates itself, Lemur acts as a broker between CAs
 and environments providing a central portal for developers to issue TLS certificates with 'sane' defaults.

--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -300,12 +300,14 @@ class CertificatesUpload(AuthenticatedResource):
 
               {
                  "owner": "joe@example.com",
-                 "publicCert": "-----BEGIN CERTIFICATE-----...",
-                 "intermediateCert": "-----BEGIN CERTIFICATE-----...",
+                 "body": "-----BEGIN CERTIFICATE-----...",
+                 "chain": "-----BEGIN CERTIFICATE-----...",
                  "privateKey": "-----BEGIN RSA PRIVATE KEY-----..."
                  "destinations": [],
                  "notifications": [],
                  "replacements": [],
+                 "roles": [],
+                 "notify": true,
                  "name": "cert1"
               }
 

--- a/lemur/common/defaults.py
+++ b/lemur/common/defaults.py
@@ -178,7 +178,7 @@ def serial(cert):
     :param cert:
     :return: serial number
     """
-    return cert.serial
+    return cert.serial_number
 
 
 def san(cert):


### PR DESCRIPTION
This fixes deprecation warning coming from cryptography package about using cert.serial instead of serial_number.