### PR TITLE
Cert Validity UI Changes

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -174,9 +174,10 @@ Specifying the `SQLALCHEMY_MAX_OVERFLOW` to 0 will enforce limit to not create c
 
 .. data:: DEFAULT_VALIDITY_DAYS
     :noindex:
-        Use this config to override the default validity of certificates offered through Lemur UI. Any CA which is not listed
-        in PUBLIC_CA_AUTHORITY_NAMES will be using this value as default validity to be displayed on UI. Below example overrides the
-        default validity of 365 days and sets it to 1095 days (3 years).
+        Use this config to override the default validity of 365 days for certificates offered through Lemur UI. Any CA which
+        is not listed in PUBLIC_CA_AUTHORITY_NAMES will be using this value as default validity to be displayed on UI. Please
+        note that this config is used for cert issuance only through Lemur UI. Below example overrides the default validity
+        of 365 days and sets it to 1095 days (3 years).
 
     ::
 

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -172,15 +172,15 @@ Specifying the `SQLALCHEMY_MAX_OVERFLOW` to 0 will enforce limit to not create c
         PUBLIC_CA_MAX_VALIDITY_DAYS = 365
 
 
-.. data:: DEFAULT_MAX_VALIDITY_DAYS
+.. data:: DEFAULT_VALIDITY_DAYS
     :noindex:
-        Use this config to override the default limit of 1095 days (3 years) of validity. Any CA which is not listed in
-        PUBLIC_CA_AUTHORITY_NAMES will be using this validity to display date range on UI. Below example overrides the
-        default validity of 1095 days and sets it to 365 days.
+        Use this config to override the default validity of certificates offered through Lemur UI. Any CA which is not listed
+        in PUBLIC_CA_AUTHORITY_NAMES will be using this value as default validity to be displayed on UI. Below example overrides the
+        default validity of 365 days and sets it to 1095 days (3 years).
 
     ::
 
-        DEFAULT_MAX_VALIDITY_DAYS = 365
+        DEFAULT_VALIDITY_DAYS = 1095
 
 
 .. data:: DEBUG_DUMP

--- a/lemur/authorities/schemas.py
+++ b/lemur/authorities/schemas.py
@@ -110,6 +110,7 @@ class RootAuthorityCertificateOutputSchema(LemurOutputSchema):
     not_after = fields.DateTime()
     not_before = fields.DateTime()
     max_issuance_days = fields.Integer()
+    default_validity_days = fields.Integer()
     owner = fields.Email()
     status = fields.Boolean()
     user = fields.Nested(UserNestedOutputSchema)
@@ -135,7 +136,7 @@ class AuthorityNestedOutputSchema(LemurOutputSchema):
     owner = fields.Email()
     plugin = fields.Nested(PluginOutputSchema)
     active = fields.Boolean()
-    authority_certificate = fields.Nested(RootAuthorityCertificateOutputSchema, only=["max_issuance_days"])
+    authority_certificate = fields.Nested(RootAuthorityCertificateOutputSchema, only=["max_issuance_days", "default_validity_days"])
 
 
 authority_update_schema = AuthorityUpdateSchema()

--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -318,6 +318,14 @@ class Certificate(db.Model):
             return current_app.config.get("PUBLIC_CA_MAX_VALIDITY_DAYS", 397)
 
     @property
+    def default_validity_days(self):
+        public_CA = current_app.config.get("PUBLIC_CA_AUTHORITY_NAMES", [])
+        if self.name.lower() in [ca.lower() for ca in public_CA]:
+            return current_app.config.get("PUBLIC_CA_MAX_VALIDITY_DAYS", 397)
+
+        return current_app.config.get("DEFAULT_VALIDITY_DAYS", 365)   # 1 year default
+
+    @property
     def subject(self):
         return self.parsed_cert.subject
 

--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -317,8 +317,6 @@ class Certificate(db.Model):
         if self.name.lower() in [ca.lower() for ca in public_CA]:
             return current_app.config.get("PUBLIC_CA_MAX_VALIDITY_DAYS", 397)
 
-        return current_app.config.get("DEFAULT_MAX_VALIDITY_DAYS", 1095)   # 3 years default
-
     @property
     def subject(self):
         return self.parsed_cert.subject

--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -131,7 +131,7 @@ def map_fields(options, csr):
     elif options.get("validity_end"):
         data["custom_expiration_date"] = determine_end_date(options.get("validity_end")).format("YYYY-MM-DD")
         # check if validity got truncated. If resultant validity is not equal to requested validity, it just got truncated
