### PR TITLE
Better error management in jwks token validation

### DIFF
--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -337,9 +337,9 @@ class Ping(Resource):
         )
 
         jwks_url = current_app.config.get('PING_JWKS_URL')
-        result = validate_id_token(id_token, args['clientId'], jwks_url)
-        if result:
-            return result
+        error_code = validate_id_token(id_token, args['clientId'], jwks_url)
+        if error_code:
+            return error_code
         user, profile = retrieve_user(user_api_url, access_token)
         roles = create_user_roles(profile)
         update_user(user, profile, roles)
@@ -387,9 +387,9 @@ class OAuth2(Resource):
         )
 
         jwks_url = current_app.config.get('PING_JWKS_URL')
-        result = validate_id_token(id_token, args['clientId'], jwks_url)
-        if result:
-            return result
+        error_code = validate_id_token(id_token, args['clientId'], jwks_url)
+        if error_code:
+            return error_code
 
         user, profile = retrieve_user(user_api_url, access_token)
         roles = create_user_roles(profile)

--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -331,8 +331,9 @@ class Ping(Resource):
         )
 
         jwks_url = current_app.config.get('PING_JWKS_URL')
-        validate_id_token(id_token, args['clientId'], jwks_url)
-
+        result = validate_id_token(id_token, args['clientId'], jwks_url)
+        if result:
+            return result
         user, profile = retrieve_user(user_api_url, access_token)
         roles = create_user_roles(profile)
         update_user(user, profile, roles)
@@ -380,7 +381,9 @@ class OAuth2(Resource):
         )
 
         jwks_url = current_app.config.get('PING_JWKS_URL')
-        validate_id_token(id_token, args['clientId'], jwks_url)
+        result = validate_id_token(id_token, args['clientId'], jwks_url)
+        if result:
+            return result
 
         user, profile = retrieve_user(user_api_url, access_token)
         roles = create_user_roles(profile)


### PR DESCRIPTION
Instead of failing horribly when validating the jwks token, use the actual errors already controlled by the exception handlers.