### PR TITLE
Bugfix: Prevent 'unserializable' error for unknown SAN types

### DIFF
--- a/lemur/common/fields.py
+++ b/lemur/common/fields.py
@@ -350,6 +350,7 @@ class SubjectAlternativeNameExtension(Field):
                     value = value.dotted_string
                 else:
                     current_app.logger.warning('Unknown SubAltName type: {name}'.format(name=name))
+                    continue
 
                 general_names.append({'nameType': name_type, 'value': value})
 


### PR DESCRIPTION
When parsing SAN's, ignore unknown san_types, because in some cases they can contain unparsable/serializable values, resulting in a TypeError(repr(o) + " is not JSON serializable")
