### PR TITLE
force owner into lowercase. Properly decode bytecode private key

### DIFF
--- a/lemur/common/schema.py
+++ b/lemur/common/schema.py
@@ -60,6 +60,8 @@ class LemurSchema(Schema):
 class LemurInputSchema(LemurSchema):
     @pre_load(pass_many=True)
     def preprocess(self, data, many):
+        if isinstance(data, dict) and data.get('owner'):
+            data['owner'] = data['owner'].lower()
         return self.under(data, many=many)
 
 

--- a/lemur/plugins/lemur_aws/iam.py
+++ b/lemur/plugins/lemur_aws/iam.py
@@ -72,6 +72,8 @@ def upload_cert(name, body, private_key, path, cert_chain=None, **kwargs):
         name = name + '-' + path.strip('/')
 
     try:
+        if isinstance(private_key, bytes):
+            private_key = private_key.decode("utf-8")
         if cert_chain:
             return client.upload_server_certificate(
                 Path=path,


### PR DESCRIPTION
Force owner into lowercase whenever a cert, authority, or owner of another entity is created or updated.