### PR TITLE
fix for #2879 cfssl-key TypeError

### DIFF
--- a/lemur/plugins/lemur_cfssl/plugin.py
+++ b/lemur/plugins/lemur_cfssl/plugin.py
@@ -56,7 +56,7 @@ class CfsslIssuerPlugin(IssuerPlugin):
         try:
             hex_key = current_app.config.get("CFSSL_KEY")
             key = bytes.fromhex(hex_key)
-        except (ValueError, NameError):
+        except (ValueError, NameError, TypeError):
             # unable to find CFSSL_KEY in config, continue using normal sign method
             pass
         else:


### PR DESCRIPTION
Mention changed [here](https://github.com/Netflix/lemur/issues/2879#issuecomment-572049821).

If CFSSL-KEY is not provided in the config the code halts which shouldn't happen since the key is optional.