### PR TITLE
Bump time limit for clean_source Celery job

### DIFF
--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -332,7 +332,7 @@ def clean_all_sources():
     metrics.send(f"{function}.success", 'counter', 1)
 
 
-@celery.task(soft_time_limit=600)
+@celery.task(soft_time_limit=3600)
 def clean_source(source):
     """
     This celery task will clean the specified source. This is a destructive operation that will delete unused


### PR DESCRIPTION
For larger accounts, I've hit SoftTimeLimit exceptions before completion of this celery job. Bumping up the time limit on this job.