### PR TITLE
Don't interrupt certificate deletion process if certificate already deleted

### DIFF
--- a/lemur/plugins/lemur_aws/iam.py
+++ b/lemur/plugins/lemur_aws/iam.py
@@ -115,7 +115,10 @@ def delete_cert(cert_name, **kwargs):
         client.delete_server_certificate(ServerCertificateName=cert_name)
     except botocore.exceptions.ClientError as e:
         if e.response["Error"]["Code"] != "NoSuchEntity":
-            raise e
+            # If the certificate is already deleted in AWS,
+            # we should continue with the remainder of the deletion process in Lemur
+            # which includes removing applicable sources and destinations
+            return
 
 
 @sts_client("iam")


### PR DESCRIPTION
Don't interrupt certificate deletion process if certificate already deleted in AWS