### PR TITLE
ACME documentation improvement

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -1171,6 +1171,23 @@ The following configuration properties are required to use the PowerDNS ACME Plu
 
             File/Dir path to CA Bundle: Verifies the TLS certificate was issued by a Certificate Authority in the provided CA bundle.
 
+ACME Plugin
+~~~~~~~~~~~~
+
+The following configration properties are optional for the ACME plugin to use. They allow reusing an existing ACME
+account.
+
+
+.. data:: ACME_PRIVATE_KEY
+    :noindex:
+
+            This is the private key, the account was registered with (in JWK format)
+
+.. data:: ACME_REGR
+    :noindex:
+
+            This is the registration for the ACME account, the most important part is the uri attribute (in JSON)
+
 .. _CommandLineInterface:
 
 Command Line Interface

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -1175,7 +1175,7 @@ ACME Plugin
 ~~~~~~~~~~~~
 
 The following configration properties are optional for the ACME plugin to use. They allow reusing an existing ACME
-account.
+account. See :ref:`Using a pre-existing ACME account <AcmeAccountReuse>` for more details.
 
 
 .. data:: ACME_PRIVATE_KEY

--- a/docs/production/index.rst
+++ b/docs/production/index.rst
@@ -513,6 +513,8 @@ The following must be added to the config file to activate the pinning (the pinn
     """
 
 
+.. _AcmeAccountReuse:
+
 LetsEncrypt: Using a pre-existing ACME account
 -----------------------------------------------
 

--- a/docs/production/index.rst
+++ b/docs/production/index.rst
@@ -540,7 +540,7 @@ configuration.
     }
 
 
-Using `python-jwt` converting a existing private key in PEM format is quite easy::
+Using `python-jwt` converting an existing private key in PEM format is quite easy::
 
     import python_jwt as jwt, jwcrypto.jwk as jwk
 
@@ -554,4 +554,4 @@ Using `python-jwt` converting a existing private key in PEM format is quite easy
 
     {"body": {}, "uri": "https://acme-staging-v02.api.letsencrypt.org/acme/acct/<ACCOUNT_NUMBER>"}
 
-The uri can be retrieved from the ACME create account endpoint, when trying to create a new account, using the existing key.
+The URI can be retrieved from the ACME create account endpoint when creating a new account, using the existing key.

--- a/docs/production/index.rst
+++ b/docs/production/index.rst
@@ -511,3 +511,45 @@ The following must be added to the config file to activate the pinning (the pinn
     KOqkqm57TH2H3eDJAkSnh6/DNFu0Qg==
     -----END CERTIFICATE-----
     """
+
+
+LetsEncrypt: Using a pre-existing ACME account
+-----------------------------------------------
+
+Let's Encrypt allows reusing an existing ACME account, to create and especially revoke certificates. The current
+implementation in the acme plugin, only allows for a single account for all ACME authorities, which might be an issue,
+when you try to use Let's Encrypt together with another certificate authority that uses the ACME protocol.
+
+To use an existing account, you need to configure the `ACME_PRIVATE_KEY` and `ACME_REGR` variables in the lemur
+configuration.
+
+`ACME_PRIVATE_KEY` needs to be in the JWK format::
+
+    {
+        "kty": "RSA",
+        "n": "yr1qBwHizA7ME_iV32bY10ILp.....",
+        "e": "AQAB",
+        "d": "llBlYhil3I.....",
+        "p": "-5LW2Lewogo.........",
+        "q": "zk6dHqHfHksd.........",
+        "dp": "qfe9fFIu3mu.......",
+        "dq": "cXFO-loeOyU.......",
+        "qi": "AfK1sh0_8sLTb..........."
+    }
+
+
+Using `python-jwt` converting a existing private key in PEM format is quite easy::
+
+    import python_jwt as jwt, jwcrypto.jwk as jwk
+
+    priv_key = jwk.JWK.from_pem(b"""-----BEGIN RSA PRIVATE KEY-----
+    ...
+    -----END RSA PRIVATE KEY-----""")
+
+    print(priv_key.export())
+
+`ACME_REGR` needs to be a valid JSON with a `body` and a `uri` attribute, similar to this::
+
+    {"body": {}, "uri": "https://acme-staging-v02.api.letsencrypt.org/acme/acct/<ACCOUNT_NUMBER>"}
+
+The uri can be retrieved from the ACME create account endpoint, when trying to create a new account, using the existing key.


### PR DESCRIPTION
Adds documentation how to reuse an ACME account.

Additionally also adds the configuration parameters, to the configuration documentation.

Fixes #3149