### PR TITLE
bug fix for overwriting certificates with sftp plugin

### DIFF
--- a/lemur/plugins/lemur_sftp/plugin.py
+++ b/lemur/plugins/lemur_sftp/plugin.py
@@ -174,7 +174,7 @@ class SFTPDestinationPlugin(DestinationPlugin):
                     with sftp.open(dst_path_cn + "/" + filename, "w") as f:
                         f.write(data)
                 except (PermissionError) as permerror:
-                    if permerror.errno == 13: 
+                    if permerror.errno == 13:
                         current_app.logger.debug(
                             "Uploading {0} to {1} returned Permission Denied Error, making file writable and retrying".format(filename, dst_path_cn)
                         )


### PR DESCRIPTION
this is my fix for issue #2861 

I wanted to preserve file permissions unless absolutely necessary to change them, and also throw an error to logs that this occurs.