### PR TITLE
adding support for pip version >=19.3 by supporting change to PipSess…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,11 @@ from setuptools import setup, find_packages
 from subprocess import check_output
 
 import pip
-if tuple(map(int, pip.__version__.split('.'))) >= (10, 0, 0):
+if tuple(map(int, pip.__version__.split('.'))) >= (19, 3, 0):
+    from pip._internal.network.session import PipSession
+    from pip._internal.req import parse_requirements
+
+elif tuple(map(int, pip.__version__.split('.'))) >= (10, 0, 0):
     from pip._internal.download import PipSession
     from pip._internal.req import parse_requirements
 else:


### PR DESCRIPTION
…ion() location in setup.py

In version 19.3 of Pip, PipSession() was moved to pip._internal.network.session(), which broke Lemur builds when Pip was over that version.  This fix updates setup.py to import differently based on the version.  In the future, it would be good to remove the dependency on pip._internal, but that is a larger effort and we want to ensure that Lemur builds on updates systems. 