### PR TITLE
Add SETUPTOOLS_USE_DISTUTILS environment variable to fix travis build issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ cache:
 env:
   global:
     - PIP_DOWNLOAD_CACHE=".pip_download_cache"
+    # The following line is a temporary workaround for this issue: https://github.com/pypa/setuptools/issues/2230
+    - SETUPTOOLS_USE_DISTUTILS=stdlib
     # do not load /etc/boto.cfg with Python 3 incompatible plugin
     # https://github.com/travis-ci/travis-ci/issues/5246#issuecomment-166460882
     - BOTO_CONFIG=/doesnotexist


### PR DESCRIPTION
Lemur build is failing due to distutils/setuptools issue.  This is a temporary fix for this issue. 
See for background. https://github.com/pypa/setuptools/issues/2230