### PR TITLE
Expose new certificate field hasPrivateKey

### DIFF
--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -137,7 +137,7 @@ class Certificate(db.Model):
 
     not_before = Column(ArrowType)
     not_after = Column(ArrowType)
-    not_after_ix = Index('ix_certificates_not_after', not_after.desc())
+    not_after_ix = Index("ix_certificates_not_after", not_after.desc())
 
     date_created = Column(ArrowType, PassiveDefault(func.now()), nullable=False)
 
@@ -336,6 +336,14 @@ class Certificate(db.Model):
     @revoked.expression
     def revoked(cls):
         return case([(cls.status == "revoked", True)], else_=False)
+
+    @hybrid_property
+    def has_private_key(self):
+        return self.private_key is not None
+
+    @has_private_key.expression
+    def has_private_key(cls):
+        return case([(cls.private_key.is_(None), True)], else_=False)
 
     @hybrid_property
     def in_rotation_window(self):

--- a/lemur/certificates/schemas.py
+++ b/lemur/certificates/schemas.py
@@ -247,6 +247,7 @@ class CertificateOutputSchema(LemurOutputSchema):
     # Note aliasing is the first step in deprecating these fields.
     notify = fields.Boolean()
     active = fields.Boolean(attribute="notify")
+    has_private_key = fields.Boolean()
 
     cn = fields.String()
     common_name = fields.String(attribute="cn")

--- a/lemur/static/app/angular/certificates/view/view.tpl.html
+++ b/lemur/static/app/angular/certificates/view/view.tpl.html
@@ -203,10 +203,10 @@
                   </uib-tab-heading>
                   <pre style="width: 100%">{{ certificate.body }}</pre>
                 </uib-tab>
-                <uib-tab ng-click="loadPrivateKey(certificate)">
+                <uib-tab ng-click="loadPrivateKey(certificate)" disable="!certificate.hasPrivateKey">
                   <uib-tab-heading>
                     Private Key
-                     <i class="glyphicon glyphicon-copy" style="cursor: pointer" clipboard text="certificate.privateKey"></i>
+                    <i class="glyphicon glyphicon-copy" style="cursor: pointer" clipboard ng-if="certificate.hasPrivateKey" text="certificate.privateKey"></i>
                   </uib-tab-heading>
                   <pre style="width: 100%">{{ certificate.privateKey }}</pre>
                 </uib-tab>


### PR DESCRIPTION
We can also now disable the 'private key' tab when cert doesn't have a private key.
