### PR TITLE
Optimize certificate filtering by name

### DIFF
--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -20,6 +20,7 @@ from lemur.common.utils import generate_private_key, truthiness
 from lemur.destinations.models import Destination
 from lemur.domains.models import Domain
 from lemur.extensions import metrics, sentry, signals
+from lemur.models import certificate_associations
 from lemur.notifications.models import Notification
 from lemur.pending_certificates.models import PendingCertificate
 from lemur.plugins.base import plugins
@@ -332,13 +333,13 @@ def render(args):
         elif 'id' in terms:
             query = query.filter(Certificate.id == cast(terms[1], Integer))
         elif 'name' in terms:
-            query = query.filter(
+            query = query.join(certificate_associations).join(Domain).filter(
                 or_(
                     Certificate.name.ilike(term),
                     Certificate.domains.any(Domain.name.ilike(term)),
                     Certificate.cn.ilike(term),
                 )
-            )
+            ).group_by(Certificate.id)
         else:
             query = database.filter(query, Certificate, terms)
 

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -336,7 +336,7 @@ def render(args):
             query = query.join(certificate_associations).join(Domain).filter(
                 or_(
                     Certificate.name.ilike(term),
-                    Certificate.domains.any(Domain.name.ilike(term)),
+                    Domain.name.ilike(term),
                     Certificate.cn.ilike(term),
                 )
             ).group_by(Certificate.id)

--- a/lemur/database.py
+++ b/lemur/database.py
@@ -11,11 +11,11 @@
 """
 from inflection import underscore
 from sqlalchemy import exc, func
-from sqlalchemy.sql import and_, or_
 from sqlalchemy.orm import make_transient
+from sqlalchemy.sql import and_, or_
 
-from lemur.extensions import db
 from lemur.exceptions import AttrNotFound, DuplicateError
+from lemur.extensions import db
 
 
 def filter_none(kwargs):
@@ -273,7 +273,7 @@ def get_count(q):
     :param q:
     :return:
     """
-    count_q = q.statement.with_only_columns([func.count()]).order_by(None)
+    count_q = q.statement.with_only_columns([func.count()]).group_by(None).order_by(None)
     count = q.session.execute(count_q).scalar()
     return count
 


### PR DESCRIPTION
Filtering by certificate name is pretty expensive for us, even after adding gin indexes ( #2037 ). Short queries could take hours to run (essentially never finishing) and peg database CPU. The expensive queries were the filter / count queries. Using explicit joins makes things faster, and the queries don't hang.

Shown below are the old and new count queries. 

Previous:
`
SELECT count(*) AS count_1
        FROM certificates
        WHERE (certificates.name ILIKE '%a%' OR (EXISTS(SELECT 1
                                                         FROM certificate_associations, domains
                                                         WHERE
                                                           certificates.id = certificate_associations.certificate_id AND
                                                           domains.id = certificate_associations.domain_id AND
                                                           domains.name ILIKE '%a%')) OR certificates.cn ILIKE '%a%')
`
New:
`
SELECT count(*) AS count_1
FROM certificates
  JOIN certificate_associations ON certificates.id = certificate_associations.certificate_id
  JOIN domains ON domains.id = certificate_associations.domain_id
WHERE certificates.name ILIKE '%a%' OR  domains.name ILIKE '%a%'  OR certificates.cn ILIKE '%a%' 
`