### PR TITLE
Optimize DB cert filtering

### DIFF
--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -307,7 +307,7 @@ def render(args):
 
     if filt:
         terms = filt.split(';')
-        term = '%{0}%'.format(terms[1])
+        term = '{0}%'.format(terms[1])
         # Exact matches for quotes. Only applies to name, issuer, and cn
         if terms[1].startswith('"') and terms[1].endswith('"'):
             term = terms[1][1:-1]


### PR DESCRIPTION
Optimize DB cert filtering by removing the first LIKE conditional wildcard in the query. When this search is ran, it compiles a SQL statement like what is displayed below. This is a very expensive query consisting of multiple joins and multiple column searches. In most of our discovered use cases, users are searching for a specific CN or a specific certificate name. When filtering, they typically do not enter "partial CNs" that they're uncertain about. As such, this query slightly reduces the expense and planning time required for the query. This is not a fully-fledged feature fix for this issue, however.

`SELECT
  certificates.id,
  certificates.external_id,
  certificates.owner,
  ....
FROM certificates
  LEFT OUTER JOIN certificate_associations ON certificates.id = certificate_associations.certificate_id
  LEFT OUTER JOIN domains ON domains.id = certificate_associations.domain_id
WHERE lower(certificates.name) LIKE lower('<seasrchterm>%') OR
      lower(domains.name) LIKE lower('<seasrchterm>%') OR
      lower(certificates.cn) LIKE lower('<seasrchterm>%')
GROUP BY certificates.id`