### PR TITLE
Fixes userinfo using Bearer token

### DIFF
--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -113,7 +113,10 @@ def retrieve_user(user_api_url, access_token):
     user_params = dict(access_token=access_token, schema='profile')
 
     # retrieve information about the current user.
-    r = requests.get(user_api_url, params=user_params)
+    r = requests.get(
+        user_api_url,
+        params=user_params,
+        headers={'Authorization': 'Bearer {}'.format(access_token)})
     profile = r.json()
 
     user = user_service.get_by_email(profile['email'])


### PR DESCRIPTION
While trying to integrate Lemur authentication with our OpenIDC provider (in this case Keycloak https://www.keycloak.org/) I found out that the userinfo endpoint expects the authorization token to be passed as an `Authorization: Bearer [token]`header which seem to be reasonable/more standard. 

Using the Ping provider and adding this patch we can use that Keycloak seamesly. 