### PR TITLE
WIP: Check that uploaded chain and private key match certificate

### DIFF
--- a/lemur/tests/test_validators.py
+++ b/lemur/tests/test_validators.py
@@ -1,16 +1,29 @@
-import pytest
 from datetime import datetime
-from .vectors import SAN_CERT_KEY
+
+import pytest
 from marshmallow.exceptions import ValidationError
+
+from lemur.common.utils import parse_private_key
+from lemur.common.validators import verify_private_key
+from lemur.tests.vectors import INTERMEDIATE_CERT
+from .vectors import SAN_CERT, SAN_CERT_KEY
 
 
 def test_private_key(session):
-    from lemur.common.validators import private_key
+    parse_private_key(SAN_CERT_KEY)
 
-    private_key(SAN_CERT_KEY)
+    with pytest.raises(ValueError):
+        parse_private_key('invalid_private_key')
+
+
+def test_validate_private_key(session):
+    key = parse_private_key(SAN_CERT_KEY)
+
+    verify_private_key(key, SAN_CERT)
 
     with pytest.raises(ValidationError):
-        private_key('invalid_private_key')
+        # Wrong key for certificate
+        verify_private_key(key, INTERMEDIATE_CERT)
 
 
 def test_sub_alt_type(session):


### PR DESCRIPTION
This is done in the upload validator as well as Certificate constructor,
to make sure that no code path can persist invalid certificates.