### PR TITLE
Clean up module imports

### DIFF
--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -21,7 +21,7 @@ from lemur.common.utils import get_psuedo_random_string
 from lemur.users import service as user_service
 from lemur.roles import service as role_service
 from lemur.auth.service import create_token, fetch_token_header, get_rsa_public_key
-import lemur.auth.ldap as ldap
+from lemur.auth import ldap
 
 
 mod = Blueprint('auth', __name__)

--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -23,13 +23,11 @@ from sqlalchemy import event, Integer, ForeignKey, String, PassiveDefault, func,
 from sqlalchemy_utils.types.arrow import ArrowType
 from werkzeug.utils import cached_property
 
-import lemur.common.utils
-
 from lemur.database import db
 from lemur.extensions import sentry
 
 from lemur.utils import Vault
-from lemur.common import defaults
+from lemur.common import defaults, utils
 
 from lemur.plugins.base import plugins
 
@@ -188,7 +186,7 @@ class Certificate(db.Model):
     @cached_property
     def parsed_cert(self):
         assert self.body, "Certificate body not set"
-        return lemur.common.utils.parse_certificate(self.body)
+        return utils.parse_certificate(self.body)
 
     @property
     def active(self):

--- a/lemur/pending_certificates/models.py
+++ b/lemur/pending_certificates/models.py
@@ -10,9 +10,8 @@ from sqlalchemy import Integer, ForeignKey, String, PassiveDefault, func, Column
 from sqlalchemy_utils.types.arrow import ArrowType
 from sqlalchemy_utils import JSONType
 
-import lemur.common.utils
 from lemur.certificates.models import get_or_increase_name
-from lemur.common import defaults
+from lemur.common import defaults, utils
 from lemur.database import db
 from lemur.utils import Vault
 
@@ -81,7 +80,7 @@ class PendingCertificate(db.Model):
                     dt.now(), dt.now(), False), self.external_id)
             self.rename = True
 
-        self.cn = defaults.common_name(lemur.common.utils.parse_csr(self.csr))
+        self.cn = defaults.common_name(utils.parse_csr(self.csr))
         self.owner = kwargs['owner']
         self.number_attempts = 0
 

--- a/lemur/utils.py
+++ b/lemur/utils.py
@@ -9,7 +9,7 @@ import os
 import tempfile
 from contextlib import contextmanager
 
-import sqlalchemy.types as types
+from sqlalchemy import types
 from cryptography.fernet import Fernet, MultiFernet
 from flask import current_app
 


### PR DESCRIPTION
Example:
* import lemur.common.utils -> from lemur.common import utils
* import sqlalchemy.types as types -> from sqlalchemy import types
