### PR TITLE
Improve periodic tasks docs

### DIFF
--- a/docs/production/index.rst
+++ b/docs/production/index.rst
@@ -390,6 +390,10 @@ Here are the Celery configuration variables that should be set::
     CELERY_IMPORTS = ('lemur.common.celery')
     CELERY_TIMEZONE = 'UTC'
 
+Do not forget to import crontab module in your configuration file::
+
+    from celery.task.schedules import crontab
+
 You must start a single Celery scheduler instance and one or more worker instances in order to handle incoming tasks.
 The scheduler can be started with::
 


### PR DESCRIPTION
If you enable Celery using the example configuration provided in the
production documentation under the periodic tasks section you will get
following error:
                                                                                                                                                                                                                                                                                                                                                                                              
```
Traceback (most recent call last):
  File "/opt/lemur/bin/lemur", line 11, in <module>
    load_entry_point('lemur', 'console_scripts', 'lemur')()
  File "/opt/lemur/lemur/manage.py", line 589, in main
    manager.run()
  File "/opt/lemur/lib/python3.8/site-packages/flask_script/__init__.py", line 417, in run
    result = self.handle(argv[0], argv[1:])
  File "/opt/lemur/lib/python3.8/site-packages/flask_script/__init__.py", line 386, in handle
    res = handle(*args, **config)
  File "/opt/lemur/lib/python3.8/site-packages/flask_script/__init__.py", line 159, in __call__
    app = app(**kwargs)
  File "/opt/lemur/lemur/__init__.py", line 79, in create_app
    app = factory.create_app(
  File "/opt/lemur/lemur/factory.py", line 53, in create_app
    configure_app(app, config)
  File "/opt/lemur/lemur/factory.py", line 102, in configure_app
    app.config.from_object(from_file(config))
  File "/opt/lemur/lemur/factory.py", line 80, in from_file
    exec(  # nosec: config file safe
  File "/etc/lemur/lemur.conf.py", line 81, in <module>
    'schedule': crontab(minute="*"),
NameError: name 'crontab' is not defined
```
To fix that error one need to import crontab module from Celery tasks
schedulers: `from celery.task.schedules import crontab`.