### PR TITLE
Remove bit length check from last query

### DIFF
--- a/lemur/migrations/versions/c301c59688d2_.py
+++ b/lemur/migrations/versions/c301c59688d2_.py
@@ -90,7 +90,7 @@ def update_key_type():
     # Loop through all certificates that are valid today or expired in the last 30 days.
     for cert_id, body in conn.execute(
             text(
-                "select id, body from certificates where bits < 1024 and not_after > CURRENT_DATE - 31 and key_type is null")
+                "select id, body from certificates where not_after > CURRENT_DATE - 31 and key_type is null")
     ):
         try:
             cert_key_type = utils.get_key_type_from_certificate(body)


### PR DESCRIPTION
This change will include valid keys with bits set to null during the backfill.
-------------------------------------------------
Upgrade script initially modifies the key_type info of the keys with bit length 1024, 2048 and 4096. So remaining keys with _key_type=null_ are indeed of length <1024. In that sense this check is redundant and it is not considering keys with bits set to null