### PR TITLE
Enable gulp server to proxy backend

### DIFF
--- a/gulp/server.js
+++ b/gulp/server.js
@@ -6,31 +6,31 @@ var browserSync = require('browser-sync');
 var httpProxy = require('http-proxy');
 
 /* This configuration allow you to configure browser sync to proxy your backend */
-/*
- var proxyTarget = 'http://localhost/context/'; // The location of your backend
- var proxyApiPrefix = 'api'; // The element in the URL which differentiate between API request and static file request
+
+ var proxyTarget = 'http://localhost:8000/'; // The location of your backend
+ var proxyApiPrefix = '/api/'; // The element in the URL which differentiate between API request and static file request
  var proxy = httpProxy.createProxyServer({
- target: proxyTarget
+     target: proxyTarget
  });
  function proxyMiddleware(req, res, next) {
- if (req.url.indexOf(proxyApiPrefix) !== -1) {
- proxy.web(req, res);
- } else {
- next();
+     if (req.url.indexOf(proxyApiPrefix) !== -1) {
+         proxy.web(req, res);
+     } else {
+         next();
+     }
  }
- }
- */
 
 function browserSyncInit(baseDir, files, browser) {
   browser = browser === undefined ? 'default' : browser;
 
   browserSync.instance = browserSync.init(files, {
     startPath: '/index.html',
-    server: {
-      baseDir: baseDir,
-      routes: {
-        '/bower_components': './bower_components'
-      }
+      server: {
+          middleware: [proxyMiddleware],
+          baseDir: baseDir,
+          routes: {
+              '/bower_components': './bower_components'
+          }
     },
     browser: browser,
     ghostMode: false


### PR DESCRIPTION
While this code is not perfect, it was already there, but commented out. It took me a while to understand what was going on, and found it very useful to integrate/test Indentity Providers when developing. This should be harmless in production as probably nobody is serving statics via gulp there. 