### PR TITLE
Raise ValidationError if CSR contains invalid CN

### DIFF
--- a/lemur/common/validators.py
+++ b/lemur/common/validators.py
@@ -99,8 +99,12 @@ def csr(data):
         raise ValidationError("CSR presented is not valid.")
 
     # Validate common name and SubjectAltNames
-    for name in request.subject.get_attributes_for_oid(NameOID.COMMON_NAME):
-        common_name(name.value)
+    try:
+        for name in request.subject.get_attributes_for_oid(NameOID.COMMON_NAME):
+            common_name(name.value)
+    except ValueError as err:
+        current_app.logger.info("Error parsing Subject from CSR: %s", err)
+        raise ValidationError("Invalid Subject value in supplied CSR")
 
     try:
         alt_names = request.extensions.get_extension_for_class(


### PR DESCRIPTION
If we supply a CSR that contains an empty field in the Subject, Lemur will crash with an error 500 as the ValueError exception is not captured. This change captures the exception and raises a ValidationError which in this case is a 400 sent back to client. Example to reproduce:

    Subject: C=ZZ, ST=Something, L=, O=My_Org, OU=My_Dept, CN=www.booking.com

The empty L= causes a ValueError which needs to be captured.