### PR TITLE
Multi profile digiCert plugin

### DIFF
--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -158,7 +158,7 @@ def map_cis_fields(options, csr):
         )
 
     data = {
-        "profile_name": current_app.config.get("DIGICERT_CIS_PROFILE_NAMES")[options['authority'].name],
+        "profile_name": current_app.config.get("DIGICERT_CIS_PROFILE_NAMES", {}).get(options['authority'].name),
         "common_name": options["common_name"],
         "additional_dns_names": get_additional_names(options),
         "csr": csr,
@@ -537,14 +537,14 @@ class DigiCertCISIssuerPlugin(IssuerPlugin):
         if "ECC" in issuer_options["key_type"]:
             return (
                 "\n".join(str(end_entity).splitlines()),
-                current_app.config.get("DIGICERT_ECC_CIS_INTERMEDIATES")[issuer_options['authority'].name],
+                current_app.config.get("DIGICERT_ECC_CIS_INTERMEDIATES", {}).get(issuer_options['authority'].name),
                 data["id"],
             )
 
         # By default return RSA
         return (
             "\n".join(str(end_entity).splitlines()),
-            current_app.config.get("DIGICERT_CIS_INTERMEDIATES")[issuer_options['authority'].name],
+            current_app.config.get("DIGICERT_CIS_INTERMEDIATES", {}).get(issuer_options['authority'].name),
             data["id"],
         )
 
@@ -577,4 +577,4 @@ class DigiCertCISIssuerPlugin(IssuerPlugin):
         :return:
         """
         role = {"username": "", "password": "", "name": "digicert"}
-        return current_app.config.get("DIGICERT_CIS_ROOTS")[options['authority'].name], "", [role]
+        return current_app.config.get("DIGICERT_CIS_ROOTS", {}).get(options['authority'].name), "", [role]

--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -158,7 +158,7 @@ def map_cis_fields(options, csr):
         )
 
     data = {
-        "profile_name": current_app.config.get("DIGICERT_CIS_PROFILE_NAME"),
+        "profile_name": current_app.config.get("DIGICERT_CIS_PROFILE_NAMES")[options['authority'].name],
         "common_name": options["common_name"],
         "additional_dns_names": get_additional_names(options),
         "csr": csr,
@@ -423,9 +423,9 @@ class DigiCertCISSourcePlugin(SourcePlugin):
         required_vars = [
             "DIGICERT_CIS_API_KEY",
             "DIGICERT_CIS_URL",
-            "DIGICERT_CIS_ROOT",
-            "DIGICERT_CIS_INTERMEDIATE",
-            "DIGICERT_CIS_PROFILE_NAME",
+            "DIGICERT_CIS_ROOTS",
+            "DIGICERT_CIS_INTERMEDIATES",
+            "DIGICERT_CIS_PROFILE_NAMES",
         ]
         validate_conf(current_app, required_vars)
 
@@ -498,9 +498,9 @@ class DigiCertCISIssuerPlugin(IssuerPlugin):
         required_vars = [
             "DIGICERT_CIS_API_KEY",
             "DIGICERT_CIS_URL",
-            "DIGICERT_CIS_ROOT",
-            "DIGICERT_CIS_INTERMEDIATE",
-            "DIGICERT_CIS_PROFILE_NAME",
+            "DIGICERT_CIS_ROOTS",
+            "DIGICERT_CIS_INTERMEDIATES",
+            "DIGICERT_CIS_PROFILE_NAMES",
         ]
 
         validate_conf(current_app, required_vars)
@@ -537,14 +537,14 @@ class DigiCertCISIssuerPlugin(IssuerPlugin):
         if "ECC" in issuer_options["key_type"]:
             return (
                 "\n".join(str(end_entity).splitlines()),
-                current_app.config.get("DIGICERT_ECC_CIS_INTERMEDIATE"),
+                current_app.config.get("DIGICERT_ECC_CIS_INTERMEDIATES")[issuer_options['authority'].name],
                 data["id"],
             )
 
         # By default return RSA
         return (
             "\n".join(str(end_entity).splitlines()),
-            current_app.config.get("DIGICERT_CIS_INTERMEDIATE"),
+            current_app.config.get("DIGICERT_CIS_INTERMEDIATES")[issuer_options['authority'].name],
             data["id"],
         )
 
@@ -577,4 +577,4 @@ class DigiCertCISIssuerPlugin(IssuerPlugin):
         :return:
         """
         role = {"username": "", "password": "", "name": "digicert"}
-        return current_app.config.get("DIGICERT_CIS_ROOT"), "", [role]
+        return current_app.config.get("DIGICERT_CIS_ROOTS")[options['authority'].name], "", [role]

--- a/lemur/plugins/lemur_digicert/tests/test_digicert.py
+++ b/lemur/plugins/lemur_digicert/tests/test_digicert.py
@@ -66,7 +66,7 @@ def test_map_fields_with_validity_years(app):
     }
 
 
-def test_map_cis_fields(app):
+def test_map_cis_fields(app, authority):
     from lemur.plugins.lemur_digicert.plugin import map_cis_fields
 
     names = [u"one.example.com", u"two.example.com", u"three.example.com"]
@@ -80,6 +80,7 @@ def test_map_cis_fields(app):
         "organizational_unit": "Example Org",
         "validity_end": arrow.get(2017, 5, 7),
         "validity_start": arrow.get(2016, 10, 30),
+        "authority": authority,
     }
 
     data = map_cis_fields(options, CSR_STR)
@@ -104,6 +105,7 @@ def test_map_cis_fields(app):
         "organization": "Example, Inc.",
         "organizational_unit": "Example Org",
         "validity_years": 2,
+        "authority": authority,
     }
 
     with freeze_time(time_to_freeze=arrow.get(2016, 11, 3).datetime):

--- a/lemur/tests/conf.py
+++ b/lemur/tests/conf.py
@@ -80,6 +80,13 @@ DIGICERT_API_KEY = "api-key"
 DIGICERT_ORG_ID = 111111
 DIGICERT_ROOT = "ROOT"
 
+DIGICERT_CIS_URL = "mock://www.digicert.com"
+DIGICERT_CIS_PROFILE_NAMES = {"sha2-rsa-ecc-root": "ssl_plus"}
+DIGICERT_CIS_API_KEY = "api-key"
+DIGICERT_CIS_ROOTS = {"root": "ROOT"}
+DIGICERT_CIS_INTERMEDIATES = {"inter": "INTERMEDIATE_CA_CERT"}
+
+
 VERISIGN_URL = "http://example.com"
 VERISIGN_PEM_PATH = "~/"
 VERISIGN_FIRST_NAME = "Jim"


### PR DESCRIPTION
adding multi profile name support with DigiCert plug. 
This requires that the configs are a dict, with multiple entries, where the key is the name of the Authority used to issue the cert.

DIGICERT_CIS_PROFILE_NAMES = {"sha2-rsa-ecc-root": "ssl_plus"}
DIGICERT_CIS_ROOTS = {"root": "ROOT"}
DIGICERT_CIS_INTERMEDIATES = {"inter": "INTERMEDIATE_CA_CERT"}

Hence, in DB one need to add
1) the corresponding authority table, with digicert-cis-issuer. Note the names here are used to mapping in the above config
2) the corresponding intermediary in the certificate table , with root_aurhority_id set to the id of the new authority_id