### PR TITLE
Deduplicate notifications

### DIFF
--- a/lemur/notifications/messaging.py
+++ b/lemur/notifications/messaging.py
@@ -155,7 +155,7 @@ def send_expiration_notifications(exclude):
 
             if (
                 notification_recipient
-                and owner != notification_recipient
+                and owner not in notification_recipient # notification_recipient is a list
                 and security_email != notification_recipient
             ):
                 if send_notification(

--- a/lemur/notifications/messaging.py
+++ b/lemur/notifications/messaging.py
@@ -155,7 +155,7 @@ def send_expiration_notifications(exclude):
 
             if (
                 notification_recipient
-                and owner not in notification_recipient # notification_recipient is a list
+                and owner not in notification_recipient  # notification_recipient is a list
                 and security_email != notification_recipient
             ):
                 if send_notification(

--- a/lemur/notifications/messaging.py
+++ b/lemur/notifications/messaging.py
@@ -145,6 +145,8 @@ def send_expiration_notifications(exclude):
             )
             if notification_recipient:
                 notification_recipient = notification_recipient.split(",")
+            else:
+                notification_recipient = []
 
             if send_notification(
                 "expiration", notification_data, [owner], notification


### PR DESCRIPTION
This PR tries to reduce the number of notifications sent when owner and notification plugin recipients are the same.
