### PR TITLE
Add CSR to certificiates

### DIFF
--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -87,6 +87,7 @@ class Certificate(db.Model):
 
     body = Column(Text(), nullable=False)
     chain = Column(Text())
+    csr = Column(Text())
     private_key = Column(Vault)
 
     issuer = Column(String(128))
@@ -157,6 +158,9 @@ class Certificate(db.Model):
 
         if kwargs.get('chain'):
             self.chain = kwargs['chain'].strip()
+
+        if kwargs.get('csr'):
+            self.csr = kwargs['csr'].strip()
 
         self.notify = kwargs.get('notify', True)
         self.destinations = kwargs.get('destinations', [])

--- a/lemur/certificates/schemas.py
+++ b/lemur/certificates/schemas.py
@@ -74,7 +74,7 @@ class CertificateInputSchema(CertificateCreationSchema):
     roles = fields.Nested(AssociatedRoleSchema, missing=[], many=True)
     dns_provider = fields.Nested(AssociatedDnsProviderSchema, missing=None, allow_none=True, required=False)
 
-    csr = fields.String(validate=validators.csr)
+    csr = fields.String(allow_none=True, validate=validators.csr)
 
     key_type = fields.String(
         validate=validate.OneOf(CERTIFICATE_KEY_TYPES),
@@ -156,6 +156,7 @@ class CertificateNestedOutputSchema(LemurOutputSchema):
     bits = fields.Integer()
     body = fields.String()
     chain = fields.String()
+    csr = fields.String()
     active = fields.Boolean()
 
     rotation = fields.Boolean()
@@ -187,6 +188,7 @@ class CertificateOutputSchema(LemurOutputSchema):
     bits = fields.Integer()
     body = fields.String()
     chain = fields.String()
+    csr = fields.String()
     deleted = fields.Boolean(default=False)
     description = fields.String()
     issuer = fields.String()

--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -72,6 +72,7 @@ class CertificatesList(AuthenticatedResource):
                     "status": null,
                     "cn": "*.test.example.net",
                     "chain": "",
+                    "csr": "-----BEGIN CERTIFICATE REQUEST-----"
                     "authority": {
                         "active": true,
                         "owner": "secure@example.com",
@@ -490,6 +491,7 @@ class Certificates(AuthenticatedResource):
                 "status": null,
                 "cn": "*.test.example.net",
                 "chain": "",
+                "csr": "-----BEGIN CERTIFICATE REQUEST-----"
                 "authority": {
                     "active": true,
                     "owner": "secure@example.com",
@@ -694,6 +696,7 @@ class NotificationCertificatesList(AuthenticatedResource):
                     "status": null,
                     "cn": "*.test.example.net",
                     "chain": "",
+                    "csr": "-----BEGIN CERTIFICATE REQUEST-----"
                     "authority": {
                         "active": true,
                         "owner": "secure@example.com",
@@ -802,6 +805,7 @@ class CertificatesReplacementsList(AuthenticatedResource):
                     "status": null,
                     "cn": "*.test.example.net",
                     "chain": "",
+                    "csr": "-----BEGIN CERTIFICATE REQUEST-----",
                     "authority": {
                         "active": true,
                         "owner": "secure@example.com",

--- a/lemur/migrations/versions/7ead443ba911_.py
+++ b/lemur/migrations/versions/7ead443ba911_.py
@@ -1,0 +1,21 @@
+"""Add csr to certificates table
+
+Revision ID: 7ead443ba911
+Revises: 6006c79b6011
+Create Date: 2018-10-21 22:06:23.056906
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '7ead443ba911'
+down_revision = '6006c79b6011'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('certificates', sa.Column('csr', sa.TEXT(), nullable=True))
+
+def downgrade():
+    op.drop_column('certificates', 'csr')

--- a/lemur/static/app/angular/certificates/certificate/certificate.js
+++ b/lemur/static/app/angular/certificates/certificate/certificate.js
@@ -215,6 +215,7 @@ angular.module('lemur')
   CertificateApi.get(editId).then(function (certificate) {
     $scope.certificate = certificate;
     $scope.certificate.name = ''; // we should prefer the generated name
+    $scope.certificate.csr = null;  // should not clone CSR in case other settings are changed in clone
     $scope.certificate.validityStart = null;
     $scope.certificate.validityEnd = null;
     CertificateService.getDefaults($scope.certificate);

--- a/lemur/static/app/angular/certificates/view/view.tpl.html
+++ b/lemur/static/app/angular/certificates/view/view.tpl.html
@@ -184,6 +184,13 @@
                 </uib-tab>
                 <uib-tab>
                   <uib-tab-heading>
+                    CSR
+                    <i class="glyphicon glyphicon-copy" style="cursor: pointer" clipboard text="certificate.csr"></i>
+                  </uib-tab-heading>
+                  <pre style="width: 100%">{{ certificate.csr }}</pre>
+                </uib-tab>
+                <uib-tab>
+                  <uib-tab-heading>
                     Public Certificate
                     <i class="glyphicon glyphicon-copy" style="cursor: pointer" clipboard text="certificate.body"></i>
                   </uib-tab-heading>

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -48,7 +48,7 @@ def test_get_certificate_primitives(certificate):
 
     with freeze_time(datetime.date(year=2016, month=10, day=30)):
         primitives = get_certificate_primitives(certificate)
-        assert len(primitives) == 25
+        assert len(primitives) == 26
 
 
 def test_certificate_output_schema(session, certificate, issuer_plugin):


### PR DESCRIPTION
Add csr column to certificates field, as pending certificates have
exposed the CSR already.  This is required as generating CSR from
existing certificate is will not include SANs due to OpenSSL bug:
https://github.com/openssl/openssl/issues/6481