### PR TITLE
updated query to ignore empty parameters

### DIFF
--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -238,17 +238,7 @@ def reissue(old_certificate_name, commit):
 
         if not old_cert:
             for certificate in get_all_pending_reissue():
-                try:
-                    request_reissue(certificate, commit)
-                except Exception as e:
-                    sentry.captureException()
-                    current_app.logger.exception(
-                        "Error reissuing certificate: {}".format(certificate.name), exc_info=True)
-                    print(
-                        "[!] Failed to reissue certificates. Reason: {}".format(
-                            e
-                        )
-                    )
+                request_reissue(certificate, commit)
         else:
             request_reissue(old_cert, commit)
 
@@ -275,30 +265,31 @@ def query(fqdns, issuer, owner, expired):
     table = []
 
     q = database.session_query(Certificate)
+    if issuer:
+        sub_query = database.session_query(Authority.id) \
+            .filter(Authority.name.ilike('%{0}%'.format(issuer))) \
+            .subquery()
 
-    sub_query = database.session_query(Authority.id) \
-        .filter(Authority.name.ilike('%{0}%'.format(issuer))) \
-        .subquery()
-
-    q = q.filter(
-        or_(
-            Certificate.issuer.ilike('%{0}%'.format(issuer)),
-            Certificate.authority_id.in_(sub_query)
+        q = q.filter(
+            or_(
+                Certificate.issuer.ilike('%{0}%'.format(issuer)),
+                Certificate.authority_id.in_(sub_query)
+            )
         )
-    )
-
-    q = q.filter(Certificate.owner.ilike('%{0}%'.format(owner)))
+    if owner:
+        q = q.filter(Certificate.owner.ilike('%{0}%'.format(owner)))
 
     if not expired:
         q = q.filter(Certificate.expired == False)  # noqa
 
-    for f in fqdns.split(','):
-        q = q.filter(
-            or_(
-                Certificate.cn.ilike('%{0}%'.format(f)),
-                Certificate.domains.any(Domain.name.ilike('%{0}%'.format(f)))
+    if fqdns:
+        for f in fqdns.split(','):
+            q = q.filter(
+                or_(
+                    Certificate.cn.ilike('%{0}%'.format(f)),
+                    Certificate.domains.any(Domain.name.ilike('%{0}%'.format(f)))
+                )
             )
-        )
 
     for c in q.all():
         table.append([c.id, c.name, c.owner, c.issuer])
@@ -373,10 +364,7 @@ def check_revoked():
             else:
                 status = verify_string(cert.body, "")
 
-            if status is None:
-                cert.status = 'unknown'
-            else:
-                cert.status = 'valid' if status else 'revoked'
+            cert.status = 'valid' if status else 'revoked'
 
         except Exception as e:
             sentry.captureException()


### PR DESCRIPTION
Check parameters for queries. If  empty, disregard them. Otherwise when passing empty parameters the resulting SQL-query looks like '%%NONE%%' which matches quite seldom.