### PR TITLE
Implemente certificates 'delete' API call

### DIFF
--- a/lemur/logs/models.py
+++ b/lemur/logs/models.py
@@ -18,6 +18,6 @@ class Log(db.Model):
     __tablename__ = 'logs'
     id = Column(Integer, primary_key=True)
     certificate_id = Column(Integer, ForeignKey('certificates.id'))
-    log_type = Column(Enum('key_view', 'create_cert', 'update_cert', 'revoke_cert', name='log_type'), nullable=False)
+    log_type = Column(Enum('key_view', 'create_cert', 'update_cert', 'revoke_cert', 'delete_cert', name='log_type'), nullable=False)
     logged_at = Column(ArrowType(), PassiveDefault(func.now()), nullable=False)
     user_id = Column(Integer, ForeignKey('users.id'), nullable=False)

--- a/lemur/migrations/versions/9f79024fe67b_.py
+++ b/lemur/migrations/versions/9f79024fe67b_.py
@@ -1,0 +1,22 @@
+""" Add delete_cert to log_type enum
+
+Revision ID: 9f79024fe67b
+Revises: ee827d1e1974
+Create Date: 2019-01-03 15:36:59.181911
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '9f79024fe67b'
+down_revision = 'ee827d1e1974'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.sync_enum_values('public', 'log_type', ['create_cert', 'key_view', 'revoke_cert', 'update_cert'], ['create_cert', 'delete_cert', 'key_view', 'revoke_cert', 'update_cert'])
+
+
+def downgrade():
+    op.sync_enum_values('public', 'log_type', ['create_cert', 'delete_cert', 'key_view', 'revoke_cert', 'update_cert'], ['create_cert', 'key_view', 'revoke_cert', 'update_cert'])

--- a/lemur/tests/conftest.py
+++ b/lemur/tests/conftest.py
@@ -15,7 +15,8 @@ from lemur.tests.vectors import SAN_CERT_KEY, INTERMEDIATE_KEY
 
 from .factories import ApiKeyFactory, AuthorityFactory, NotificationFactory, DestinationFactory, \
     CertificateFactory, UserFactory, RoleFactory, SourceFactory, EndpointFactory, \
-    RotationPolicyFactory, PendingCertificateFactory, AsyncAuthorityFactory, CryptoAuthorityFactory
+    RotationPolicyFactory, PendingCertificateFactory, AsyncAuthorityFactory, InvalidCertificateFactory, \
+    CryptoAuthorityFactory
 
 
 def pytest_runtest_setup(item):
@@ -166,6 +167,15 @@ def pending_certificate(session):
     p = PendingCertificateFactory(user=u, authority=a)
     session.commit()
     return p
+
+
+@pytest.fixture
+def invalid_certificate(session):
+    u = UserFactory()
+    a = AsyncAuthorityFactory()
+    i = InvalidCertificateFactory(user=u, authority=a)
+    session.commit()
+    return i
 
 
 @pytest.fixture

--- a/lemur/tests/factories.py
+++ b/lemur/tests/factories.py
@@ -20,7 +20,7 @@ from lemur.policies.models import RotationPolicy
 from lemur.api_keys.models import ApiKey
 
 from .vectors import SAN_CERT_STR, SAN_CERT_KEY, CSR_STR, INTERMEDIATE_CERT_STR, ROOTCA_CERT_STR, INTERMEDIATE_KEY, \
-    WILDCARD_CERT_KEY
+    WILDCARD_CERT_KEY, INVALID_CERT_STR
 
 
 class BaseFactory(SQLAlchemyModelFactory):
@@ -135,6 +135,11 @@ class CACertificateFactory(CertificateFactory):
     chain = ROOTCA_CERT_STR
     body = INTERMEDIATE_CERT_STR
     private_key = INTERMEDIATE_KEY
+
+
+class InvalidCertificateFactory(CertificateFactory):
+    body = INVALID_CERT_STR
+    private_key = ''
 
 
 class AuthorityFactory(BaseFactory):

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -647,13 +647,24 @@ def test_certificate_put_with_data(client, certificate, issuer_plugin):
 
 
 @pytest.mark.parametrize("token,status", [
-    (VALID_USER_HEADER_TOKEN, 405),
-    (VALID_ADMIN_HEADER_TOKEN, 405),
-    (VALID_ADMIN_API_TOKEN, 405),
-    ('', 405)
+    (VALID_USER_HEADER_TOKEN, 403),
+    (VALID_ADMIN_HEADER_TOKEN, 412),
+    (VALID_ADMIN_API_TOKEN, 412),
+    ('', 401)
 ])
 def test_certificate_delete(client, token, status):
     assert client.delete(api.url_for(Certificates, certificate_id=1), headers=token).status_code == status
+
+
+@pytest.mark.parametrize("token,status", [
+    (VALID_USER_HEADER_TOKEN, 403),
+    (VALID_ADMIN_HEADER_TOKEN, 204),
+    (VALID_ADMIN_API_TOKEN, 204),
+    ('', 401)
+])
+def test_invalid_certificate_delete(client, invalid_certificate, token, status):
+    assert client.delete(
+        api.url_for(Certificates, certificate_id=invalid_certificate.id), headers=token).status_code == status
 
 
 @pytest.mark.parametrize("token,status", [


### PR DESCRIPTION
This PR implements the 'delete' operation of the 'certificates' API endpoint. It will mark a certificate as deleted in the database and create an audit entry. This is only succeeds when the certificate is expired.