### PR TITLE
Fix textarea and validation on destination page

### DIFF
--- a/lemur/plugins/lemur_aws/plugin.py
+++ b/lemur/plugins/lemur_aws/plugin.py
@@ -163,7 +163,7 @@ class AWSDestinationPlugin(DestinationPlugin):
             'name': 'accountNumber',
             'type': 'str',
             'required': True,
-            'validation': '/^[0-9]{12,12}$/',
+            'validation': '[0-9]{12}',
             'helpMessage': 'Must be a valid AWS account number!',
         },
         {
@@ -279,14 +279,14 @@ class S3DestinationPlugin(ExportDestinationPlugin):
             'name': 'bucket',
             'type': 'str',
             'required': True,
-            'validation': '/^$|\s+/',
+            'validation': '[0-9a-z.-]{3,63}',
             'helpMessage': 'Must be a valid S3 bucket name!',
         },
         {
             'name': 'accountNumber',
             'type': 'str',
             'required': True,
-            'validation': '/^[0-9]{12,12}$/',
+            'validation': '[0-9]{12}',
             'helpMessage': 'A valid AWS account number with permission to access S3',
         },
         {
@@ -308,7 +308,6 @@ class S3DestinationPlugin(ExportDestinationPlugin):
             'name': 'prefix',
             'type': 'str',
             'required': False,
-            'validation': '/^$|\s+/',
             'helpMessage': 'Must be a valid S3 object prefix!',
         }
     ]

--- a/lemur/static/app/angular/destinations/destination/destination.tpl.html
+++ b/lemur/static/app/angular/destinations/destination/destination.tpl.html
@@ -47,7 +47,9 @@
             <select name="sub" ng-if="item.type == 'select'" class="form-control" ng-options="i for i in item.available"
                     ng-model="item.value"></select>
             <input name="sub" ng-if="item.type == 'bool'" class="form-control" type="checkbox" ng-model="item.value">
-            <input name="sub" ng-if="item.type == 'str'" type="text" class="form-control" ng-model="item.value"/>
+            <input name="sub" ng-if="item.type == 'str'" type="text" class="form-control" ng-model="item.value" ng-pattern="item.validation"/>
+            <textarea name="sub" ng-if="item.type == 'textarea'" class="form-control"
+                      ng-model="item.value" ng-pattern="item.validation"></textarea>
             <div ng-if="item.type == 'export-plugin'">
               <form name="exportForm" class="form-horizontal" role="form" novalidate>
                 <select class="form-control" ng-model="item.value"
@@ -69,6 +71,8 @@
                                  ng-model="item.value">
                           <input name="sub" ng-if="item.type == 'str'" type="text" class="form-control"
                                  ng-model="item.value" ng-pattern="item.validation"/>
+                          <textarea name="sub" ng-if="item.type == 'textarea'" class="form-control"
+                                    ng-model="item.value" ng-pattern="item.validation"></textarea>
                           <p ng-show="subForm.sub.$invalid && !subForm.sub.$pristine"
                              class="help-block">{{ item.helpMessage }}</p>
                         </div>


### PR DESCRIPTION
The destination configuration page did not previously support a textarea input as was supported on most other pages. The validation of string inputs was not being performed. This commit addresses both of those issues and corrects the validation expressions for the AWS and S3 destination plugins so that they continue to function. The SFTP destination plugin does not have any string validation. The Kubernetes plugin does not work at all as far as I can tell; there will be another PR in the coming days to address that.