### PR TITLE
Add key_type to CertificateUploadInputSchema

### DIFF
--- a/lemur/certificates/schemas.py
+++ b/lemur/certificates/schemas.py
@@ -376,7 +376,13 @@ class CertificateUploadInputSchema(CertificateCreationSchema):
 
     @pre_load
     def load_data(self, data):
-        data["key_type"] = utils.get_key_type_from_certificate(data["body"])
+        if data.get("body"):
+            try:
+                data["key_type"] = utils.get_key_type_from_certificate(data["body"])
+            except ValueError:
+                raise ValidationError(
+                    "Public certificate presented is not valid.", field_names=["body"]
+                )
 
 
 class CertificateExportInputSchema(LemurInputSchema):

--- a/lemur/certificates/schemas.py
+++ b/lemur/certificates/schemas.py
@@ -326,6 +326,7 @@ class CertificateUploadInputSchema(CertificateCreationSchema):
     body = fields.String(required=True)
     chain = fields.String(missing=None, allow_none=True)
     csr = fields.String(required=False, allow_none=True, validate=validators.csr)
+    key_type = fields.String()
 
     destinations = fields.Nested(AssociatedDestinationSchema, missing=[], many=True)
     notifications = fields.Nested(AssociatedNotificationSchema, missing=[], many=True)
@@ -372,6 +373,10 @@ class CertificateUploadInputSchema(CertificateCreationSchema):
 
             # Throws ValidationError
             validators.verify_cert_chain([cert] + chain)
+
+    @pre_load
+    def load_data(self, data):
+        data["key_type"] = utils.get_key_type_from_certificate(data["body"])
 
 
 class CertificateExportInputSchema(LemurInputSchema):

--- a/lemur/tests/test_pending_certificates.py
+++ b/lemur/tests/test_pending_certificates.py
@@ -55,6 +55,7 @@ def test_create_pending(pending_certificate, user, session):
     assert real_cert.notify == pending_certificate.notify
     assert real_cert.private_key == pending_certificate.private_key
     assert real_cert.external_id == "54321"
+    assert real_cert.key_type == "RSA2048"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Parse cert body to determine algo
-----------------------------------------
This change is needed for asynchronous certificate issuance e.g. Let's Encrypt issued certificates. The body of the resolved certificate is parsed to determine the algorithm.