### PR TITLE
removing 2 year option from Lemur certificate request form

### DIFF
--- a/lemur/static/app/angular/certificates/certificate/tracking.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/tracking.tpl.html
@@ -140,7 +140,6 @@
         <select ng-model="certificate.validityYears" class="form-control">
           <option value="">-</option>
           <option value="1">1 year</option>
-          <option value="2">2 years</option>
         </select>
       </div>
       <span style="padding-top: 15px" class="text-center col-sm-1">


### PR DESCRIPTION
The industry has been moving to shorter-lived certificates.  In the past they were 3 years, then 2, now its time to embrance 1 year certificates. Google requested to reduce certificates to one year in August 2019 as CA/B Forum Ballot SC22. Apple just announced that Safari will no longer trust certificate issued after September 1, 2020 with lifetimes longer than 1 year.  

This change just remvoes the 2 year certificate option from the Lemur web interface.  If you still require certificates greater than 1 year, users can manually choose a longer validity range via the startDate and endDate ranges. 

https://www.digicert.com/position-on-1-year-certificates/