### PR TITLE
Eliminate SQL subqueries when showing certificates list

### DIFF
--- a/lemur/certificates/schemas.py
+++ b/lemur/certificates/schemas.py
@@ -6,6 +6,8 @@
 .. moduleauthor:: Kevin Glisson <kglisson@netflix.com>
 """
 from flask import current_app
+from flask_restful import inputs
+from flask_restful.reqparse import RequestParser
 from marshmallow import fields, validate, validates_schema, post_load, pre_load
 from marshmallow.exceptions import ValidationError
 
@@ -285,6 +287,16 @@ class CertificateOutputSchema(LemurOutputSchema):
     rotation_policy = fields.Nested(RotationPolicyNestedOutputSchema)
 
 
+class CertificateShortOutputSchema(LemurOutputSchema):
+    id = fields.Integer()
+    name = fields.String()
+    owner = fields.Email()
+    notify = fields.Boolean()
+    authority = fields.Nested(AuthorityNestedOutputSchema)
+    issuer = fields.String()
+    cn = fields.String()
+
+
 class CertificateUploadInputSchema(CertificateCreationSchema):
     name = fields.String()
     authority = fields.Nested(AssociatedAuthoritySchema, required=False)
@@ -363,9 +375,22 @@ class CertificateRevokeSchema(LemurInputSchema):
     comments = fields.String()
 
 
+certificates_list_request_parser = RequestParser()
+certificates_list_request_parser.add_argument("short", type=inputs.boolean, default=False, location="args")
+
+
+def certificates_list_output_schema_factory():
+    args = certificates_list_request_parser.parse_args()
+    if args["short"]:
+        return certificates_short_output_schema
+    else:
+        return certificates_output_schema
+
+
 certificate_input_schema = CertificateInputSchema()
 certificate_output_schema = CertificateOutputSchema()
 certificates_output_schema = CertificateOutputSchema(many=True)
+certificates_short_output_schema = CertificateShortOutputSchema(many=True)
 certificate_upload_input_schema = CertificateUploadInputSchema()
 certificate_export_input_schema = CertificateExportInputSchema()
 certificate_edit_input_schema = CertificateEditInputSchema()

--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -27,6 +27,7 @@ from lemur.certificates.schemas import (
     certificates_output_schema,
     certificate_export_input_schema,
     certificate_edit_input_schema,
+    certificates_list_output_schema_factory,
 )
 
 from lemur.roles import service as role_service
@@ -250,7 +251,7 @@ class CertificatesList(AuthenticatedResource):
         self.reqparse = reqparse.RequestParser()
         super(CertificatesList, self).__init__()
 
-    @validate_schema(None, certificates_output_schema)
+    @validate_schema(None, certificates_list_output_schema_factory)
     def get(self):
         """
         .. http:get:: /certificates

--- a/lemur/common/schema.py
+++ b/lemur/common/schema.py
@@ -169,7 +169,12 @@ def validate_schema(input_schema, output_schema):
             if not resp:
                 return dict(message="No data found"), 404
 
-            return unwrap_pagination(resp, output_schema), 200
+            if callable(output_schema):
+                output_schema_to_use = output_schema()
+            else:
+                output_schema_to_use = output_schema
+
+            return unwrap_pagination(resp, output_schema_to_use), 200
 
         return decorated_function
 

--- a/lemur/static/app/angular/certificates/certificate/certificate.js
+++ b/lemur/static/app/angular/certificates/certificate/certificate.js
@@ -371,4 +371,12 @@ angular.module('lemur')
         });
       });
   };
-});
+})
+.controller('CertificateInfoController', function ($scope, CertificateApi) {
+  $scope.fetchFullCertificate = function (certId) {
+    CertificateApi.get(certId).then(function (certificate) {
+      $scope.certificate = certificate;
+    });
+  };
+})
+;

--- a/lemur/static/app/angular/certificates/view/view.js
+++ b/lemur/static/app/angular/certificates/view/view.js
@@ -28,6 +28,7 @@ angular.module('lemur')
       sorting: {
         id: 'desc'     // initial sorting
       },
+      short: true,
       filter: $scope.filter
     }, {
       total: 0,           // length of data
@@ -54,6 +55,7 @@ angular.module('lemur')
         sorting: {
           id: 'desc'     // initial sorting
         },
+        short: true,
         filter: $scope.filter
       }, {
         getData: function ($defer, params) {

--- a/lemur/static/app/angular/certificates/view/view.tpl.html
+++ b/lemur/static/app/angular/certificates/view/view.tpl.html
@@ -71,7 +71,7 @@
                 </div>
             </td>
           </tr>
-          <tr class="warning" ng-if="certificate.toggle" ng-repeat-end>
+          <tr class="warning" ng-if="certificate.toggle" ng-controller="CertificateInfoController" ng-init="fetchFullCertificate(certificate.id)" ng-repeat-end>
             <td colspan="12">
               <uib-tabset justified="true" class="col-md-8">
                 <uib-tab>


### PR DESCRIPTION
When loading list of certificates in Web UI  endpoint `/api/1/certificates` returns full Certificate entry with all associations loaded.It produces about 7-8 SQL requests for **each** returned certificate, i.e. several hundreds requests for large pages (50-100 certificates). Given that certificates table needs only few Certificate fields it makes sense to return only data we need. It eliminates tons of SQL queries and reduces traffic a bit :)

So this PR introduces boolean query parameter `short` for `/api/v1/certificates` which tells backend to return only those certificate fields we need to render certificate table. 