### PR TITLE
fixing setup-git so build continues if ./git/hooks does not exist.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,13 @@ reset-db:
 	cd lemur && lemur db upgrade
 
 setup-git:
-	@echo "--> Installing git hooks"
-	git config branch.autosetuprebase always
-	cd .git/hooks && ln -sf ../../hooks/* ./
-	@echo ""
+	if [ -d .git/hooks ]; then \
+		@echo "--> Installing git hooks"; \
+		git config branch.autosetuprebase always; \
+		cd .git/hooks && ln -sf ../../hooks/* ./; \
+		@echo ""; \
+	fi
+
 
 clean:
 	@echo "--> Cleaning static cache"

--- a/Makefile
+++ b/Makefile
@@ -49,13 +49,12 @@ reset-db:
 	cd lemur && lemur db upgrade
 
 setup-git:
+	@echo "--> Installing git hooks"
 	if [ -d .git/hooks ]; then \
-		@echo "--> Installing git hooks"; \
 		git config branch.autosetuprebase always; \
 		cd .git/hooks && ln -sf ../../hooks/* ./; \
-		@echo ""; \
 	fi
-
+	@echo ""
 
 clean:
 	@echo "--> Cleaning static cache"


### PR DESCRIPTION
If Lemur is built as a git submodule, the .git/hooks folder is in the parent git repo.  If this is the case, don't link the hooks. 