### PR TITLE
Expired Toggle

### DIFF
--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -329,12 +329,14 @@ def render(args):
     """
     query = database.session_query(Certificate)
 
-    time_range = args.pop("time_range")
-    if not time_range:
-        six_month_old = arrow.now()\
-            .shift(months=current_app.config.get("HIDE_EXPIRED_CERTS_AFTER_MONTHS", -6))\
+    show_expired = args.pop("showExpired")
+    if show_expired != 1:
+        one_month_old = arrow.now()\
+            .shift(months=current_app.config.get("HIDE_EXPIRED_CERTS_AFTER_MONTHS", -1))\
             .format("YYYY-MM-DD")
-        query = query.filter(Certificate.not_after > six_month_old)
+        query = query.filter(Certificate.not_after > one_month_old)
+
+    time_range = args.pop("time_range")
 
     destination_id = args.pop("destination_id")
     notification_id = args.pop("notification_id", None)

--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -347,6 +347,7 @@ class CertificatesList(AuthenticatedResource):
         )
         parser.add_argument("creator", type=str, location="args")
         parser.add_argument("show", type=str, location="args")
+        parser.add_argument("showExpired", type=int, location="args")
 
         args = parser.parse_args()
         args["user"] = g.user

--- a/lemur/static/app/angular/certificates/view/view.js
+++ b/lemur/static/app/angular/certificates/view/view.js
@@ -19,6 +19,9 @@ angular.module('lemur')
 
   .controller('CertificatesViewController', function ($q, $scope, $uibModal, $stateParams, $location, CertificateApi, CertificateService, MomentService, ngTableParams, toaster) {
     $scope.filter = $stateParams;
+    $scope.expiredText = ["Show Expired", "Hide Expired"];
+    $scope.expiredValue = 0;
+    $scope.expiredButton = $scope.expiredText[$scope.expiredValue];
     $scope.certificateTable = new ngTableParams({
       page: 1,            // show first page
       count: 10,          // count per page
@@ -49,6 +52,34 @@ angular.module('lemur')
         }
       }
     });
+
+    $scope.showExpired = function () {
+      if ($scope.expiredValue === 0) {
+        $scope.expiredValue = 1;
+      }
+      else {
+        $scope.expiredValue = 0;
+      }
+      $scope.expiredButton = $scope.expiredText[$scope.expiredValue];
+      $scope.certificateTable = new ngTableParams({
+        page: 1,            // show first page
+        count: 10,          // count per page
+        sorting: {
+          id: 'desc'     // initial sorting
+        },
+        filter: $scope.filter
+      }, {
+        getData: function ($defer, params) {
+          $scope.temp = angular.copy(params.url());
+          $scope.temp.showExpired = $scope.expiredValue;
+          CertificateApi.getList($scope.temp)
+            .then(function (data) {
+              params.total(data.total);
+              $defer.resolve(data);
+            });
+        }
+      })
+    };
 
     $scope.momentService = MomentService;
 

--- a/lemur/static/app/angular/certificates/view/view.js
+++ b/lemur/static/app/angular/certificates/view/view.js
@@ -19,7 +19,7 @@ angular.module('lemur')
 
   .controller('CertificatesViewController', function ($q, $scope, $uibModal, $stateParams, $location, CertificateApi, CertificateService, MomentService, ngTableParams, toaster) {
     $scope.filter = $stateParams;
-    $scope.expiredText = ["Show Expired", "Hide Expired"];
+    $scope.expiredText = ['Show Expired', 'Hide Expired'];
     $scope.expiredValue = 0;
     $scope.expiredButton = $scope.expiredText[$scope.expiredValue];
     $scope.certificateTable = new ngTableParams({
@@ -78,7 +78,7 @@ angular.module('lemur')
               $defer.resolve(data);
             });
         }
-      })
+      });
     };
 
     $scope.momentService = MomentService;

--- a/lemur/static/app/angular/certificates/view/view.tpl.html
+++ b/lemur/static/app/angular/certificates/view/view.tpl.html
@@ -17,6 +17,11 @@
                   btn-checkbox-true="1"
                   btn-checkbox-false="0">Filter</button>
         </div>
+        <div class="btn-group">
+          <button ng-click="showExpired()" class="btn btn-default">
+            {{ expiredButton }}
+          </button>
+        </div>
         <!--<select class="form-control" ng-model="show" ng-options="item.value as item.title for item in fields"></select>-->
         <div class="clearfix"></div>
       </div>


### PR DESCRIPTION
This change updates the default behavior of Lemur to hide certs that have expired more than a month ago. (The current default behavior is to include certs that have expired up to 6 months ago). This will help lower the load on the server. There is also an additional button on the Certificates page now, that allows the user to view all certs, including all expired certs. The user can switch between showing and hiding expired certs.
![image](https://user-images.githubusercontent.com/9394800/59885444-205b8600-9370-11e9-9c99-144809f208ef.png)

![image](https://user-images.githubusercontent.com/9394800/59885456-2b161b00-9370-11e9-83d8-81fb782b0021.png)

Respective API changes have also been made to replicate this behavior. An additional parameter "showExpired=1" is required to retrieve all (including expired) certs, while viewing certificates.