### PR TITLE
Check that stored private keys match certificates

### DIFF
--- a/lemur/certificates/schemas.py
+++ b/lemur/certificates/schemas.py
@@ -10,7 +10,7 @@ from marshmallow import fields, validate, validates_schema, post_load, pre_load
 from marshmallow.exceptions import ValidationError
 
 from lemur.authorities.schemas import AuthorityNestedOutputSchema
-from lemur.common import validators, missing
+from lemur.common import missing, utils, validators
 from lemur.common.fields import ArrowDateTime, Hex
 from lemur.common.schema import LemurInputSchema, LemurOutputSchema
 from lemur.constants import CERTIFICATE_KEY_TYPES
@@ -242,8 +242,8 @@ class CertificateUploadInputSchema(CertificateCreationSchema):
     authority = fields.Nested(AssociatedAuthoritySchema, required=False)
     notify = fields.Boolean(missing=True)
     external_id = fields.String(missing=None, allow_none=True)
-    private_key = fields.String(validate=validators.private_key)
-    body = fields.String(required=True, validate=validators.public_certificate)
+    private_key = fields.String()
+    body = fields.String(required=True)
     chain = fields.String(validate=validators.public_certificate, missing=None,
                           allow_none=True)  # TODO this could be multiple certificates
 
@@ -257,6 +257,26 @@ class CertificateUploadInputSchema(CertificateCreationSchema):
         if data.get('destinations'):
             if not data.get('private_key'):
                 raise ValidationError('Destinations require private key.')
+
+    @validates_schema
+    def validate_cert_private_key(self, data):
+        cert = None
+        key = None
+        if data.get('body'):
+            try:
+                cert = utils.parse_certificate(data['body'])
+            except ValueError:
+                raise ValidationError("Public certificate presented is not valid.", field_names=['body'])
+
+        if data.get('private_key'):
+            try:
+                key = utils.parse_private_key(data['private_key'])
+            except ValueError:
+                raise ValidationError("Private key presented is not valid.", field_names=['private_key'])
+
+        if cert and key:
+            # Throws ValidationError
+            validators.verify_private_key_match(key, cert)
 
 
 class CertificateExportInputSchema(LemurInputSchema):

--- a/lemur/common/utils.py
+++ b/lemur/common/utils.py
@@ -13,6 +13,7 @@ import sqlalchemy
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa, ec
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from flask_restful.reqparse import RequestParser
 from sqlalchemy import and_, func
 
@@ -50,6 +51,20 @@ def parse_certificate(body):
         body = body.encode('utf-8')
 
     return x509.load_pem_x509_certificate(body, default_backend())
+
+
+def parse_private_key(private_key):
+    """
+    Parses a PEM-format private key (RSA, DSA, ECDSA or any other supported algorithm).
+
+    Raises ValueError for an invalid string.
+
+    :param private_key: String containing PEM private key
+    """
+    if isinstance(private_key, str):
+        private_key = private_key.encode('utf8')
+
+    return load_pem_private_key(private_key, password=None, backend=default_backend())
 
 
 def parse_csr(csr):

--- a/lemur/tests/conftest.py
+++ b/lemur/tests/conftest.py
@@ -15,7 +15,7 @@ from lemur.tests.vectors import SAN_CERT_KEY, INTERMEDIATE_KEY
 
 from .factories import ApiKeyFactory, AuthorityFactory, NotificationFactory, DestinationFactory, \
     CertificateFactory, UserFactory, RoleFactory, SourceFactory, EndpointFactory, \
-    RotationPolicyFactory, PendingCertificateFactory, AsyncAuthorityFactory
+    RotationPolicyFactory, PendingCertificateFactory, AsyncAuthorityFactory, CryptoAuthorityFactory
 
 
 def pytest_runtest_setup(item):
@@ -87,6 +87,13 @@ def client(app, session, client):
 @pytest.fixture
 def authority(session):
     a = AuthorityFactory()
+    session.commit()
+    return a
+
+
+@pytest.fixture
+def crypto_authority(session):
+    a = CryptoAuthorityFactory()
     session.commit()
     return a
 

--- a/lemur/tests/factories.py
+++ b/lemur/tests/factories.py
@@ -168,6 +168,11 @@ class AsyncAuthorityFactory(AuthorityFactory):
     authority_certificate = SubFactory(CertificateFactory)
 
 
+class CryptoAuthorityFactory(AuthorityFactory):
+    """Authority factory based on 'cryptography' plugin."""
+    plugin = {'slug': 'cryptography-issuer'}
+
+
 class DestinationFactory(BaseFactory):
     """Destination factory."""
     plugin_name = 'test-destination'

--- a/lemur/tests/test_validators.py
+++ b/lemur/tests/test_validators.py
@@ -1,16 +1,28 @@
-import pytest
 from datetime import datetime
-from .vectors import SAN_CERT_KEY
+
+import pytest
 from marshmallow.exceptions import ValidationError
+
+from lemur.common.utils import parse_private_key
+from lemur.common.validators import verify_private_key_match
+from lemur.tests.vectors import INTERMEDIATE_CERT, SAN_CERT, SAN_CERT_KEY
 
 
 def test_private_key(session):
-    from lemur.common.validators import private_key
+    parse_private_key(SAN_CERT_KEY)
 
-    private_key(SAN_CERT_KEY)
+    with pytest.raises(ValueError):
+        parse_private_key('invalid_private_key')
+
+
+def test_validate_private_key(session):
+    key = parse_private_key(SAN_CERT_KEY)
+
+    verify_private_key_match(key, SAN_CERT)
 
     with pytest.raises(ValidationError):
-        private_key('invalid_private_key')
+        # Wrong key for certificate
+        verify_private_key_match(key, INTERMEDIATE_CERT)
 
 
 def test_sub_alt_type(session):


### PR DESCRIPTION
I split this out from #1514, to reduce its scope and make the review/merge easier.

Verification is done in two places:
* Certificate import validator -- throws validation errors.
* Certificate model constructor -- to ensure integrity of Lemur's data even when issuer plugins or other code paths have bugs.