### PR TITLE
Add Support for ACME_POWERDNS_VERIFY Option

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -1008,6 +1008,15 @@ The following configuration properties are required to use the PowerDNS ACME Plu
 
             This is the number of times DNS Verification should be attempted (i.e. 20)
 
+
+.. data:: ACME_POWERDNS_VERIFY
+    :noindex:
+
+            This configures how PowerDNS verifies TLS certificates.  The PowerDNS Plugin relies on the requests library, supported options are as follows:
+            * True: Verifies the certificate chains to a known publicly-trusted CA. (Default)
+            * False: Disable certificate validation (Not Recommended)
+            * File/Dir path to CA Bundle: Verify that the certificate chains to a Certificate Authority in the provided CA bundle.
+
 .. _CommandLineInterface:
 
 Command Line Interface

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -1012,7 +1012,7 @@ The following configuration properties are required to use the PowerDNS ACME Plu
 .. data:: ACME_POWERDNS_VERIFY
     :noindex:
 
-            This configures how TLS certificates on the PowerDNS API target are validated.  The PowerDNS Plugin depends on the PyPi requests library, which supports the following options:
+            This configures how TLS certificates on the PowerDNS API target are validated.  The PowerDNS Plugin depends on the PyPi requests library, which supports the following options for the verify parameter:
             * True: Verifies the TLS certificate was issued by a known publicly-trusted CA. (Default)
             * False: Disables certificate validation (Not Recommended)
             * File/Dir path to CA Bundle: Verifies the TLS certificate was issued by a Certificate Authority in the provided CA bundle.

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -1012,10 +1012,10 @@ The following configuration properties are required to use the PowerDNS ACME Plu
 .. data:: ACME_POWERDNS_VERIFY
     :noindex:
 
-            This configures how PowerDNS verifies TLS certificates.  The PowerDNS Plugin relies on the requests library, supported options are as follows:
-            * True: Verifies the certificate chains to a known publicly-trusted CA. (Default)
-            * False: Disable certificate validation (Not Recommended)
-            * File/Dir path to CA Bundle: Verify that the certificate chains to a Certificate Authority in the provided CA bundle.
+            This configures how TLS certificates on the PowerDNS API target are validated.  The PowerDNS Plugin depends on the PyPi requests library, which supports the following options:
+            * True: Verifies the TLS certificate was issued by a known publicly-trusted CA. (Default)
+            * False: Disables certificate validation (Not Recommended)
+            * File/Dir path to CA Bundle: Verifies the TLS certificate was issued by a Certificate Authority in the provided CA bundle.
 
 .. _CommandLineInterface:
 

--- a/lemur/plugins/lemur_acme/powerdns.py
+++ b/lemur/plugins/lemur_acme/powerdns.py
@@ -246,11 +246,12 @@ def _get_zone_name(domain, account_number):
 def _get(path, params=None):
     """ Execute a GET request on the given URL (base_uri + path) and return response as JSON object """
     base_uri = current_app.config.get("ACME_POWERDNS_DOMAIN")
+    verify_value = current_app.config.get("ACME_POWERDNS_VERIFY", True)
     resp = requests.get(
         f"{base_uri}{path}",
         headers=_generate_header(),
         params=params,
-        verify=True,
+        verify=verify_value,
     )
     resp.raise_for_status()
     return resp.json()
@@ -259,9 +260,11 @@ def _get(path, params=None):
 def _patch(path, payload):
     """ Execute a Patch request on the given URL (base_uri + path) with given payload """
     base_uri = current_app.config.get("ACME_POWERDNS_DOMAIN")
+    verify_value = current_app.config.get("ACME_POWERDNS_VERIFY", True)
     resp = requests.patch(
         f"{base_uri}{path}",
         data=json.dumps(payload),
-        headers=_generate_header()
+        headers=_generate_header(),
+        verify=verify_value,
     )
     resp.raise_for_status()

--- a/lemur/plugins/lemur_acme/powerdns.py
+++ b/lemur/plugins/lemur_acme/powerdns.py
@@ -251,7 +251,7 @@ def _get(path, params=None):
         f"{base_uri}{path}",
         headers=_generate_header(),
         params=params,
-        verify=verify_value,
+        verify=verify_value
     )
     resp.raise_for_status()
     return resp.json()
@@ -265,6 +265,6 @@ def _patch(path, payload):
         f"{base_uri}{path}",
         data=json.dumps(payload),
         headers=_generate_header(),
-        verify=verify_value,
+        verify=verify_value
     )
     resp.raise_for_status()


### PR DESCRIPTION
This option allows for enabling or disabling TLS certificate verification when connecting to a PowerDNS API.  It also enables the ability to provide a CA Bundle, helpful when using private or internal certificates. 