### PR TITLE
fixing issue where set_domains() is still called when get_all_zones()…

### DIFF
--- a/lemur/dns_providers/cli.py
+++ b/lemur/dns_providers/cli.py
@@ -35,7 +35,6 @@ def get_all_zones():
             print("[+] Error with DNS Provider {}: {}".format(dns_provider.name, e))
             log_data["message"] = f"get all zones failed for {dns_provider} {e}."
             sentry.captureException(extra=log_data)
-            set_domains(dns_provider, [])
 
     status = SUCCESS_METRIC_STATUS
 


### PR DESCRIPTION
… throws an exception.  

get_all_zones() is called for each acme provider and if it throws an exception, dns_providers/cli.py will still overwrite the domains in the database with an empty set.  This PR solves this problem by removing the DB write in case of exception. 