### PR TITLE
Common name auto addition as domain name

### DIFF
--- a/lemur/static/app/angular/certificates/certificate/tracking.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/tracking.tpl.html
@@ -33,6 +33,8 @@
                uib-tooltip="If you need a certificate with multiple domains enter your primary domain here and the rest under 'Subject Alternate Names' by clicking 'More Options'"
                ng-model="certificate.commonName" placeholder="Common Name" class="form-control"
                ng-maxlength="64"
+               ng-blur="certificate.attachCommonName()"
+               ng-focus="certificate.removeCommonName()"
                required/>
 
         <p ng-show="trackingForm.commonName.$invalid && !trackingForm.commonName.$pristine" class="help-block">

--- a/lemur/static/app/angular/certificates/services.js
+++ b/lemur/static/app/angular/certificates/services.js
@@ -18,6 +18,26 @@ angular.module('lemur')
           this.authority = authority;
           this.authority.maxDate = moment(this.authority.notAfter).subtract(1, 'days').format('YYYY/MM/DD');
         },
+        attachCommonName: function () {
+          if (this.extensions === undefined) {
+            this.extensions = {};
+          }
+
+          if (this.extensions.subAltNames === undefined) {
+            this.extensions.subAltNames = {'names': []};
+          }
+
+          if (angular.isString(this.commonName)) {
+            this.extensions.subAltNames.names.unshift({'nameType': 'DNSName', 'value': this.commonName});
+          }
+        },
+        removeCommonName: function () {
+          if (angular.isDefined(this.extensions) && angular.isDefined(this.extensions.subAltNames)) {
+            if (angular.equals(this.extensions.subAltNames.names[0].value, this.commonName)) {
+              this.extensions.subAltNames.names.shift();
+            }
+          }
+        },
         attachSubAltName: function () {
           if (this.extensions === undefined) {
             this.extensions = {};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "bower": "^1.8.2",
     "browser-sync": "^2.3.1",
     "del": "^2.2.2",
-    "gulp": "^3.8.11",
     "gulp-autoprefixer": "^3.1.1",
     "gulp-cache": "^0.4.5",
     "gulp-concat": "^2.4.1",
@@ -60,6 +59,7 @@
     "test": "gulp test"
   },
   "devDependencies": {
+    "gulp": "^3.9.1",
     "jshint": "^2.8.0",
     "karma-chrome-launcher": "^2.0.0"
   }


### PR DESCRIPTION
Changes to allow automatically add the common name to the list of Domain names. How it works - When the user types a common name and moves focus from the text box, the common name gets added to the list of Domain Names. Any further edits to the common name will be appropriately reflected in the list on Domain names automatically as well.

![image](https://user-images.githubusercontent.com/9394800/58736578-31d5f180-83b3-11e9-8096-1fcb2b83bc78.png)
Text box is in focus and the list of domain names is empty.

![image](https://user-images.githubusercontent.com/9394800/58736622-6053cc80-83b3-11e9-926a-37741aa6295f.png)
Text box loses focus, common name gets added to list

![image](https://user-images.githubusercontent.com/9394800/58736690-9c872d00-83b3-11e9-9a0c-5a64d0b79eca.png)
Subsequent alternate names get added to the list after the common name

![image](https://user-images.githubusercontent.com/9394800/58736715-b6c10b00-83b3-11e9-9c76-315e5f437ebe.png)
Common name modified, changes reflect in the list of domain names
