### PR TITLE
Certificate cloning enhancements/fixes

### DIFF
--- a/lemur/static/app/angular/certificates/certificate/certificate.js
+++ b/lemur/static/app/angular/certificates/certificate/certificate.js
@@ -215,11 +215,14 @@ angular.module('lemur')
   $scope.certificate = LemurRestangular.restangularizeElement(null, {}, 'certificates');
   CertificateApi.get(editId).then(function (certificate) {
     $scope.certificate = certificate;
+    // prepare the certificate for cloning
     $scope.certificate.name = ''; // we should prefer the generated name
     $scope.certificate.csr = null;  // should not clone CSR in case other settings are changed in clone
     $scope.certificate.validityStart = null;
     $scope.certificate.validityEnd = null;
     $scope.certificate.keyType = 'RSA2048'; // default algo to show during clone
+    $scope.certificate.replacedBy = []; // should not clone 'replaced by' info
+    $scope.certificate.removeReplaces(); // should not clone 'replacement cert' info
     CertificateService.getDefaults($scope.certificate);
   });
 

--- a/lemur/static/app/angular/certificates/certificate/certificate.js
+++ b/lemur/static/app/angular/certificates/certificate/certificate.js
@@ -221,6 +221,7 @@ angular.module('lemur')
     $scope.certificate.validityStart = null;
     $scope.certificate.validityEnd = null;
     $scope.certificate.keyType = 'RSA2048'; // default algo to show during clone
+    $scope.certificate.description = 'Cloning from cert ID ' + editId;
     $scope.certificate.replacedBy = []; // should not clone 'replaced by' info
     $scope.certificate.removeReplaces(); // should not clone 'replacement cert' info
     CertificateService.getDefaults($scope.certificate);

--- a/lemur/static/app/angular/certificates/certificate/certificate.js
+++ b/lemur/static/app/angular/certificates/certificate/certificate.js
@@ -212,12 +212,14 @@ angular.module('lemur')
   })
 
 .controller('CertificateCloneController', function ($scope, $uibModalInstance, CertificateApi, CertificateService, DestinationService, AuthorityService, AuthorityApi, PluginService, MomentService, WizardHandler, LemurRestangular, NotificationService, toaster, editId) {
+  $scope.certificate = LemurRestangular.restangularizeElement(null, {}, 'certificates');
   CertificateApi.get(editId).then(function (certificate) {
     $scope.certificate = certificate;
     $scope.certificate.name = ''; // we should prefer the generated name
     $scope.certificate.csr = null;  // should not clone CSR in case other settings are changed in clone
     $scope.certificate.validityStart = null;
     $scope.certificate.validityEnd = null;
+    $scope.certificate.keyType = 'RSA2048'; // default algo to show during clone
     CertificateService.getDefaults($scope.certificate);
   });
 


### PR DESCRIPTION
Support added for

- Honor selected algorithm during certificate cloning, currently it defaults to RSA2048
- Do not inherit **replacement** configs during cert clone
- Include ID of the cert being cloned in description
> Cloning from cert ID 80764