### PR TITLE
New variable VERISIGN_PRODUCT_(authority.name)

### DIFF
--- a/lemur/plugins/lemur_verisign/plugin.py
+++ b/lemur/plugins/lemur_verisign/plugin.py
@@ -98,14 +98,12 @@ def process_options(options):
     :param options:
     :return: dict or valid verisign options
     """
-
     # if there is a config variable with VERISIGN_PRODUCT_<upper(authority.name)> take the value as Cert product-type
     # else default to "Server", to be compatoible with former versions
     authority = options.get("authority").name.upper()
     product_type = current_app.config.get("VERISIGN_PRODUCT_{0}".format(authority))
     if product_type is None:
         product_type = "Server"
-
     data = {
         "challenge": get_psuedo_random_string(),
         "serverType": "Apache",

--- a/lemur/plugins/lemur_verisign/plugin.py
+++ b/lemur/plugins/lemur_verisign/plugin.py
@@ -104,7 +104,7 @@ def process_options(options):
     authority = options.get("authority").name.upper()
     product_type = current_app.config.get("VERISIGN_PRODUCT_{0}".format(authority))
     if product_type is None:
-      product_type ="Server"
+        product_type = "Server"
     
     data = {
         "challenge": get_psuedo_random_string(),

--- a/lemur/plugins/lemur_verisign/plugin.py
+++ b/lemur/plugins/lemur_verisign/plugin.py
@@ -98,14 +98,14 @@ def process_options(options):
     :param options:
     :return: dict or valid verisign options
     """
-   
+
     # if there is a config variable with VERISIGN_PRODUCT_<upper(authority.name)> take the value as Cert product-type
     # else default to "Server", to be compatoible with former versions
     authority = options.get("authority").name.upper()
     product_type = current_app.config.get("VERISIGN_PRODUCT_{0}".format(authority))
     if product_type is None:
         product_type = "Server"
-    
+
     data = {
         "challenge": get_psuedo_random_string(),
         "serverType": "Apache",

--- a/lemur/plugins/lemur_verisign/plugin.py
+++ b/lemur/plugins/lemur_verisign/plugin.py
@@ -101,9 +101,7 @@ def process_options(options):
     # if there is a config variable with VERISIGN_PRODUCT_<upper(authority.name)> take the value as Cert product-type
     # else default to "Server", to be compatoible with former versions
     authority = options.get("authority").name.upper()
-    product_type = current_app.config.get("VERISIGN_PRODUCT_{0}".format(authority))
-    if product_type is None:
-        product_type = "Server"
+    product_type = current_app.config.get("VERISIGN_PRODUCT_{0}".format(authority), "Server")
     data = {
         "challenge": get_psuedo_random_string(),
         "serverType": "Apache",

--- a/lemur/plugins/lemur_verisign/plugin.py
+++ b/lemur/plugins/lemur_verisign/plugin.py
@@ -98,10 +98,18 @@ def process_options(options):
     :param options:
     :return: dict or valid verisign options
     """
+   
+    # if there is a config variable with VERISIGN_PRODUCT_<upper(authority.name)> take the value as Cert product-type
+    # else default to "Server", to be compatoible with former versions
+    authority = options.get("authority").name.upper()
+    product_type = current_app.config.get("VERISIGN_PRODUCT_{0}".format(authority))
+    if product_type is None:
+      product_type ="Server"
+    
     data = {
         "challenge": get_psuedo_random_string(),
         "serverType": "Apache",
-        "certProductType": "Server",
+        "certProductType": product_type,
         "firstName": current_app.config.get("VERISIGN_FIRST_NAME"),
         "lastName": current_app.config.get("VERISIGN_LAST_NAME"),
         "signatureAlgorithm": "sha256WithRSAEncryption",


### PR DESCRIPTION
If there is a config variable with VERISIGN_PRODUCT_<upper(authority.name)> take the value as Cert product-type else default to "Server" to be compatible with former versions.
This enables the creation of different Verisign cert-products eg. EV or Standard Certs using several cert authorities.