### PR TITLE
Remove 397 days validation as it causes error in API calls

### DIFF
--- a/lemur/common/validators.py
+++ b/lemur/common/validators.py
@@ -152,18 +152,6 @@ def dates(data):
                         data["authority"].authority_certificate.not_after
                     )
                 )
-            # Allow no more than PUBLIC_CA_MAX_VALIDITY_DAYS (Default: 397) days of validity
-            # for certs issued by public CA
-            # The list of public issuers can be managed through a config named PUBLIC_CA
-            public_CA = current_app.config.get("PUBLIC_CA_AUTHORITY_NAMES", [])
-            if data["authority"].name.lower() in [ca.lower() for ca in public_CA]:
-                max_validity_days = current_app.config.get("PUBLIC_CA_MAX_VALIDITY_DAYS", 397)
-                if (
-                    (data.get("validity_end").date() - data.get("validity_start").date()).days
-                    > max_validity_days
-                ):
-                    raise ValidationError("Certificate cannot be valid for more than " +
-                                          str(max_validity_days) + " days")
 
     return data
 


### PR DESCRIPTION
More to come in future
Undoing https://github.com/Netflix/lemur/pull/3081/files#diff-c886e56668fea4a1442fd0bc275c1dfdR155-R166