### PR TITLE
add missing requirements files for setup

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include setup.py version.py package.json bower.json gulpfile.js README.rst MANIFEST.in LICENSE AUTHORS
+include setup.py version.py package.json bower.json gulpfile.js README.rst MANIFEST.in LICENSE AUTHORS requirements*.txt
 recursive-include lemur/plugins/lemur_email/templates *
 recursive-include lemur/static *
 global-exclude *~


### PR DESCRIPTION
When packaging lemur, installs fail because [`setup.py`](https://github.com/Netflix/lemur/blob/1b77dfa47a310a3c72f9e869e7cd6d84f5658304/setup.py#L43) directly reads all of the `requirements*.txt` files that are not included as part of the package.