### PR TITLE
Properly handle Unicode in issuer name sanitization

### DIFF
--- a/lemur/tests/conftest.py
+++ b/lemur/tests/conftest.py
@@ -11,7 +11,7 @@ from flask_principal import identity_changed, Identity
 from lemur import create_app
 from lemur.database import db as _db
 from lemur.auth.service import create_token
-from lemur.tests.vectors import SAN_CERT_KEY
+from lemur.tests.vectors import SAN_CERT_KEY, INTERMEDIATE_KEY
 
 from .factories import ApiKeyFactory, AuthorityFactory, NotificationFactory, DestinationFactory, \
     CertificateFactory, UserFactory, RoleFactory, SourceFactory, EndpointFactory, \
@@ -229,6 +229,11 @@ def logged_in_admin(session, app):
 @pytest.fixture
 def private_key():
     return load_pem_private_key(SAN_CERT_KEY.encode(), password=None, backend=default_backend())
+
+
+@pytest.fixture
+def issuer_private_key():
+    return load_pem_private_key(INTERMEDIATE_KEY.encode(), password=None, backend=default_backend())
 
 
 @pytest.fixture


### PR DESCRIPTION
If the point of sanitization is to get rid of all non-alphanumeric
characters then Unicode characters should probably be forbidden too.

We can re-use the same sanitization function as used for cert 'name'.