### PR TITLE
Adding documentation for Vault and CFSSL Plugin changes

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -716,7 +716,7 @@ The following configuration properties are required to use the CFSSL issuer plug
 
 
 Hashicorp Vault Source/Destination Plugin
-^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Lemur can import and export certificate data to and from a Hashicorp Vault secrets store. Lemur can connect to a different Vault service per source/destination. 
 


### PR DESCRIPTION
Just documentation updates for the changes and additions to CFSSL Plugin and Hashicorp Vault Plugin.
Fixed hierarchy on Digicert Plugin.