### PR TITLE
Perma link resolving private key load

### DIFF
--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -353,6 +353,11 @@ def render(args):
         if terms[1].startswith('"') and terms[1].endswith('"'):
             term = terms[1][1:-1]
 
+        perma = args.pop("perma")
+        if perma == 1:
+            if "name" in terms:
+                return query_name(term[1:-1], args)
+
         if "issuer" in terms:
             # we can't rely on issuer being correct in the cert directly so we combine queries
             sub_query = (

--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -348,6 +348,7 @@ class CertificatesList(AuthenticatedResource):
         parser.add_argument("creator", type=str, location="args")
         parser.add_argument("show", type=str, location="args")
         parser.add_argument("showExpired", type=int, location="args")
+        parser.add_argument("perma", type=int, location="args")
 
         args = parser.parse_args()
         args["user"] = g.user

--- a/lemur/static/app/angular/certificates/view/view.js
+++ b/lemur/static/app/angular/certificates/view/view.js
@@ -17,7 +17,7 @@ angular.module('lemur')
       });
   })
 
-  .controller('CertificatesViewController', function ($q, $scope, $uibModal, $stateParams, CertificateApi, CertificateService, MomentService, ngTableParams, toaster) {
+  .controller('CertificatesViewController', function ($q, $scope, $uibModal, $stateParams, $location, CertificateApi, CertificateService, MomentService, ngTableParams, toaster) {
     $scope.filter = $stateParams;
     $scope.expiredText = ['Show Expired', 'Hide Expired'];
     $scope.expiredValue = 0;

--- a/lemur/static/app/angular/certificates/view/view.js
+++ b/lemur/static/app/angular/certificates/view/view.js
@@ -32,24 +32,16 @@ angular.module('lemur')
     }, {
       total: 0,           // length of data
       getData: function ($defer, params) {
-        $scope.path = $location.path();
-        // Handle Permalink clicks through a separate API
-        // Clicking on Permalink adds the certificate name to the URL after "certificates/", which is used to identify the click
-        if ($scope.path.indexOf('certificates/') > -1 && $scope.path.split('/')[2].length > 0) {
-          $scope.certificateName = $scope.path.split('/')[2];
-          CertificateApi.one('name').one($scope.certificateName).getList()
-            .then(function (data) {
-              params.total(data.total);
-              $defer.resolve(data);
-            });
+        $scope.url = $location.url();
+        $scope.temp_url = angular.copy(params.url());
+         if ($scope.url.indexOf('perma') > -1) {
+          $scope.temp_url.perma = 1;
         }
-        else {
-          CertificateApi.getList(params.url())
-              .then(function (data) {
-                params.total(data.total);
-                $defer.resolve(data);
-              });
-        }
+        CertificateApi.getList($scope.temp_url)
+          .then(function (data) {
+            params.total(data.total);
+            $defer.resolve(data);
+          });
       }
     });
 

--- a/lemur/static/app/angular/certificates/view/view.tpl.html
+++ b/lemur/static/app/angular/certificates/view/view.tpl.html
@@ -52,7 +52,7 @@
             </td>
             <td data-title="''" style="text-align: center; vertical-align: middle;">
                 <div class="btn-group pull-right" role="group" aria-label="...">
-                  <a class="btn btn-sm btn-primary" ui-sref="certificate({name: certificate.name})">Permalink</a>
+                  <a class="btn btn-sm btn-primary" href="#/certificates/{{certificate.name}}?perma">Permalink</a>
                   <button ng-model="certificate.toggle" class="btn btn-sm btn-info" uib-btn-checkbox btn-checkbox-true="1"
                             btn-checkbox-false="0">More
                   </button>


### PR DESCRIPTION
These code changes fix the issue where the Permalink changes were breaking the PrivateKey functionality. Previously, the change for Permalink to call a new API was causing PrivateKey feature to point to a non existent API on the Permalink page. The Permalink feature is handled differently now, so as to not affect the PrivateKeyLoad feature. A parameter called "perma" is added to the URL for permalink and "perma=1" is added to the GET request to do a lookup for a certificate by its name instead of searching for it. 