### PR TITLE
cab_compliant option in authority

### DIFF
--- a/docker/src/lemur.conf.py
+++ b/docker/src/lemur.conf.py
@@ -24,7 +24,7 @@ LEMUR_TOKEN_SECRET = repr(os.environ.get('LEMUR_TOKEN_SECRET',
 LEMUR_ENCRYPTION_KEYS = repr(os.environ.get('LEMUR_ENCRYPTION_KEYS',
                                             base64.b64encode(get_random_secret(32).encode('utf8'))))
 
-LEMUR_WHITELISTED_DOMAINS = []
+LEMUR_ALLOWED_DOMAINS = []
 
 LEMUR_EMAIL = ''
 LEMUR_SECURITY_TEAM_EMAIL = []

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -100,7 +100,7 @@ Specifying the `SQLALCHEMY_MAX_OVERFLOW` to 0 will enforce limit to not create c
 
         Specifies whether to allow certificates created by Lemur to expire on weekends. Default is True.
 
-.. data:: LEMUR_WHITELISTED_DOMAINS
+.. data:: LEMUR_ALLOWED_DOMAINS
     :noindex:
 
         List of regular expressions for domain restrictions; if the list is not empty, normal users can only issue

--- a/lemur/authorities/models.py
+++ b/lemur/authorities/models.py
@@ -6,6 +6,8 @@
     :license: Apache, see LICENSE for more details.
 .. moduleauthor:: Kevin Glisson <kglisson@netflix.com>
 """
+import json
+
 from sqlalchemy.orm import relationship
 from sqlalchemy import (
     Column,
@@ -79,6 +81,21 @@ class Authority(db.Model):
     @property
     def plugin(self):
         return plugins.get(self.plugin_name)
+
+    @property
+    def is_cab_compliant(self):
+        """
+        Parse the options to find whether authority is CAB Compliant. Returns None if
+        option is not available
+        """
+        if not self.options:
+            return None
+
+        for option in json.loads(self.options):
+            if option["name"] == 'cab_compliant':
+                return option["value"]
+
+        return None
 
     def __repr__(self):
         return "Authority(name={name})".format(name=self.name)

--- a/lemur/authorities/schemas.py
+++ b/lemur/authorities/schemas.py
@@ -139,6 +139,7 @@ class AuthorityNestedOutputSchema(LemurOutputSchema):
     plugin = fields.Nested(PluginOutputSchema)
     active = fields.Boolean()
     authority_certificate = fields.Nested(RootAuthorityCertificateOutputSchema, only=["max_issuance_days", "default_validity_days"])
+    is_cab_compliant = fields.Boolean()
 
 
 authority_update_schema = AuthorityUpdateSchema()

--- a/lemur/authorities/service.py
+++ b/lemur/authorities/service.py
@@ -54,6 +54,7 @@ def update_options(authority_id, options):
 
     return database.update(authority)
 
+
 def mint(**kwargs):
     """
     Creates the authority based on the plugin provided.

--- a/lemur/authorities/service.py
+++ b/lemur/authorities/service.py
@@ -39,6 +39,21 @@ def update(authority_id, description, owner, active, roles):
     return database.update(authority)
 
 
+def update_options(authority_id, options):
+    """
+    Update an authority with new options.
+
+    :param authority_id:
+    :param options: the new options to be saved into the authority
+    :return:
+    """
+
+    authority = get(authority_id)
+
+    authority.options = options
+
+    return database.update(authority)
+
 def mint(**kwargs):
     """
     Creates the authority based on the plugin provided.

--- a/lemur/common/validators.py
+++ b/lemur/common/validators.py
@@ -22,7 +22,7 @@ def common_name(value):
 
 def sensitive_domain(domain):
     """
-    Checks if user has the admin role, the domain does not match sensitive domains and whitelisted domain patterns.
+    Checks if user has the admin role, the domain does not match sensitive domains and allowed domain patterns.
     :param domain: domain name (str)
     :return:
     """
@@ -30,10 +30,10 @@ def sensitive_domain(domain):
         # User has permission, no need to check anything
         return
 
-    whitelist = current_app.config.get("LEMUR_WHITELISTED_DOMAINS", [])
-    if whitelist and not any(re.match(pattern, domain) for pattern in whitelist):
+    allowlist = current_app.config.get("LEMUR_ALLOWED_DOMAINS", [])
+    if allowlist and not any(re.match(pattern, domain) for pattern in allowlist):
         raise ValidationError(
-            "Domain {0} does not match whitelisted domain patterns. "
+            "Domain {0} does not match allowed domain patterns. "
             "Contact an administrator to issue the certificate.".format(domain)
         )
 

--- a/lemur/manage.py
+++ b/lemur/manage.py
@@ -95,7 +95,7 @@ LEMUR_TOKEN_SECRET = '{secret_token}'
 LEMUR_ENCRYPTION_KEYS = '{encryption_key}'
 
 # List of domain regular expressions that non-admin users can issue
-LEMUR_WHITELISTED_DOMAINS = []
+LEMUR_ALLOWED_DOMAINS = []
 
 # Mail Server
 

--- a/lemur/plugins/lemur_acme/plugin.py
+++ b/lemur/plugins/lemur_acme/plugin.py
@@ -476,7 +476,7 @@ class ACMEIssuerPlugin(IssuerPlugin):
             "type": "bool",
             "required": False,
             "helpMessage": "Disable to create a new account for each ACME request",
-            "default": True,
+            "default": False,
         }
     ]
 

--- a/lemur/plugins/lemur_acme/plugin.py
+++ b/lemur/plugins/lemur_acme/plugin.py
@@ -32,6 +32,7 @@ from lemur.extensions import metrics, sentry
 from lemur.plugins import lemur_acme as acme
 from lemur.plugins.bases import IssuerPlugin
 from lemur.plugins.lemur_acme import cloudflare, dyn, route53, ultradns, powerdns
+from lemur.authorities import service as authorities_service
 from retrying import retry
 
 
@@ -264,6 +265,27 @@ class AcmeHandler(object):
             registration = client.new_account_and_tos(
                 messages.NewRegistration.from_data(email=email)
             )
+
+            # if store_account is checked, add the private_key and registration resources to the options
+            if options['store_account']:
+                new_options = json.loads(authority.options)
+                # the key returned by fields_to_partial_json is missing the key type, so we add it manually
+                key_dict = key.fields_to_partial_json()
+                key_dict["kty"] = "RSA"
+                acme_private_key = {
+                    "name": "acme_private_key",
+                    "value": json.dumps(key_dict)
+                }
+                new_options.append(acme_private_key)
+
+                acme_regr = {
+                    "name": "acme_regr",
+                    "value": json.dumps({"body": {}, "uri": registration.uri})
+                }
+                new_options.append(acme_regr)
+
+                authorities_service.update_options(authority.id, options=json.dumps(new_options))
+
             current_app.logger.debug("Connected: {0}".format(registration.uri))
 
         return client, registration

--- a/lemur/plugins/lemur_acme/plugin.py
+++ b/lemur/plugins/lemur_acme/plugin.py
@@ -240,6 +240,7 @@ class AcmeHandler(object):
         existing_regr = options.get("acme_regr", current_app.config.get("ACME_REGR"))
 
         if existing_key and existing_regr:
+            current_app.logger.debug("Reusing existing ACME account")
             # Reuse the same account for each certificate issuance
             key = jose.JWK.json_loads(existing_key)
             regr = messages.RegistrationResource.json_loads(existing_regr)
@@ -253,6 +254,7 @@ class AcmeHandler(object):
             # Create an account for each certificate issuance
             key = jose.JWKRSA(key=generate_private_key("RSA2048"))
 
+            current_app.logger.debug("Creating a new ACME account")
             current_app.logger.debug(
                 "Connecting with directory at {0}".format(directory_url)
             )
@@ -447,6 +449,13 @@ class ACMEIssuerPlugin(IssuerPlugin):
             "validation": "/^-----BEGIN CERTIFICATE-----/",
             "helpMessage": "Certificate to use",
         },
+        {
+            "name": "store_account",
+            "type": "bool",
+            "required": False,
+            "helpMessage": "Disable to create a new account for each ACME request",
+            "default": True,
+        }
     ]
 
     def __init__(self, *args, **kwargs):

--- a/lemur/plugins/lemur_acme/tests/test_acme.py
+++ b/lemur/plugins/lemur_acme/tests/test_acme.py
@@ -165,12 +165,42 @@ class TestAcme(unittest.TestCase):
         with self.assertRaises(Exception):
             self.acme.setup_acme_client(mock_authority)
 
+    @patch("lemur.plugins.lemur_acme.plugin.jose.JWKRSA.fields_to_partial_json")
+    @patch("lemur.plugins.lemur_acme.plugin.authorities_service")
+    @patch("lemur.plugins.lemur_acme.plugin.BackwardsCompatibleClientV2")
+    @patch("lemur.plugins.lemur_acme.plugin.current_app")
+    def test_setup_acme_client_success_store_new_account(self, mock_current_app, mock_acme, mock_authorities_service,
+                                                         mock_key_generation):
+        mock_authority = Mock()
+        mock_authority.id = 2
+        mock_authority.options = '[{"name": "mock_name", "value": "mock_value"}, ' \
+                                 '{"name": "store_account", "value": true}]'
+        mock_client = Mock()
+        mock_registration = Mock()
+        mock_registration.uri = "http://test.com"
+        mock_client.register = mock_registration
+        mock_client.agree_to_tos = Mock(return_value=True)
+        mock_client.new_account_and_tos.return_value = mock_registration
+        mock_acme.return_value = mock_client
+        mock_current_app.config = {}
+
+        mock_key_generation.return_value = {"n": "PwIOkViO"}
+
+        mock_authorities_service.update_options = Mock(return_value=True)
+
+        self.acme.setup_acme_client(mock_authority)
+
+        mock_authorities_service.update_options.assert_called_with(2, options='[{"name": "mock_name", "value": "mock_value"}, '
+        '{"name": "store_account", "value": true}, '
+        '{"name": "acme_private_key", "value": "{\\"n\\": \\"PwIOkViO\\", \\"kty\\": \\"RSA\\"}"}, '
+        '{"name": "acme_regr", "value": "{\\"body\\": {}, \\"uri\\": \\"http://test.com\\"}"}]')
+
     @patch("lemur.plugins.lemur_acme.plugin.BackwardsCompatibleClientV2")
     @patch("lemur.plugins.lemur_acme.plugin.current_app")
     def test_setup_acme_client_success(self, mock_current_app, mock_acme):
         mock_authority = Mock()
         mock_authority.options = '[{"name": "mock_name", "value": "mock_value"}, ' \
-                                 '{"name": "store_account", "value": false}] '
+                                 '{"name": "store_account", "value": false}]'
         mock_client = Mock()
         mock_registration = Mock()
         mock_registration.uri = "http://test.com"

--- a/lemur/plugins/lemur_acme/tests/test_acme.py
+++ b/lemur/plugins/lemur_acme/tests/test_acme.py
@@ -219,9 +219,10 @@ class TestAcme(unittest.TestCase):
         '{"name": "acme_private_key", "value": "{\\"n\\": \\"PwIOkViO\\", \\"kty\\": \\"RSA\\"}"}, '
         '{"name": "acme_regr", "value": "{\\"body\\": {}, \\"uri\\": \\"http://test.com\\"}"}]')
 
+    @patch("lemur.plugins.lemur_acme.plugin.authorities_service")
     @patch("lemur.plugins.lemur_acme.plugin.BackwardsCompatibleClientV2")
     @patch("lemur.plugins.lemur_acme.plugin.current_app")
-    def test_setup_acme_client_success(self, mock_current_app, mock_acme):
+    def test_setup_acme_client_success(self, mock_current_app, mock_acme, mock_authorities_service):
         mock_authority = Mock()
         mock_authority.options = '[{"name": "mock_name", "value": "mock_value"}, ' \
                                  '{"name": "store_account", "value": false}]'
@@ -233,6 +234,7 @@ class TestAcme(unittest.TestCase):
         mock_acme.return_value = mock_client
         mock_current_app.config = {}
         result_client, result_registration = self.acme.setup_acme_client(mock_authority)
+        mock_authorities_service.update_options.assert_not_called()
         assert result_client
         assert result_registration
 

--- a/lemur/plugins/lemur_acme/tests/test_acme.py
+++ b/lemur/plugins/lemur_acme/tests/test_acme.py
@@ -169,7 +169,8 @@ class TestAcme(unittest.TestCase):
     @patch("lemur.plugins.lemur_acme.plugin.current_app")
     def test_setup_acme_client_success(self, mock_current_app, mock_acme):
         mock_authority = Mock()
-        mock_authority.options = '[{"name": "mock_name", "value": "mock_value"}]'
+        mock_authority.options = '[{"name": "mock_name", "value": "mock_value"}, ' \
+                                 '{"name": "store_account", "value": false}] '
         mock_client = Mock()
         mock_registration = Mock()
         mock_registration.uri = "http://test.com"

--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -175,7 +175,6 @@ def map_cis_fields(options, csr):
         },
         "organization": {
             "name": options["organization"],
-            "units": [options["organizational_unit"]],
         },
     }
     #  possibility to default to a SIGNING_ALGORITHM for a given profile

--- a/lemur/plugins/lemur_digicert/tests/test_digicert.py
+++ b/lemur/plugins/lemur_digicert/tests/test_digicert.py
@@ -121,7 +121,7 @@ def test_map_cis_fields_with_validity_years(mock_current_app, authority):
             "csr": CSR_STR,
             "additional_dns_names": names,
             "signature_hash": "sha256",
-            "organization": {"name": "Example, Inc.", "units": ["Example Org"]},
+            "organization": {"name": "Example, Inc."},
             "validity": {
                 "valid_to": arrow.get(2018, 11, 3).format("YYYY-MM-DDTHH:MM") + "Z"
             },
@@ -157,7 +157,7 @@ def test_map_cis_fields_with_validity_end_and_start(mock_current_app, app, autho
             "csr": CSR_STR,
             "additional_dns_names": names,
             "signature_hash": "sha256",
-            "organization": {"name": "Example, Inc.", "units": ["Example Org"]},
+            "organization": {"name": "Example, Inc."},
             "validity": {
                 "valid_to": arrow.get(2017, 5, 7).format("YYYY-MM-DDTHH:MM") + "Z"
             },

--- a/lemur/static/app/angular/certificates/certificate/certificate.js
+++ b/lemur/static/app/angular/certificates/certificate/certificate.js
@@ -255,9 +255,6 @@ angular.module('lemur')
     $scope.certificate.replacedBy = []; // should not clone 'replaced by' info
     $scope.certificate.removeReplaces(); // should not clone 'replacement cert' info
 
-    if(!$scope.certificate.keyType) {
-      $scope.certificate.keyType = 'RSA2048'; // default algo to select during clone if backend did not return algo
-    }
     CertificateService.getDefaults($scope.certificate);
   });
 

--- a/lemur/static/app/angular/certificates/services.js
+++ b/lemur/static/app/angular/certificates/services.js
@@ -289,6 +289,11 @@ angular.module('lemur')
         if (certificate.dnsProviderId) {
           certificate.dnsProvider = {id: certificate.dnsProviderId};
         }
+
+        if(!certificate.keyType) {
+          certificate.keyType = 'RSA2048'; // default algo to select during clone if backend did not return algo
+        }
+
       });
     };
 

--- a/lemur/tests/conf.py
+++ b/lemur/tests/conf.py
@@ -36,7 +36,7 @@ LEMUR_ENCRYPTION_KEYS = base64.urlsafe_b64encode(get_random_secret(length=32).en
 
 
 # List of domain regular expressions that non-admin users can issue
-LEMUR_WHITELISTED_DOMAINS = [
+LEMUR_ALLOWED_DOMAINS = [
     r"^[a-zA-Z0-9-]+\.example\.com$",
     r"^[a-zA-Z0-9-]+\.example\.org$",
     r"^example\d+\.long\.com$",

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -400,7 +400,7 @@ def test_certificate_cn_admin(client, authority, logged_in_admin):
     from lemur.certificates.schemas import CertificateInputSchema
 
     input_data = {
-        "commonName": "*.admin-overrides-whitelist.com",
+        "commonName": "*.admin-overrides-allowlist.com",
         "owner": "jim@example.com",
         "authority": {"id": authority.id},
         "description": "testtestest",
@@ -461,7 +461,7 @@ def test_certificate_incative_authority(client, authority, session, logged_in_us
 
 
 def test_certificate_disallowed_names(client, authority, session, logged_in_user):
-    """The CN and SAN are disallowed by LEMUR_WHITELISTED_DOMAINS."""
+    """The CN and SAN are disallowed by LEMUR_ALLOWED_DOMAINS."""
     from lemur.certificates.schemas import CertificateInputSchema
 
     input_data = {
@@ -484,10 +484,10 @@ def test_certificate_disallowed_names(client, authority, session, logged_in_user
 
     data, errors = CertificateInputSchema().load(input_data)
     assert errors["common_name"][0].startswith(
-        "Domain *.example.com does not match whitelisted domain patterns"
+        "Domain *.example.com does not match allowed domain patterns"
     )
     assert errors["extensions"]["sub_alt_names"]["names"][0].startswith(
-        "Domain evilhacker.org does not match whitelisted domain patterns"
+        "Domain evilhacker.org does not match allowed domain patterns"
     )
 
 
@@ -674,7 +674,7 @@ def test_csr_empty_san(client):
 
 
 def test_csr_disallowed_cn(client, logged_in_user):
-    """Domain name CN is disallowed via LEMUR_WHITELISTED_DOMAINS."""
+    """Domain name CN is disallowed via LEMUR_ALLOWED_DOMAINS."""
     from lemur.common import validators
 
     request, pkey = create_csr(
@@ -683,12 +683,12 @@ def test_csr_disallowed_cn(client, logged_in_user):
     with pytest.raises(ValidationError) as err:
         validators.csr(request)
     assert str(err.value).startswith(
-        "Domain evilhacker.org does not match whitelisted domain patterns"
+        "Domain evilhacker.org does not match allowed domain patterns"
     )
 
 
 def test_csr_disallowed_san(client, logged_in_user):
-    """SAN name is disallowed by LEMUR_WHITELISTED_DOMAINS."""
+    """SAN name is disallowed by LEMUR_ALLOWED_DOMAINS."""
     from lemur.common import validators
 
     request, pkey = create_csr(
@@ -704,7 +704,7 @@ def test_csr_disallowed_san(client, logged_in_user):
     with pytest.raises(ValidationError) as err:
         validators.csr(request)
     assert str(err.value).startswith(
-        "Domain evilhacker.org does not match whitelisted domain patterns"
+        "Domain evilhacker.org does not match allowed domain patterns"
     )
 
 


### PR DESCRIPTION
Using options field of Authority, store a boolean value for option `cab_compliant`.
For non-cab-compliant issuers, copy subject details during the cloning instead of using default values.

Additionally, the PR has some minor changes
1. code cleanup to remove OU from digicert plugin + unit test changes
2. set default algo in `CertificateService.getDefaults`