### PR TITLE
Adds an optional interval variable to notification service's

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -274,7 +274,6 @@ Lemur supports sending certification expiration notifications through SES and SM
 
             LEMUR_SECURITY_TEAM_EMAIL = ['security@example.com']
 
-
 .. data:: LEMUR_DEFAULT_EXPIRATION_NOTIFICATION_INTERVALS
     :noindex:
 
@@ -283,6 +282,15 @@ Lemur supports sending certification expiration notifications through SES and SM
         ::
 
             LEMUR_DEFAULT_EXPIRATION_NOTIFICATION_INTERVALS = [30, 15, 2]
+
+.. data:: LEMUR_SECURITY_TEAM_EMAIL_INTERVALS
+    :noindex:
+
+       Alternate notification interval set for security team notifications. Use this if you would like the default security team notification interval for new certificates to differ from the global default as specified in LEMUR_DEFAULT_EXPIRATION_NOTIFICATION_INTERVALS. If unspecified, the value of LEMUR_DEFAULT_EXPIRATION_NOTIFICATION_INTERVALS is used. Security team default notifications for new certificates can effectively be disabled by setting this value to an empty array.
+
+       ::
+
+          LEMUR_SECURITY_TEAM_EMAIL_INTERVALS = [15, 2]
 
 
 Authentication Options

--- a/lemur/certificates/schemas.py
+++ b/lemur/certificates/schemas.py
@@ -48,9 +48,11 @@ class CertificateCreationSchema(CertificateSchema):
                 "DEFAULT_{0}".format(data['owner'].split('@')[0].upper()),
                 [data['owner']],
             )
+
             data['notifications'] += notification_service.create_default_expiration_notifications(
                 'DEFAULT_SECURITY',
-                current_app.config.get('LEMUR_SECURITY_TEAM_EMAIL')
+                current_app.config.get('LEMUR_SECURITY_TEAM_EMAIL'),
+                current_app.config.get('LEMUR_SECURITY_TEAM_EMAIL_INTERVALS', None)
             )
         return data
 

--- a/lemur/notifications/service.py
+++ b/lemur/notifications/service.py
@@ -16,10 +16,11 @@ from lemur.common.utils import truthiness
 from lemur.notifications.models import Notification
 
 
-def create_default_expiration_notifications(name, recipients):
+def create_default_expiration_notifications(name, recipients, intervals=None):
     """
-    Will create standard 30, 10 and 2 day notifications for a given owner. If standard notifications
-    already exist these will be returned instead of new notifications.
+    Will create standard 30, 10 and 2 day notifications for a given owner unless an alternate set of
+    intervals is supplied. If standard notifications already exist these will be returned instead of
+    new notifications.
 
     :param name:
     :param recipients:
@@ -48,7 +49,8 @@ def create_default_expiration_notifications(name, recipients):
         },
     ]
 
-    intervals = current_app.config.get("LEMUR_DEFAULT_EXPIRATION_NOTIFICATION_INTERVALS", [30, 15, 2])
+    if intervals is None:
+        intervals = current_app.config.get("LEMUR_DEFAULT_EXPIRATION_NOTIFICATION_INTERVALS", [30, 15, 2])
 
     notifications = []
     for i in intervals:


### PR DESCRIPTION
create_default_expiration_notifications and introduces a new optional
configuration variable, LEMUR_SECURITY_TEAM_EMAIL_INTERVALS, to allow admins
control over the centralized email notification defaults.