### PR TITLE
Fix dns-providers type missing from schema

### DIFF
--- a/lemur/dns_providers/schemas.py
+++ b/lemur/dns_providers/schemas.py
@@ -8,7 +8,7 @@ class DnsProvidersNestedOutputSchema(LemurOutputSchema):
     __envelope__ = False
     id = fields.Integer()
     name = fields.String()
-    providerType = fields.String()
+    provider_type = fields.String()
     description = fields.String()
     credentials = fields.String()
     api_endpoint = fields.String()


### PR DESCRIPTION
Fixes the missing provider_type in the DNS providers list

Fixes #3165
