### PR TITLE
Fix intermediate CA creation on cryptography plugin

### DIFF
--- a/lemur/plugins/lemur_cryptography/plugin.py
+++ b/lemur/plugins/lemur_cryptography/plugin.py
@@ -24,7 +24,12 @@ from lemur.certificates.service import create_csr
 def build_certificate_authority(options):
     options["certificate_authority"] = True
     csr, private_key = create_csr(**options)
-    cert_pem, chain_cert_pem = issue_certificate(csr, options, private_key)
+
+    if options.get("parent"):
+        # Intermediate Cert Issuance
+        cert_pem, chain_cert_pem = issue_certificate(csr, options, None)
+    else:
+        cert_pem, chain_cert_pem = issue_certificate(csr, options, private_key)
 
     return cert_pem, private_key, chain_cert_pem
 

--- a/lemur/plugins/lemur_cryptography/tests/test_cryptography.py
+++ b/lemur/plugins/lemur_cryptography/tests/test_cryptography.py
@@ -25,6 +25,31 @@ def test_build_certificate_authority():
     assert chain_cert_pem == ""
 
 
+def test_build_intermediate_certificate_authority(authority):
+    from lemur.plugins.lemur_cryptography.plugin import build_certificate_authority
+
+    options = {
+        "key_type": "RSA2048",
+        "country": "US",
+        "state": "CA",
+        "location": "Example place",
+        "organization": "Example, Inc.",
+        "organizational_unit": "Example Unit",
+        "common_name": "Example INTERMEDIATE",
+        "validity_start": arrow.get("2016-12-01").datetime,
+        "validity_end": arrow.get("2016-12-02").datetime,
+        "first_serial": 1,
+        "serial_number": 1,
+        "owner": "owner@example.com",
+        "parent": authority
+    }
+    cert_pem, private_key_pem, chain_cert_pem = build_certificate_authority(options)
+
+    assert cert_pem
+    assert private_key_pem
+    assert chain_cert_pem == authority.authority_certificate.body
+
+
 def test_issue_certificate(authority):
     from lemur.tests.vectors import CSR_STR
     from lemur.plugins.lemur_cryptography.plugin import issue_certificate


### PR DESCRIPTION
Creating an intermediate CA using the `cryptography` plugin fails with the message `"Private would be ignored, authority key used instead"`. This pull request fixes that issue and adds a test to cover that use-case.