### PR TITLE
Improved verify

### DIFF
--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -363,7 +363,10 @@ def check_revoked():
             else:
                 status = verify_string(cert.body, "")
 
-            cert.status = 'valid' if status else 'revoked'
+            if status is None:
+                cert.status = 'unknown'
+            else:
+                cert.status = 'valid' if status else 'revoked'
 
         except Exception as e:
             sentry.captureException()

--- a/lemur/certificates/verify.py
+++ b/lemur/certificates/verify.py
@@ -24,6 +24,7 @@ def ocsp_verify(cert, cert_path, issuer_chain_path):
     of CRL in that it will query the OCSP URI in order to determine if the
     certificate has been revoked
 
+    :param cert:
     :param cert_path:
     :param issuer_chain_path:
     :return bool: True if certificate is valid, False otherwise
@@ -62,6 +63,7 @@ def crl_verify(cert, cert_path):
     """
     Attempts to verify a certificate using CRL.
 
+    :param cert:
     :param cert_path:
     :return: True if certificate is valid, False otherwise
     :raise Exception: If certificate does not have CRL

--- a/lemur/certificates/verify.py
+++ b/lemur/certificates/verify.py
@@ -17,6 +17,7 @@ from lemur.common.utils import parse_certificate
 
 crl_cache = {}
 
+
 def ocsp_verify(cert, cert_path, issuer_chain_path):
     """
     Attempts to verify a certificate via OCSP. OCSP is a more modern version
@@ -67,8 +68,8 @@ def crl_verify(cert, cert_path):
     """
     try:
         distribution_points = cert.extensions.get_extension_for_oid(
-                                                    x509.OID_CRL_DISTRIBUTION_POINTS
-                                                ).value
+            x509.OID_CRL_DISTRIBUTION_POINTS
+        ).value
     except x509.ExtensionNotFound:
         current_app.logger.debug("No CRLDP extension in certificate {}".format(cert.serial_number))
         return None

--- a/lemur/tests/test_verify.py
+++ b/lemur/tests/test_verify.py
@@ -13,8 +13,7 @@ from .vectors import INTERMEDIATE_CERT_STR
 def test_verify_simple_cert():
     """Simple certificate without CRL or OCSP."""
     # Verification raises an exception for "unknown" if there are no means to verify it
-    with pytest.raises(Exception, match="Failed to verify"):
-        verify_string(INTERMEDIATE_CERT_STR, '')
+    assert verify_string(INTERMEDIATE_CERT_STR, '') == None
 
 
 def test_verify_crl_unknown_scheme(cert_builder, private_key):
@@ -31,7 +30,7 @@ def test_verify_crl_unknown_scheme(cert_builder, private_key):
             f.write(cert.public_bytes(serialization.Encoding.PEM))
 
         # Must not raise exception
-        crl_verify(cert_tmp)
+        crl_verify(cert, cert_tmp)
 
 
 def test_verify_crl_unreachable(cert_builder, private_key):
@@ -48,4 +47,4 @@ def test_verify_crl_unreachable(cert_builder, private_key):
             f.write(cert.public_bytes(serialization.Encoding.PEM))
 
         with pytest.raises(Exception, match="Unable to retrieve CRL:"):
-            crl_verify(cert_tmp)
+            crl_verify(cert, cert_tmp)


### PR DESCRIPTION
Redoing this completely since I broke the last one.  

This PR addresses a few issues in the CLI verification process, and #1079 

* _Stacked exceptions were yielding lots of tracebacks_
   Rather than using exceptions for non-error failure states, I've updated the code to use return values (False = revoked, True = good, None = unknown).  Exceptions were left in place where they are for unexpected errors (parse errors, http errors, etc.)

* _Verifying a large number of certificates was causing slowdowns as the code was pulling the same  CRL over and over for certs with the same CRL._
   I implemented an extremely simple cache so that an individual CRL is only downloaded once.  This works fine for the CLI where the code is loaded fresh each time but it *could* be a problem if the verify methods are used by the running web app, as the cache has no update/expire feature.  Currently, verification is only in use by the CLI code.

* _Better logging_
   Added debug logging output in case anyone needs to troubleshoot the process.  Also, parse the cert in verify() and pass it to crl_verify() and ocsp_cerify() so they both have access to cert data for logging purposes.

Tests, flake8 and docstrings have been updated since the previous PR and master is merged in.