### PR TITLE
Authority create: Email added to subject DN

### DIFF
--- a/lemur/authorities/schemas.py
+++ b/lemur/authorities/schemas.py
@@ -50,6 +50,8 @@ class AuthorityInputSchema(LemurInputSchema):
         missing=lambda: current_app.config.get("LEMUR_DEFAULT_COUNTRY")
     )
     state = fields.String(missing=lambda: current_app.config.get("LEMUR_DEFAULT_STATE"))
+    # Creating a String field instead of Email to allow empty value
+    email = fields.String()
 
     plugin = fields.Nested(PluginInputSchema)
 

--- a/lemur/authorities/schemas.py
+++ b/lemur/authorities/schemas.py
@@ -43,9 +43,7 @@ class AuthorityInputSchema(LemurInputSchema):
     organization = fields.String(
         missing=lambda: current_app.config.get("LEMUR_DEFAULT_ORGANIZATION")
     )
-    location = fields.String(
-        missing=lambda: current_app.config.get("LEMUR_DEFAULT_LOCATION")
-    )
+    location = fields.String()
     country = fields.String(
         missing=lambda: current_app.config.get("LEMUR_DEFAULT_COUNTRY")
     )

--- a/lemur/certificates/schemas.py
+++ b/lemur/certificates/schemas.py
@@ -107,9 +107,7 @@ class CertificateInputSchema(CertificateCreationSchema):
     organization = fields.String(
         missing=lambda: current_app.config.get("LEMUR_DEFAULT_ORGANIZATION")
     )
-    location = fields.String(
-        missing=lambda: current_app.config.get("LEMUR_DEFAULT_LOCATION")
-    )
+    location = fields.String()
     country = fields.String(
         missing=lambda: current_app.config.get("LEMUR_DEFAULT_COUNTRY")
     )

--- a/lemur/static/app/angular/authorities/authority/authority.js
+++ b/lemur/static/app/angular/authorities/authority/authority.js
@@ -125,8 +125,7 @@ angular.module('lemur')
     };
 
     $scope.populateSubjectEmail = function () {
-      if($scope.authority.plugin.title.toLowerCase() === 'cloudca')
-        $scope.authority.email = $scope.authority.owner;
+      $scope.authority.email = $scope.authority.owner;
     };
 
   });

--- a/lemur/static/app/angular/authorities/authority/authority.js
+++ b/lemur/static/app/angular/authorities/authority/authority.js
@@ -124,4 +124,9 @@ angular.module('lemur')
       opened: false
     };
 
+    $scope.populateSubjectEmail = function () {
+      if($scope.authority.plugin.title.toLowerCase() === 'cloudca')
+        $scope.authority.email = $scope.authority.owner;
+    };
+
   });

--- a/lemur/static/app/angular/authorities/authority/distinguishedName.tpl.html
+++ b/lemur/static/app/angular/authorities/authority/distinguishedName.tpl.html
@@ -49,6 +49,15 @@
         <input name="organizationalUnit" ng-model="authority.organizationalUnit" placeholder="Organizational Unit" class="form-control"/>
       </div>
     </div>
+    <div class="form-group" ng-if="authority.plugin.title.toLowerCase()==='cloudca'"
+         ng-class="{'has-error': dnForm.email.$invalid, 'has-success': !dnForm.$invalid&&dnForm.email.$dirty}">
+      <label class="control-label col-sm-2">
+        Email
+      </label>
+      <div class="col-sm-10">
+        <input type="email" name="email" ng-model="authority.email" placeholder="Email Address" class="form-control"/>
+      </div>
+    </div>
   </div>
 </form>
 

--- a/lemur/static/app/angular/authorities/authority/distinguishedName.tpl.html
+++ b/lemur/static/app/angular/authorities/authority/distinguishedName.tpl.html
@@ -49,7 +49,7 @@
         <input name="organizationalUnit" ng-model="authority.organizationalUnit" placeholder="Organizational Unit" class="form-control"/>
       </div>
     </div>
-    <div class="form-group" ng-if="authority.plugin.title.toLowerCase()==='cloudca'"
+    <div class="form-group"
          ng-class="{'has-error': dnForm.email.$invalid, 'has-success': !dnForm.$invalid&&dnForm.email.$dirty}">
       <label class="control-label col-sm-2">
         Email

--- a/lemur/static/app/angular/authorities/authority/distinguishedName.tpl.html
+++ b/lemur/static/app/angular/authorities/authority/distinguishedName.tpl.html
@@ -26,8 +26,7 @@
         Location
       </label>
       <div class="col-sm-10">
-        <input name="location" ng-model="authority.location" placeholder="Location" class="form-control" required/>
-        <p ng-show="dnForm.location.$invalid && !dnForm.location.$pristine" class="help-block">You must enter a location</p>
+        <input name="location" ng-model="authority.location" placeholder="Location" class="form-control"/>
       </div>
     </div>
     <div class="form-group"

--- a/lemur/static/app/angular/authorities/authority/tracking.tpl.html
+++ b/lemur/static/app/angular/authorities/authority/tracking.tpl.html
@@ -21,7 +21,7 @@
             <div class="col-sm-10">
                 <input type="email" name="owner" ng-model="authority.owner" placeholder="TeamDL@example.com"
                        uib-tooltip="This is the authorities team distribution list or the main point of contact for this authority"
-                       class="form-control" required/>
+                       class="form-control" ng-change="populateSubjectEmail()" required/>
                 <p ng-show="trackingForm.owner.$invalid && !trackingForm.owner.$pristine" class="help-block">You must
                     enter an Certificate Authority owner</p>
             </div>

--- a/lemur/static/app/angular/certificates/certificate/distinguishedName.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/distinguishedName.tpl.html
@@ -38,9 +38,7 @@
         Location
       </label>
       <div class="col-sm-10">
-        <input name="location" ng-model="certificate.location" placeholder="Location" class="form-control" required/>
-        <p ng-show="dnForm.location.$invalid && !dnForm.location.$pristine" class="help-block">You must enter a
-          location</p>
+        <input name="location" ng-model="certificate.location" placeholder="Location" class="form-control"/>
       </div>
     </div>
     <div class="form-group"

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -154,7 +154,7 @@ def test_get_certificate_primitives(certificate):
 
     with freeze_time(datetime.date(year=2016, month=10, day=30)):
         primitives = get_certificate_primitives(certificate)
-        assert len(primitives) == 26
+        assert len(primitives) == 25
         assert (primitives["key_type"] == "RSA2048")
 
 
@@ -254,17 +254,18 @@ def test_certificate_input_schema(client, authority):
         "validityStart": arrow.get(2018, 11, 9).isoformat(),
         "validityEnd": arrow.get(2019, 11, 9).isoformat(),
         "dnsProvider": None,
+        "location": "A Place"
     }
 
     data, errors = CertificateInputSchema().load(input_data)
 
     assert not errors
     assert data["authority"].id == authority.id
+    assert data["location"] == "A Place"
 
     # make sure the defaults got set
     assert data["common_name"] == "test.example.com"
     assert data["country"] == "US"
-    assert data["location"] == "Los Gatos"
 
     assert len(data.keys()) == 19
 


### PR DESCRIPTION
Added Email to distinguished name options during CA creation.
The owner email will be copied over to Email filed by default. It can be modified to be empty before submitting the form.