### PR TITLE
Implement 'Show deleted certificates' toggle button

### DIFF
--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -101,7 +101,7 @@ class Certificate(db.Model):
     issuer = Column(String(128))
     serial = Column(String(128))
     cn = Column(String(128))
-    deleted = Column(Boolean, index=True)
+    deleted = Column(Boolean, index=True, default=False)
     dns_provider_id = Column(Integer(), ForeignKey('dns_providers.id', ondelete='CASCADE'), nullable=True)
 
     not_before = Column(ArrowType)

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -325,6 +325,8 @@ def render(args):
             query = query.filter(Certificate.notify == truthiness(terms[1]))
         elif 'active' in filt:
             query = query.filter(Certificate.active == truthiness(terms[1]))
+        elif 'deleted' in filt:
+            query = query.filter(Certificate.deleted == truthiness(terms[1]))
         elif 'cn' in terms:
             query = query.filter(
                 or_(

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -298,6 +298,7 @@ def render(args):
     # creator = args.pop('creator')  # TODO we should enabling filtering by owner
 
     filt = args.pop('filter')
+    include_deleted = args.pop('includeDeleted', None)
 
     if filt:
         terms = filt.split(';')
@@ -355,6 +356,9 @@ def render(args):
                 Certificate.owner.in_(sub_query)
             )
         )
+
+    if include_deleted is not None and not include_deleted:
+        query = query.filter(Certificate.deleted == False)  # noqa
 
     if destination_id:
         query = query.filter(Certificate.destinations.any(Destination.id == destination_id))

--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -140,6 +140,7 @@ class CertificatesList(AuthenticatedResource):
         parser.add_argument('destinationId', type=int, dest="destination_id", location='args')
         parser.add_argument('creator', type=str, location='args')
         parser.add_argument('show', type=str, location='args')
+        parser.add_argument('includeDeleted', type=inputs.boolean, location='args')
 
         args = parser.parse_args()
         args['user'] = g.user

--- a/lemur/migrations/versions/318b66568358_.py
+++ b/lemur/migrations/versions/318b66568358_.py
@@ -1,0 +1,23 @@
+""" Set 'deleted' flag from null to false on all certificates once
+
+Revision ID: 318b66568358
+Revises: 9f79024fe67b
+Create Date: 2019-02-05 15:42:25.477587
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '318b66568358'
+down_revision = '9f79024fe67b'
+
+from alembic import op
+
+
+def upgrade():
+    connection = op.get_bind()
+    # Delete duplicate entries
+    connection.execute('UPDATE certificates SET deleted = false WHERE deleted IS NULL')
+
+
+def downgrade():
+    pass

--- a/lemur/static/app/angular/certificates/view/deleted-toggle.html
+++ b/lemur/static/app/angular/certificates/view/deleted-toggle.html
@@ -1,0 +1,2 @@
+<label for="show-deleted-toggle">Show deleted certificates</label>
+<switch ng-change="updateIncludeDeleted()" ng-model="includeDeleted" id="show-deleted-toggle" name="includeDeleted" class="green tiny" height="10px"></switch>

--- a/lemur/static/app/angular/certificates/view/view.js
+++ b/lemur/static/app/angular/certificates/view/view.js
@@ -25,6 +25,7 @@ angular.module('lemur')
       sorting: {
         id: 'desc'     // initial sorting
       },
+      includeDeleted: false,
       filter: $scope.filter
     }, {
       total: 0,           // length of data
@@ -100,6 +101,12 @@ angular.module('lemur')
           certificate.notify = false;
         });
     };
+
+    $scope.updateIncludeDeleted = function() {
+      $scope.certificateTable.parameters({'includeDeleted': this.includeDeleted}, true);
+      $scope.certificateTable.reload();
+    };
+
     $scope.getCertificateStatus = function () {
       var def = $q.defer();
       def.resolve([{'title': 'True', 'id': true}, {'title': 'False', 'id': false}]);

--- a/lemur/static/app/angular/certificates/view/view.tpl.html
+++ b/lemur/static/app/angular/certificates/view/view.tpl.html
@@ -45,7 +45,7 @@
             <td data-title="'Common Name'" filter="{ 'cn': 'text'}">
               {{ certificate.cn }}
             </td>
-            <td data-title="''" style="text-align: center; vertical-align: middle;">
+            <td header="'/angular/certificates/view/deleted-toggle.html'" style="text-align: center; vertical-align: middle;">
                 <div class="btn-group pull-right" role="group" aria-label="...">
                   <a class="btn btn-sm btn-primary" ui-sref="certificate({name: certificate.name})">Permalink</a>
                   <button ng-model="certificate.toggle" class="btn btn-sm btn-info" uib-btn-checkbox btn-checkbox-true="1"


### PR DESCRIPTION
This PR implements a 'Show deleted certificates' toggle button in the filter bar of the 'Certificates' overview. It defaults to off, so certificates marked as deleted in the database are not shown by default anymore. This is a continuation of PR #2289, as discussed with @hosseinsh.

The API is not affected and will still return all certificates, including deleted ones. I did however add the possibility to filter on the deleted flag by passing ?filter=deleted;false. The UI does not use this however, because filter only understands one key;value pair, and it would mess up the regular UI table filtering.
