### PR TITLE
Add redis configuration to celery documentation

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -328,6 +328,54 @@ Lemur supports sending certification expiration notifications through SES and SM
           LEMUR_SECURITY_TEAM_EMAIL_INTERVALS = [15, 2]
 
 
+Celery Options
+---------------
+To make use of automated tasks within lemur (e.g. syncing source/destinations, or reissuing ACME certificates), you
+need to configure celery. See :ref:`Periodic Tasks <PeriodicTasks>` for more in depth documentation.
+
+.. data:: CELERY_RESULT_BACKEND
+    :noindex:
+
+        The url to your redis backend (needs to be in the format `redis://<host>:<port>/<database>`)
+
+.. data:: CELERY_BROKER_URL
+    :noindex:
+
+        The url to your redis broker (needs to be in the format `redis://<host>:<port>/<database>`)
+
+.. data:: CELERY_IMPORTS
+    :noindex:
+
+        The module that celery needs to import, in our case thats `lemur.common.celery`
+
+.. data:: CELERY_TIMEZONE
+    :noindex:
+
+        The timezone for celery to work with
+
+
+.. data:: CELERYBEAT_SCHEDULE
+    :noindex:
+
+        This defines the schedule, with which the celery beat makes the worker run the specified tasks.
+
+Since the celery module, relies on the RedisHandler, the following options also need to be set.
+
+.. data:: REDIS_HOST
+    :noindex:
+
+        Hostname of your redis instance
+
+.. data:: REDIS_PORT
+    :noindex:
+
+        Port on which redis is running (default: 6379)
+
+.. data:: REDIS_DB
+    :noindex:
+
+        Which redis database to be used, by default redis offers databases 0-15 (default: 0)
+
 Authentication Options
 ----------------------
 Lemur currently supports Basic Authentication, LDAP Authentication, Ping OAuth2, and Google out of the box. Additional flows can be added relatively easily.

--- a/docs/production/index.rst
+++ b/docs/production/index.rst
@@ -315,6 +315,7 @@ It will start a shell from which you can start/stop/restart the service.
 
 You can read all errors that might occur from /tmp/lemur.log.
 
+.. _PeriodicTasks:
 
 Periodic Tasks
 ==============

--- a/docs/production/index.rst
+++ b/docs/production/index.rst
@@ -388,12 +388,16 @@ To enable celery support, you must also have configuration values that tell Cele
 Here are the Celery configuration variables that should be set::
 
     CELERY_RESULT_BACKEND = 'redis://your_redis_url:6379'
-    CELERY_BROKER_URL = 'redis://your_redis_url:6379'
+    CELERY_BROKER_URL = 'redis://your_redis_url:6379/0'
     CELERY_IMPORTS = ('lemur.common.celery')
     CELERY_TIMEZONE = 'UTC'
 
     REDIS_HOST="your_redis_url"
-    REDIS_PORT="6379"
+    REDIS_PORT=6379
+    REDIS_DB=0
+
+Out of the box, every Redis instance supports 16 databases. The default database (`REDIS_DB`) is  set to 0, however, you can use any of the databases from 0-15. Via `redis.conf` more databases can be supported.
+In the `redis://` url, the database number needs to be added with a slash after the port.
 
 Do not forget to import crontab module in your configuration file::
 

--- a/docs/production/index.rst
+++ b/docs/production/index.rst
@@ -398,7 +398,7 @@ Here are the Celery configuration variables that should be set::
     REDIS_DB=0
 
 Out of the box, every Redis instance supports 16 databases. The default database (`REDIS_DB`) is  set to 0, however, you can use any of the databases from 0-15. Via `redis.conf` more databases can be supported.
-In the `redis://` url, the database number needs to be added with a slash after the port.
+In the `redis://` url, the database number can be added with a slash after the port. (defaults to 0, if omitted)
 
 Do not forget to import crontab module in your configuration file::
 

--- a/docs/production/index.rst
+++ b/docs/production/index.rst
@@ -390,6 +390,9 @@ Here are the Celery configuration variables that should be set::
     CELERY_IMPORTS = ('lemur.common.celery')
     CELERY_TIMEZONE = 'UTC'
 
+    REDIS_HOST="your_redis_url"
+    REDIS_PORT="6379"
+
 Do not forget to import crontab module in your configuration file::
 
     from celery.task.schedules import crontab


### PR DESCRIPTION
Currently when adding the celery config, the RedisHandler still tries to connect to `locahost:6379` even if a different `CELERY_BROKER_URL ` and `CELERY_BACKEND` is configured.

This documentation update, adds the configurations necessary, for the RedisHandler to properly use the same redis instance as celery.

Fixes #3147 