### PR TITLE
Fix: Update kombu dep to 4.2.2.post1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ jinja2==2.10
 jmespath==0.9.3           # via boto3, botocore
 josepy==1.1.0             # via acme
 jsonlines==1.2.0          # via cloudflare
-kombu==4.2.2              # via celery
+kombu==4.2.2.post1        # via celery
 lockfile==0.12.2
 mako==1.0.7               # via alembic
 markupsafe==1.1.0         # via jinja2, mako


### PR DESCRIPTION
kombu 4.2.2 is no more available on pypi and thus
breaks the current install.
It is now required to depend on 4.2.2.post1