### PR TITLE
manage.py: Restore shebang line

### DIFF
--- a/lemur/manage.py
+++ b/lemur/manage.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import unicode_literals  # at top of module
 
 import os


### PR DESCRIPTION
It's been a while, been busy with other stuff. This is a trivial fix that I've carried in my own branches for now:

> This is an executable file but cannot be executed without the interpreter.
> 
> The shebang line was lost in commit 8cbc6b8325c08bb3a72932c7e67c6476f7d29edb
