### PR TITLE
Don't fail if googleGroups is not found in user profile

### DIFF
--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -129,13 +129,16 @@ def create_user_roles(profile):
     roles = []
 
     # update their google 'roles'
-    for group in profile['googleGroups']:
-        role = role_service.get_by_name(group)
-        if not role:
-            role = role_service.create(group, description='This is a google group based role created by Lemur', third_party=True)
-        if not role.third_party:
-            role = role_service.set_third_party(role.id, third_party_status=True)
-        roles.append(role)
+    if 'googleGroups' in profile:
+        for group in profile['googleGroups']:
+            role = role_service.get_by_name(group)
+            if not role:
+                role = role_service.create(group, description='This is a google group based role created by Lemur', third_party=True)
+            if not role.third_party:
+                role = role_service.set_third_party(role.id, third_party_status=True)
+            roles.append(role)
+    else:
+        current_app.logger.warning("'googleGroups' not sent by identity provider, no specific roles will assigned to the user.")
 
     role = role_service.get_by_name(profile['email'])
 


### PR DESCRIPTION
This will aid when integration new Identity providers. Whether using `googleGroups` or any other more standard attribute probably is irrelevant (as most Identity providers will allow mapping any name here) but instead of failing it would be great to have a more detailed log trace. 