### PR TITLE
No csr reissue

### DIFF
--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -367,7 +367,7 @@ def update_destinations(target, value, initiator):
     destination_plugin = plugins.get(value.plugin_name)
     status = FAILURE_METRIC_STATUS
     try:
-        if target.private_key:
+        if target.private_key or not destination_plugin.requires_key:
             destination_plugin.upload(target.name, target.body, target.private_key, target.chain, value.options)
             status = SUCCESS_METRIC_STATUS
     except Exception as e:

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -539,6 +539,9 @@ def reissue_certificate(certificate, replace=None, user=None):
     """
     primitives = get_certificate_primitives(certificate)
 
+    if primitives.get("csr"):
+        #  We do not want to re-use the CSR when creating a certificate because this defeats the purpose of rotation.
+        del primitives["csr"]
     if not user:
         primitives['creator'] = certificate.user
 

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -142,8 +142,7 @@ def fetch_all_pending_acme_certs():
     for cert in pending_certs:
         cert_authority = get_authority(cert.authority_id)
         if cert_authority.plugin_name == 'acme-issuer':
-            if cert.last_updated == cert.date_created or datetime.now(
-                    timezone.utc) - cert.last_updated > timedelta(minutes=5):
+            if datetime.now(timezone.utc) - cert.last_updated > timedelta(minutes=5):
                 fetch_acme_cert.delay(cert.id)
 
 

--- a/lemur/plugins/lemur_aws/plugin.py
+++ b/lemur/plugins/lemur_aws/plugin.py
@@ -35,8 +35,8 @@
 from flask import current_app
 
 from lemur.plugins import lemur_aws as aws
-from lemur.plugins.lemur_aws import iam, s3, elb, ec2
 from lemur.plugins.bases import DestinationPlugin, ExportDestinationPlugin, SourcePlugin
+from lemur.plugins.lemur_aws import iam, s3, elb, ec2
 
 
 def get_region_from_dns(dns):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ importlib-metadata==0.6   # via pre-commit
 importlib-resources==1.0.2  # via pre-commit
 invoke==1.2.0
 mccabe==0.6.1             # via flake8
-nodeenv==1.3.2
+nodeenv==1.3.3
 pkginfo==1.4.2            # via twine
 pre-commit==1.12.0
 pycodestyle==2.3.1        # via flake8
@@ -27,7 +27,7 @@ pygments==2.2.0           # via readme-renderer
 pyyaml==3.13              # via aspy.yaml, pre-commit
 readme-renderer==24.0     # via twine
 requests-toolbelt==0.8.0  # via twine
-requests==2.20.0          # via requests-toolbelt, twine
+requests==2.20.1          # via requests-toolbelt, twine
 six==1.11.0               # via bleach, cfgv, pre-commit, readme-renderer
 toml==0.10.0              # via pre-commit
 tqdm==4.28.1              # via twine

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -38,7 +38,7 @@ flask-principal==0.4.0
 flask-restful==0.3.6
 flask-script==2.0.6
 flask-sqlalchemy==2.3.2
-flask==0.12.4
+flask==1.0.2
 future==0.17.1
 gunicorn==19.9.0
 idna==2.7
@@ -84,7 +84,7 @@ s3transfer==0.1.13
 six==1.11.0
 snowballstemmer==1.2.1    # via sphinx
 sphinx-rtd-theme==0.4.2
-sphinx==1.8.1
+sphinx==1.8.2
 sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-websupport==1.1.0  # via sphinx
 sqlalchemy-utils==0.33.6

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -8,15 +8,15 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-boto3==1.9.37             # via moto
+boto3==1.9.42             # via moto
 boto==2.49.0              # via moto
-botocore==1.12.37         # via boto3, moto, s3transfer
+botocore==1.12.42         # via boto3, moto, s3transfer
 certifi==2018.10.15       # via requests
 cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via requests
 click==7.0                # via flask
-coverage==4.5.1
-cryptography==2.3.1       # via moto
+coverage==4.5.2
+cryptography==2.4.1       # via moto
 docker-pycreds==0.3.0     # via docker
 docker==3.5.1             # via moto
 docutils==0.14            # via botocore
@@ -46,14 +46,14 @@ pycryptodome==3.7.0       # via python-jose
 pyflakes==2.0.0
 pytest-flask==0.14.0
 pytest-mock==1.10.0
-pytest==3.10.0
+pytest==3.10.1
 python-dateutil==2.7.5    # via botocore, faker, freezegun, moto
 python-jose==2.0.2        # via moto
 pytz==2018.7              # via moto
 pyyaml==3.13              # via pyaml
 requests-mock==1.5.2
-requests==2.20.0          # via aws-xray-sdk, docker, moto, requests-mock, responses
-responses==0.10.2         # via moto
+requests==2.20.1          # via aws-xray-sdk, docker, moto, requests-mock, responses
+responses==0.10.3         # via moto
 s3transfer==0.1.13        # via boto3
 six==1.11.0               # via cryptography, docker, docker-pycreds, faker, freezegun, mock, more-itertools, moto, pytest, python-dateutil, python-jose, requests-mock, responses, websocket-client
 text-unidecode==1.2       # via faker

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --no-index --output-file requirements.txt requirements.in
 #
-acme==0.27.1
+acme==0.28.0
 alembic-autogenerate-enums==0.0.2
 alembic==1.0.2            # via flask-migrate
 amqp==2.3.2               # via kombu
@@ -15,21 +15,21 @@ asyncpool==1.0
 bcrypt==3.1.4             # via flask-bcrypt, paramiko
 billiard==3.5.0.4         # via celery
 blinker==1.4              # via flask-mail, flask-principal, raven
-boto3==1.9.37
-botocore==1.12.37
+boto3==1.9.42
+botocore==1.12.42
 celery[redis]==4.2.1
 certifi==2018.10.15
 cffi==1.11.5              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 click==7.0                # via flask
 cloudflare==2.1.0
-cryptography==2.3.1
+cryptography==2.4.1
 dnspython3==1.15.0
 dnspython==1.15.0         # via dnspython3
 docutils==0.14            # via botocore
 dyn==1.8.1
 flask-bcrypt==0.7.1
-flask-cors==3.0.6
+flask-cors==3.0.7
 flask-mail==0.9.1
 flask-migrate==2.3.0
 flask-principal==0.4.0
@@ -57,7 +57,7 @@ ndg-httpsclient==0.5.1
 paramiko==2.4.2
 pbr==5.1.1                # via mock
 pem==18.2.0
-psycopg2==2.7.5
+psycopg2==2.7.6.1
 pyasn1-modules==0.2.2     # via python-ldap
 pyasn1==0.4.4             # via ndg-httpsclient, paramiko, pyasn1-modules, python-ldap
 pycparser==2.19           # via cffi
@@ -73,12 +73,12 @@ pyyaml==3.13              # via cloudflare
 raven[flask]==6.9.0
 redis==2.10.6             # via celery
 requests-toolbelt==0.8.0  # via acme
-requests[security]==2.20.0
+requests[security]==2.20.1
 retrying==1.3.3
 s3transfer==0.1.13        # via boto3
 six==1.11.0
 sqlalchemy-utils==0.33.6
-sqlalchemy==1.2.13        # via alembic, flask-sqlalchemy, marshmallow-sqlalchemy, sqlalchemy-utils
+sqlalchemy==1.2.14        # via alembic, flask-sqlalchemy, marshmallow-sqlalchemy, sqlalchemy-utils
 tabulate==0.8.2
 urllib3==1.24.1           # via botocore, requests
 vine==1.1.4               # via amqp


### PR DESCRIPTION
* Do not re-use CSR from certificate primitives when reissuing a certificate. This defeats the purpose of re-issuance and increases the chances that something will break (Such as uploading the certificate to a destination).

* Change certificate model to allow uploading certificate to destination with no private key if that plugin specifies that a private key is not required.

* Add more detailed logging to help debug celery jobs.

* Update requirements to the bleeding edge.
 