### PR TITLE
fixing the private DNS zone issue.

### DIFF
--- a/lemur/plugins/lemur_acme/route53.py
+++ b/lemur/plugins/lemur_acme/route53.py
@@ -35,9 +35,10 @@ def get_zones(client=None):
     zones = []
     for page in paginator.paginate():
         for zone in page["HostedZones"]:
-            zones.append(
-                zone["Name"][:-1]
-            )  # We need [:-1] to strip out the trailing dot.
+            if not zone["Config"]["PrivateZone"]:
+                zones.append(
+                    zone["Name"][:-1]
+                )  # We need [:-1] to strip out the trailing dot.
     return zones
 
 


### PR DESCRIPTION
Private hosted zones will never be visible to third-parties like LetsEncrypt, and Lemur should not consider them as authoritative zones.
This fix, make sure  they are not added to the  dns_provider table.