-        if data["custom_expiration_date"] != options.get("validity_end"):
+        if data["custom_expiration_date"] != options.get("validity_end").format("YYYY-MM-DD"):
             log_validity_truncation(options, f"{__name__}.{sys._getframe().f_code.co_name}")
     else:
         data["validity_years"] = determine_validity_years(0)
@@ -185,6 +185,7 @@ def map_cis_fields(options, csr):
 
     return data
 
+
 def log_validity_truncation(options, function):
     log_data = {
         "cn": options["common_name"],
@@ -195,6 +196,7 @@ def log_validity_truncation(options, function):
     log_data["function"] = function
     log_data["message"] = "Digicert Plugin truncated the validity of certificate, cn = {0}".format(options["common_name"])
     current_app.logger.info(log_data)
+
 
 def handle_response(response):
     """

--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -194,7 +194,7 @@ def log_validity_truncation(options, function):
     metrics.send("digicert_validity_truncated", "counter", 1, metric_tags=log_data)
 
     log_data["function"] = function
-    log_data["message"] = "Digicert Plugin truncated the validity of certificate, cn = {0}".format(options["common_name"])
+    log_data["message"] = "Digicert Plugin truncated the validity of certificate"
     current_app.logger.info(log_data)
 
 

--- a/lemur/static/app/angular/certificates/certificate/certificate.js
+++ b/lemur/static/app/angular/certificates/certificate/certificate.js
@@ -107,7 +107,6 @@ angular.module('lemur')
       startingDay: 1
     };
 
-
     $scope.open1 = function() {
       $scope.popup1.opened = true;
     };
@@ -140,6 +139,12 @@ angular.module('lemur')
     );
 
     $scope.create = function (certificate) {
+      if(certificate.validityType === 'dates' &&
+          (!certificate.validityStart || !certificate.validityEnd)) { // these are not mandatory fields in schema, thus handling validation in js
+          return showMissingDateError();
+      }
+      delete certificate.validityType;
+
       WizardHandler.wizard().context.loading = true;
       CertificateService.create(certificate).then(
         function () {
@@ -163,6 +168,23 @@ angular.module('lemur')
           WizardHandler.wizard().context.loading = false;
         });
     };
+
+    function showMissingDateError() {
+      let error = {};
+        error.message = '';
+        error.reasons = {};
+        error.reasons.validityRange = 'Valid start and end dates are needed, else select Default option';
+
+        toaster.pop({
+          type: 'error',
+          title: 'Validation Error',
+          body: 'lemur-bad-request',
+          bodyOutputType: 'directive',
+          directiveData: error,
+          timeout: 100000
+        });
+        return;
+    }
 
     $scope.templates = [
       {

--- a/lemur/static/app/angular/certificates/certificate/tracking.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/tracking.tpl.html
@@ -96,7 +96,7 @@
         Certificate Authority
       </label>
       <div class="col-sm-10">
-        <ui-select class="input-md" ng-model="certificate.authority" theme="bootstrap" title="choose an authority">
+        <ui-select class="input-md" ng-model="certificate.authority" theme="bootstrap" title="choose an authority" ng-change="clearDates()">
           <ui-select-match placeholder="select an authority...">{{$select.selected.name}}</ui-select-match>
           <ui-select-choices class="form-control" repeat="authority in authorities"
                              refresh="getAuthoritiesByName($select.search)"
@@ -159,6 +159,7 @@
                  min-date="certificate.authority.authorityCertificate.notBefore"
                  alt-input-formats="altInputFormats"
                  placeholder="Start Date"
+                 readonly="true"
           />
           <span class="input-group-btn">
                         <button type="button" class="btn btn-default" ng-click="open1()"><i
@@ -179,6 +180,7 @@
                  min-date="certificate.authority.authorityCertificate.minValidityEnd"
                  alt-input-formats="altInputFormats"
                  placeholder="End Date"
+                 readonly="true"
           />
           <span class="input-group-btn">
                         <button type="button" class="btn btn-default" ng-click="open2()"><i

--- a/lemur/static/app/angular/certificates/certificate/tracking.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/tracking.tpl.html
@@ -133,7 +133,7 @@
       </div>
     <div class="form-group" ng-hide="certificate.authority.plugin.slug == 'acme-issuer'">
       <label class="control-label col-sm-2"
-             uib-tooltip="You can select custom date range, however we recommend continuing with default validity.">
+             uib-tooltip="You can select custom date range; however, we recommend continuing with default validity.">
         Validity Range <span class="glyphicon glyphicon-question-sign"></span>
       </label>
       <div class="col-sm-4">

--- a/lemur/static/app/angular/certificates/certificate/tracking.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/tracking.tpl.html
@@ -136,19 +136,17 @@
              uib-tooltip="If no date is selected Lemur attempts to issue a 1 year certificate">
         Validity Range <span class="glyphicon glyphicon-question-sign"></span>
       </label>
-      <div class="col-sm-2">
-        <select ng-model="certificate.validityYears" class="form-control">
-          <option value="">-</option>
-          <option value="1">1 year</option>
-        </select>
+      <div class="col-sm-4">
+        <div class="btn-group">
+          <label class="btn btn-success" ng-model="certificate.validityType" uib-btn-radio="'defaultDays'" ng-click="clearDates()">
+              Default ({{certificate.authority.authorityCertificate.defaultValidityDays}} days)</label>
+          <label class="btn btn-success" ng-model="certificate.validityType" uib-btn-radio="'dates'">Select Date</label>
+        </div>
       </div>
-      <span style="padding-top: 15px" class="text-center col-sm-1">
-                <strong>or</strong>
-            </span>
-      <div class="col-sm-3">
+      <div class="col-sm-3" ng-if="certificate.validityType==='dates'">
         <div class="input-group">
           <input type="text" class="form-control"
-                 uib-tooltip="yyyy/MM/dd"
+                 uib-tooltip="Start Date (yyyy/MM/dd)"
                  uib-datepicker-popup="yyyy/MM/dd"
                  ng-model="certificate.validityStart"
                  ng-change="certificate.setValidityEndDateRange(certificate.validityStart)"
@@ -167,10 +165,10 @@
                     </span>
         </div>
       </div>
-      <div class="col-sm-3">
+      <div class="col-sm-3" ng-if="certificate.validityType==='dates'">
         <div class="input-group">
           <input type="text" class="form-control"
-                 uib-tooltip="yyyy/MM/dd"
+                 uib-tooltip="End Date (yyyy/MM/dd)"
                  uib-datepicker-popup="yyyy/MM/dd"
                  ng-model="certificate.validityEnd"
                  is-open="popup2.opened"
@@ -187,10 +185,6 @@
                           class="glyphicon glyphicon-calendar"></i></button>
                     </span>
         </div>
-      </div>
-      <div class="col-sm-1">
-        <button uib-tooltip="Clear Validity" ng-click="clearDates()" class="btn btn-default"><i
-          class="glyphicon glyphicon-remove"></i></button>
       </div>
     </div>
     <div class="form-group" ng-show="certificate.authority.plugin.slug == 'acme-issuer'">

--- a/lemur/static/app/angular/certificates/certificate/tracking.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/tracking.tpl.html
@@ -133,17 +133,17 @@
       </div>
     <div class="form-group" ng-hide="certificate.authority.plugin.slug == 'acme-issuer'">
       <label class="control-label col-sm-2"
-             uib-tooltip="If no date is selected Lemur attempts to issue a 1 year certificate">
+             uib-tooltip="You can select custom date range, however we recommend continuing with default validity.">
         Validity Range <span class="glyphicon glyphicon-question-sign"></span>
       </label>
       <div class="col-sm-4">
-        <div class="btn-group">
-          <label class="btn btn-success" ng-model="certificate.validityType" uib-btn-radio="'defaultDays'" ng-click="clearDates()">
+        <div class="btn-group btn-group-toggle" data-toggle="buttons">
+          <label class="btn btn-info" ng-model="certificate.validityType" uib-btn-radio="'defaultDays'" ng-click="clearDates()">
               Default ({{certificate.authority.authorityCertificate.defaultValidityDays}} days)</label>
-          <label class="btn btn-success" ng-model="certificate.validityType" uib-btn-radio="'dates'">Select Date</label>
+          <label class="btn btn-info" ng-model="certificate.validityType" uib-btn-radio="'customDates'" ng-change="clearDates()">Custom</label>
         </div>
       </div>
-      <div class="col-sm-3" ng-if="certificate.validityType==='dates'">
+      <div class="col-sm-3" ng-if="certificate.validityType==='customDates'">
         <div class="input-group">
           <input type="text" class="form-control"
                  uib-tooltip="Start Date (yyyy/MM/dd)"
@@ -165,7 +165,7 @@
                     </span>
         </div>
       </div>
-      <div class="col-sm-3" ng-if="certificate.validityType==='dates'">
+      <div class="col-sm-3" ng-if="certificate.validityType==='customDates'">
         <div class="input-group">
           <input type="text" class="form-control"
                  uib-tooltip="End Date (yyyy/MM/dd)"

--- a/lemur/static/app/angular/certificates/services.js
+++ b/lemur/static/app/angular/certificates/services.js
@@ -197,7 +197,7 @@ angular.module('lemur')
     CertificateService.create = function (certificate) {
       certificate.attachSubAltName();
       certificate.attachCustom();
-      if (certificate.validityYears === '') { // if a user de-selects validity years we ignore it
+      if (certificate.validityYears === '') { // if a user de-selects validity years we ignore it - might not be needed anymore
         delete certificate.validityYears;
       }
       return CertificateApi.post(certificate);
@@ -282,6 +282,9 @@ angular.module('lemur')
 
         certificate.authority.authorityCertificate.minValidityEnd = defaults.authority.authorityCertificate.notBefore;
         certificate.authority.authorityCertificate.maxValidityEnd = defaults.authority.authorityCertificate.notAfter;
+
+        // pre-select validity type radio button to default days
+        certificate.validityType = 'defaultDays';
 
         if (certificate.dnsProviderId) {
           certificate.dnsProvider = {id: certificate.dnsProviderId};

--- a/lemur/static/app/angular/certificates/services.js
+++ b/lemur/static/app/angular/certificates/services.js
@@ -167,17 +167,19 @@ angular.module('lemur')
         },
         setValidityEndDateRange: function (value) {
           // clear selected validity end date as we are about to calculate new range
-          if(this.validityEnd) {
-            this.validityEnd = '';
-          }
-          
+          this.validityEnd = '';
+
           // Minimum end date will be same as selected start date
           this.authority.authorityCertificate.minValidityEnd = value;
 
-          // Move max end date by maxIssuanceDays
-          let endDate = new Date(value);
-          endDate.setDate(endDate.getDate() + this.authority.authorityCertificate.maxIssuanceDays);
-          this.authority.authorityCertificate.maxValidityEnd = endDate;
+          if(!this.authority.authorityCertificate || !this.authority.authorityCertificate.maxIssuanceDays) {
+            this.authority.authorityCertificate.maxValidityEnd = this.authority.authorityCertificate.notAfter;
+          } else {
+            // Move max end date by maxIssuanceDays
+            let endDate = new Date(value);
+            endDate.setDate(endDate.getDate() + this.authority.authorityCertificate.maxIssuanceDays);
+            this.authority.authorityCertificate.maxValidityEnd = endDate;
+          }
         }
       });
     });

--- a/lemur/static/app/angular/pending_certificates/services.js
+++ b/lemur/static/app/angular/pending_certificates/services.js
@@ -147,17 +147,19 @@ angular.module('lemur')
         },
         setValidityEndDateRange: function (value) {
           // clear selected validity end date as we are about to calculate new range
-          if(this.validityEnd) {
-            this.validityEnd = '';
-          }
+          this.validityEnd = '';
 
           // Minimum end date will be same as selected start date
           this.authority.authorityCertificate.minValidityEnd = value;
 
-          // Move max end date by maxIssuanceDays
-          let endDate = new Date(value);
-          endDate.setDate(endDate.getDate() + this.authority.authorityCertificate.maxIssuanceDays);
-          this.authority.authorityCertificate.maxValidityEnd = endDate;
+          if(!this.authority.authorityCertificate || !this.authority.authorityCertificate.maxIssuanceDays) {
+            this.authority.authorityCertificate.maxValidityEnd = this.authority.authorityCertificate.notAfter;
+          } else {
+            // Move max end date by maxIssuanceDays
+            let endDate = new Date(value);
+            endDate.setDate(endDate.getDate() + this.authority.authorityCertificate.maxIssuanceDays);
+            this.authority.authorityCertificate.maxValidityEnd = endDate;
+          }
         }
       });
     });


### PR DESCRIPTION
Selecting validity range of certificate from UI was offering a dropdown with 1 year validity option and datepicker. Now it is replaced with radio buttons offering 2 options
1. Default validity in terms of days: Configured through PUBLIC_CA_MAX_VALIDITY_DAYS and DEFAULT_VALIDITY_DAYS. This option is selected by default
2. Select custom dates - Selecting this options shows datepicker which offers a custom date range. For public CA configured through PUBLIC_CA_AUTHORITY_NAMES, the datepicker will allow end date within the PUBLIC_CA_MAX_VALIDITY_DAYS days from start date.

![image](https://user-images.githubusercontent.com/6845690/91785963-5ecb1280-ebbb-11ea-8607-9b47e09cebf8.png)
