### PR TITLE
Fix disable notify

### DIFF
--- a/lemur/certificates/schemas.py
+++ b/lemur/certificates/schemas.py
@@ -194,7 +194,7 @@ class CertificateEditInputSchema(CertificateSchema):
         :param data:
         :return:
         """
-        if data["owner"]:
+        if data.get("owner"):
             notification_name = "DEFAULT_{0}".format(
                 data["owner"].split("@")[0].upper()
             )

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -256,6 +256,17 @@ def update(cert_id, **kwargs):
     return database.update(cert)
 
 
+def update_notify(cert, notify_flag):
+    """
+    Toggle notification value which is a boolean
+    :param notify_flag: new notify value
+    :param cert: Certificate object to be updated
+    :return:
+    """
+    cert.notify = notify_flag
+    return database.update(cert)
+
+
 def create_certificate_roles(**kwargs):
     # create an role for the owner and assign it
     owner_role = role_service.get_by_name(kwargs["owner"])

--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -888,6 +888,110 @@ class Certificates(AuthenticatedResource):
         log_service.create(g.current_user, "update_cert", certificate=cert)
         return cert
 
+    @validate_schema(certificate_edit_input_schema, certificate_output_schema)
+    def post(self, certificate_id, data=None):
+        """
+        .. http:post:: /certificates/1/update/notify
+
+           Update certificate notification
+
+           **Example request**:
+
+           .. sourcecode:: http
+
+              POST /certificates/1/update/notify HTTP/1.1
+              Host: example.com
+              Accept: application/json, text/javascript
+
+              {
+                 "notify": false
+              }
+
+           **Example response**:
+
+           .. sourcecode:: http
+
+              HTTP/1.1 200 OK
+              Vary: Accept
+              Content-Type: text/javascript
+
+              {
+                "status": null,
+                "cn": "*.test.example.net",
+                "chain": "",
+                "authority": {
+                    "active": true,
+                    "owner": "secure@example.com",
+                    "id": 1,
+                    "description": "verisign test authority",
+                    "name": "verisign"
+                },
+                "owner": "joe@example.com",
+                "serial": "82311058732025924142789179368889309156",
+                "id": 2288,
+                "issuer": "SymantecCorporation",
+                "dateCreated": "2016-06-03T06:09:42.133769+00:00",
+                "notBefore": "2016-06-03T00:00:00+00:00",
+                "notAfter": "2018-01-12T23:59:59+00:00",
+                "destinations": [],
+                "bits": 2048,
+                "body": "-----BEGIN CERTIFICATE-----...",
+                "description": null,
+                "deleted": null,
+                "notify": false,
+                "notifications": [{
+                    "id": 1
+                }]
+                "signingAlgorithm": "sha256",
+                "user": {
+                    "username": "jane",
+                    "active": true,
+                    "email": "jane@example.com",
+                    "id": 2
+                },
+                "active": true,
+                "domains": [{
+                    "sensitive": false,
+                    "id": 1090,
+                    "name": "*.test.example.net"
+                }],
+                "replaces": [],
+                "name": "WILDCARD.test.example.net-SymantecCorporation-20160603-20180112",
+                "roles": [{
+                    "id": 464,
+                    "description": "This is a google group based role created by Lemur",
+                    "name": "joe@example.com"
+                }],
+                "rotation": true,
+                "rotationPolicy": {"name": "default"},
+                "san": null
+              }
+
+           :reqheader Authorization: OAuth token to authenticate
+           :statuscode 200: no error
+           :statuscode 403: unauthenticated
+
+        """
+        cert = service.get(certificate_id)
+
+        if not cert:
+            return dict(message="Cannot find specified certificate"), 404
+
+        # allow creators
+        if g.current_user != cert.user:
+            owner_role = role_service.get_by_name(cert.owner)
+            permission = CertificatePermission(owner_role, [x.name for x in cert.roles])
+
+            if not permission.can():
+                return (
+                    dict(message="You are not authorized to update this certificate"),
+                    403,
+                )
+
+        cert = service.update_notify(cert, data.get("notify"))
+        log_service.create(g.current_user, "update_cert", certificate=cert)
+        return cert
+
     def delete(self, certificate_id, data=None):
         """
         .. http:delete:: /certificates/1
@@ -1353,6 +1457,9 @@ api.add_resource(
 )
 api.add_resource(
     Certificates, "/certificates/<int:certificate_id>", endpoint="certificate"
+)
+api.add_resource(
+    Certificates, "/certificates/<int:certificate_id>/update/notify", endpoint="certificateUpdateNotify"
 )
 api.add_resource(CertificatesStats, "/certificates/stats", endpoint="certificateStats")
 api.add_resource(

--- a/lemur/static/app/angular/certificates/services.js
+++ b/lemur/static/app/angular/certificates/services.js
@@ -301,7 +301,7 @@ angular.module('lemur')
     };
 
     CertificateService.updateNotify = function (certificate) {
-      return certificate.put();
+      return certificate.post();
     };
 
     CertificateService.export = function (certificate) {

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -922,19 +922,25 @@ def test_certificate_get_body(client):
 @pytest.mark.parametrize(
     "token,status",
     [
-        (VALID_USER_HEADER_TOKEN, 405),
-        (VALID_ADMIN_HEADER_TOKEN, 405),
-        (VALID_ADMIN_API_TOKEN, 405),
-        ("", 405),
+        (VALID_USER_HEADER_TOKEN, 403),
+        (VALID_ADMIN_HEADER_TOKEN, 200),
+        (VALID_ADMIN_API_TOKEN, 200),
+        ("", 401),
     ],
 )
-def test_certificate_post(client, token, status):
-    assert (
-        client.post(
-            api.url_for(Certificates, certificate_id=1), data={}, headers=token
-        ).status_code
-        == status
+def test_certificate_post_update_notify(client, certificate, token, status):
+    # negate the current notify flag and pass it to update POST call to flip the notify
+    toggled_notify = not certificate.notify
+
+    response = client.post(
+        api.url_for(Certificates, certificate_id=certificate.id),
+        data=json.dumps({"notify": toggled_notify}),
+        headers=token
     )
+    
+    assert response.status_code == status
+    if status == 200:
+        assert response.json.get("notify") == toggled_notify
 
 
 @pytest.mark.parametrize(

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -937,7 +937,7 @@ def test_certificate_post_update_notify(client, certificate, token, status):
         data=json.dumps({"notify": toggled_notify}),
         headers=token
     )
-    
+
     assert response.status_code == status
     if status == 200:
         assert response.json.get("notify") == toggled_notify


### PR DESCRIPTION
Updating notification from Certificates table is clearing few other fields of the certificate like description, role.
Introducing a new minimal API that would just update notification information.