### PR TITLE
Fix unmatched field in Authorization

### DIFF
--- a/lemur/authorizations/models.py
+++ b/lemur/authorizations/models.py
@@ -25,7 +25,7 @@ class Authorization(db.Model):
         return plugins.get(self.plugin_name)
 
     def __repr__(self):
-        return "Authorization(id={id})".format(label=self.id)
+        return "Authorization(id={id})".format(id=self.id)
 
     def __init__(self, account_number, domains, dns_provider_type, options=None):
         self.account_number = account_number


### PR DESCRIPTION
The field in the formatted string was not matching the args