### PR TITLE
docker - add libtool, fix url context path

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,8 @@ FROM alpine:3.8
 ARG VERSION
 ENV VERSION master
 
+ARG URLCONTEXT
+
 ENV uid 1337
 ENV gid 1337
 ENV user lemur
@@ -22,6 +24,7 @@ RUN addgroup -S ${group} -g ${gid} && \
                 gcc \
                 autoconf \
                 automake \
+                libtool \
                 make \
                 nasm  \
                 zlib-dev \
@@ -42,7 +45,7 @@ WORKDIR /opt/lemur
 RUN npm install --unsafe-perm && \
     pip3 install -e . && \
     node_modules/.bin/gulp build && \
-    node_modules/.bin/gulp package --urlContextPath=$(urlContextPath) && \
+    node_modules/.bin/gulp package --urlContextPath=${URLCONTEXT} && \
     apk del build-dependencies
 
 COPY entrypoint /

--- a/docker/Dockerfile-src
+++ b/docker/Dockerfile-src
@@ -3,6 +3,8 @@ FROM alpine:3.8
 ARG VERSION
 ENV VERSION master
 
+ARG URLCONTEXT
+
 ENV uid 1337
 ENV gid 1337
 ENV user lemur
@@ -22,6 +24,7 @@ RUN addgroup -S ${group} -g ${gid} && \
                 gcc \
                 autoconf \
                 automake \
+                libtool \
                 make \
                 nasm  \
                 zlib-dev \
@@ -42,7 +45,7 @@ RUN chown -R $user:$group /opt/lemur/ /home/lemur/.lemur/ && \
     npm install --unsafe-perm && \
     pip3 install -e . && \
     node_modules/.bin/gulp build && \
-    node_modules/.bin/gulp package --urlContextPath=$(urlContextPath) && \
+    node_modules/.bin/gulp package --urlContextPath=${URLCONTEXT} && \
     apk del build-dependencies
 
 COPY docker/entrypoint /


### PR DESCRIPTION
it looks like $(urlContextPath) copy pasted as is from the Makefile file

```
node_modules/.bin/gulp package --urlContextPath=$(urlContextPath)
```

also missing libtool led to error below

w/o libtool 

```
  ? spawn /opt/lemur/node_modules/mozjpeg/vendor/cjpeg ENOENT
  ? mozjpeg pre-build test failed
  ? compiling from source
  ? Error: Command failed: /bin/sh -c autoreconf -fiv
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force
autoreconf: configure.ac: tracing
autoreconf: configure.ac: not using Libtool
autoreconf: running: /usr/bin/autoconf --force
configure.ac:23: error: possibly undefined macro: AC_PROG_LIBTOOL
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: /usr/bin/autoconf failed with exit status: 1


    at Promise.all.then.arr (/opt/lemur/node_modules/bin-build/node_modules/execa/index.js:231:11)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
```

w/ libtool

```
> mozjpeg@6.0.1 postinstall /opt/lemur/node_modules/mozjpeg
> node lib/install.js

  ? spawn /opt/lemur/node_modules/mozjpeg/vendor/cjpeg ENOENT
  ? mozjpeg pre-build test failed
  ? compiling from source
  ? mozjpeg built successfully
```