### PR TITLE
Fix Certificate Appending With v2 Vault API

### DIFF
--- a/lemur/plugins/lemur_vault_dest/plugin.py
+++ b/lemur/plugins/lemur_vault_dest/plugin.py
@@ -311,6 +311,7 @@ def get_secret(client, mount, path):
             result = client.secrets.kv.v2.read_secret_version(
                 path=path, mount_point=mount
             )
+            result = result['data']
     except ConnectionError:
         pass
     finally:


### PR DESCRIPTION
HVAC nests a 'data' object inside another 'data' object when querying Vault using the V2 API. This was resulting in malformed data being written to Vault. This strips out the redundant wrapper resulting in the certificate data being appended to the correct object and then only that object being written back to Vault.