### PR TITLE
fix fatal error in schema validator

### DIFF
--- a/lemur/certificates/schemas.py
+++ b/lemur/certificates/schemas.py
@@ -119,6 +119,9 @@ class CertificateInputSchema(CertificateCreationSchema):
 
     @validates_schema
     def validate_authority(self, data):
+        if 'authority' not in data:
+            raise ValidationError("Missing Authority.")
+
         if isinstance(data["authority"], str):
             raise ValidationError("Authority not found.")
 


### PR DESCRIPTION
Currently the request crashes and gives out a 500 instead of handling the missing field gracefully and providing an invalid schema error with a 400.