### PR TITLE
Fix import metrics in notifications/messaging.py

### DIFF
--- a/lemur/notifications/messaging.py
+++ b/lemur/notifications/messaging.py
@@ -17,9 +17,9 @@ from flask import current_app
 
 from sqlalchemy import and_
 
-from lemur import database, metrics
+from lemur import database
 from lemur.constants import FAILURE_METRIC_STATUS, SUCCESS_METRIC_STATUS
-from lemur.extensions import sentry
+from lemur.extensions import metrics, sentry
 from lemur.common.utils import windowed_query
 
 from lemur.certificates.schemas import certificate_notification_output_schema


### PR DESCRIPTION
`from lemur import metrics` is incorrect for notifications/messaging.py
because that is importing the `metrics` module rather than the
instanciated `lemur.extensions.metrics` object.  This will cause errors
if you import notifications/messaging.py elsewhere, since it can cause
circular dependencies.