### PR TITLE
Resolving the 2 years error from UI during cert creation

### DIFF
--- a/lemur/common/missing.py
+++ b/lemur/common/missing.py
@@ -16,6 +16,9 @@ def convert_validity_years(data):
         data['validity_start'] = now.isoformat()
 
         end = now.replace(years=+int(data['validity_years']))
+        # some CAs want to see exactly two years validity, and not two years plus one day, as is the case currently
+        # 1/25/2019 + 2 years ==> 1/25/2019 (two years and 1 day extra, violating the 2 year's limit)
+        end = end.replace(days=-1)
         if not current_app.config.get('LEMUR_ALLOW_WEEKEND_EXPIRATION', True):
             if is_weekend(end):
                 end = end.replace(days=-2)

--- a/lemur/common/missing.py
+++ b/lemur/common/missing.py
@@ -16,9 +16,7 @@ def convert_validity_years(data):
         data['validity_start'] = now.isoformat()
 
         end = now.replace(years=+int(data['validity_years']))
-        # some CAs want to see exactly two years validity, and not two years plus one day, as is the case currently
-        # 1/25/2019 + 2 years ==> 1/25/2019 (two years and 1 day extra, violating the 2 year's limit)
-        end = end.replace(days=-1)
+
         if not current_app.config.get('LEMUR_ALLOW_WEEKEND_EXPIRATION', True):
             if is_weekend(end):
                 end = end.replace(days=-2)

--- a/lemur/tests/test_missing.py
+++ b/lemur/tests/test_missing.py
@@ -6,12 +6,12 @@ from freezegun import freeze_time
 def test_convert_validity_years(session):
     from lemur.common.missing import convert_validity_years
 
-    with freeze_time("2016-01-02"):
+    with freeze_time("2016-01-01"):
         data = convert_validity_years(dict(validity_years=2))
 
         assert data['validity_start'] == arrow.utcnow().isoformat()
-        assert data['validity_end'] == arrow.utcnow().replace(years=+2, days=-1).isoformat()
+        assert data['validity_end'] == arrow.utcnow().replace(years=+2).isoformat()
 
-    with freeze_time("2015-01-11"):
+    with freeze_time("2015-01-10"):
         data = convert_validity_years(dict(validity_years=1))
-        assert data['validity_end'] == arrow.utcnow().replace(years=+1, days=-3).isoformat()
+        assert data['validity_end'] == arrow.utcnow().replace(years=+1, days=-2).isoformat()

--- a/lemur/tests/test_missing.py
+++ b/lemur/tests/test_missing.py
@@ -6,12 +6,12 @@ from freezegun import freeze_time
 def test_convert_validity_years(session):
     from lemur.common.missing import convert_validity_years
 
-    with freeze_time("2016-01-01"):
+    with freeze_time("2016-01-02"):
         data = convert_validity_years(dict(validity_years=2))
 
         assert data['validity_start'] == arrow.utcnow().isoformat()
-        assert data['validity_end'] == arrow.utcnow().replace(years=+2).isoformat()
+        assert data['validity_end'] == arrow.utcnow().replace(years=+2, days=-1).isoformat()
 
-    with freeze_time("2015-01-10"):
+    with freeze_time("2015-01-11"):
         data = convert_validity_years(dict(validity_years=1))
-        assert data['validity_end'] == arrow.utcnow().replace(years=+1, days=-2).isoformat()
+        assert data['validity_end'] == arrow.utcnow().replace(years=+1, days=-3).isoformat()


### PR DESCRIPTION
Though a CA would accept two year validity, we were getting error for being beyond 2 years.
This is because our current conversion is just current date plus 2 years,
1/25/2019 + 2 years ==> 1/25/2019
This is more strictly seen two years and 1 day extra, violating the 2 year's limit.