### PR TITLE
Use cab_compliant option instead of authority name list

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -155,17 +155,12 @@ Specifying the `SQLALCHEMY_MAX_OVERFLOW` to 0 will enforce limit to not create c
 
         LEMUR_ENCRYPTION_KEYS = ['1YeftooSbxCiX2zo8m1lXtpvQjy27smZcUUaGmffhMY=', 'LAfQt6yrkLqOK5lwpvQcT4jf2zdeTQJV1uYeh9coT5s=']
 
-.. data:: PUBLIC_CA_AUTHORITY_NAMES
-    :noindex:
-        A list of public issuers which would be checked against to determine whether limit of max validity of 397 days
-        should be applied to the certificate. Configure public CA authority names in this list to enforce validity check.
-        This is an optional setting. Using this will allow the sanity check as mentioned. The name check is a case-insensitive
-        string comparision.
 
 .. data:: PUBLIC_CA_MAX_VALIDITY_DAYS
     :noindex:
-        Use this config to override the limit of 397 days of validity for certificates issued by public issuers configured
-        using PUBLIC_CA_AUTHORITY_NAMES. Below example overrides the default validity of 397 days and sets it to 365 days.
+        Use this config to override the limit of 397 days of validity for certificates issued by CA/Browser compliant authorities.
+        The authorities with cab_compliant option set to true will use this config. Below example overrides the default validity
+        of 397 days and sets it to 365 days.
 
     ::
 
@@ -175,7 +170,7 @@ Specifying the `SQLALCHEMY_MAX_OVERFLOW` to 0 will enforce limit to not create c
 .. data:: DEFAULT_VALIDITY_DAYS
     :noindex:
         Use this config to override the default validity of 365 days for certificates offered through Lemur UI. Any CA which
-        is not listed in PUBLIC_CA_AUTHORITY_NAMES will be using this value as default validity to be displayed on UI. Please
+        is not CA/Browser Forum compliant will be using this value as default validity to be displayed on UI. Please
         note that this config is used for cert issuance only through Lemur UI. Below example overrides the default validity
         of 365 days and sets it to 1095 days (3 years).
 

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -159,7 +159,7 @@ Specifying the `SQLALCHEMY_MAX_OVERFLOW` to 0 will enforce limit to not create c
 .. data:: PUBLIC_CA_MAX_VALIDITY_DAYS
     :noindex:
         Use this config to override the limit of 397 days of validity for certificates issued by CA/Browser compliant authorities.
-        The authorities with cab_compliant option set to true will use this config. Below example overrides the default validity
+        The authorities with cab_compliant option set to true will use this config. The example below overrides the default validity
         of 397 days and sets it to 365 days.
 
     ::
@@ -171,7 +171,7 @@ Specifying the `SQLALCHEMY_MAX_OVERFLOW` to 0 will enforce limit to not create c
     :noindex:
         Use this config to override the default validity of 365 days for certificates offered through Lemur UI. Any CA which
         is not CA/Browser Forum compliant will be using this value as default validity to be displayed on UI. Please
-        note that this config is used for cert issuance only through Lemur UI. Below example overrides the default validity
+        note that this config is used for cert issuance only through Lemur UI. The example below overrides the default validity
         of 365 days and sets it to 1095 days (3 years).
 
     ::

--- a/lemur/authorities/models.py
+++ b/lemur/authorities/models.py
@@ -8,6 +8,7 @@
 """
 import json
 
+from flask import current_app
 from sqlalchemy.orm import relationship
 from sqlalchemy import (
     Column,
@@ -97,6 +98,18 @@ class Authority(db.Model):
                 return option["value"]
 
         return None
+
+    @property
+    def max_issuance_days(self):
+        if self.is_cab_compliant:
+            return current_app.config.get("PUBLIC_CA_MAX_VALIDITY_DAYS", 397)
+
+    @property
+    def default_validity_days(self):
+        if self.is_cab_compliant:
+            return current_app.config.get("PUBLIC_CA_MAX_VALIDITY_DAYS", 397)
+
+        return current_app.config.get("DEFAULT_VALIDITY_DAYS", 365)  # 1 year default
 
     def __repr__(self):
         return "Authority(name={name})".format(name=self.name)

--- a/lemur/authorities/schemas.py
+++ b/lemur/authorities/schemas.py
@@ -111,8 +111,6 @@ class RootAuthorityCertificateOutputSchema(LemurOutputSchema):
     cn = fields.String()
     not_after = fields.DateTime()
     not_before = fields.DateTime()
-    max_issuance_days = fields.Integer()
-    default_validity_days = fields.Integer()
     owner = fields.Email()
     status = fields.Boolean()
     user = fields.Nested(UserNestedOutputSchema)
@@ -127,6 +125,8 @@ class AuthorityOutputSchema(LemurOutputSchema):
     active = fields.Boolean()
     options = fields.Dict()
     roles = fields.List(fields.Nested(AssociatedRoleSchema))
+    max_issuance_days = fields.Integer()
+    default_validity_days = fields.Integer()
     authority_certificate = fields.Nested(RootAuthorityCertificateOutputSchema)
 
 
@@ -138,8 +138,10 @@ class AuthorityNestedOutputSchema(LemurOutputSchema):
     owner = fields.Email()
     plugin = fields.Nested(PluginOutputSchema)
     active = fields.Boolean()
-    authority_certificate = fields.Nested(RootAuthorityCertificateOutputSchema, only=["max_issuance_days", "default_validity_days"])
+    authority_certificate = fields.Nested(RootAuthorityCertificateOutputSchema, only=["not_after", "not_before"])
     is_cab_compliant = fields.Boolean()
+    max_issuance_days = fields.Integer()
+    default_validity_days = fields.Integer()
 
 
 authority_update_schema = AuthorityUpdateSchema()

--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -318,20 +318,6 @@ class Certificate(db.Model):
         return self.not_after - self.not_before
 
     @property
-    def max_issuance_days(self):
-        public_CA = current_app.config.get("PUBLIC_CA_AUTHORITY_NAMES", [])
-        if self.name.lower() in [ca.lower() for ca in public_CA]:
-            return current_app.config.get("PUBLIC_CA_MAX_VALIDITY_DAYS", 397)
-
-    @property
-    def default_validity_days(self):
-        public_CA = current_app.config.get("PUBLIC_CA_AUTHORITY_NAMES", [])
-        if self.name.lower() in [ca.lower() for ca in public_CA]:
-            return current_app.config.get("PUBLIC_CA_MAX_VALIDITY_DAYS", 397)
-
-        return current_app.config.get("DEFAULT_VALIDITY_DAYS", 365)   # 1 year default
-
-    @property
     def subject(self):
         return self.parsed_cert.subject
 

--- a/lemur/static/app/angular/certificates/certificate/certificate.js
+++ b/lemur/static/app/angular/certificates/certificate/certificate.js
@@ -190,7 +190,7 @@ angular.module('lemur')
     function populateValidityDateAsPerDefault(certificate) {
       // calculate start and end date as per default validity
       let startDate = new Date(), endDate = new Date();
-      endDate.setDate(startDate.getDate() + certificate.authority.authorityCertificate.defaultValidityDays);
+      endDate.setDate(startDate.getDate() + certificate.authority.defaultValidityDays);
       certificate.validityStart = startDate;
       certificate.validityEnd = endDate;
     }
@@ -359,7 +359,7 @@ angular.module('lemur')
     function populateValidityDateAsPerDefault(certificate) {
       // calculate start and end date as per default validity
       let startDate = new Date(), endDate = new Date();
-      endDate.setDate(startDate.getDate() + certificate.authority.authorityCertificate.defaultValidityDays);
+      endDate.setDate(startDate.getDate() + certificate.authority.defaultValidityDays);
       certificate.validityStart = startDate;
       certificate.validityEnd = endDate;
     }

--- a/lemur/static/app/angular/certificates/certificate/tracking.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/tracking.tpl.html
@@ -139,7 +139,7 @@
       <div class="col-sm-4">
         <div class="btn-group btn-group-toggle" data-toggle="buttons">
           <label class="btn btn-info" ng-model="certificate.validityType" uib-btn-radio="'defaultDays'" ng-click="clearDates()">
-              Default ({{certificate.authority.authorityCertificate.defaultValidityDays}} days)</label>
+              Default ({{certificate.authority.defaultValidityDays}} days)</label>
           <label class="btn btn-info" ng-model="certificate.validityType" uib-btn-radio="'customDates'" ng-change="clearDates()">Custom</label>
         </div>
       </div>

--- a/lemur/static/app/angular/certificates/services.js
+++ b/lemur/static/app/angular/certificates/services.js
@@ -172,12 +172,12 @@ angular.module('lemur')
           // Minimum end date will be same as selected start date
           this.authority.authorityCertificate.minValidityEnd = value;
 
-          if(!this.authority.authorityCertificate || !this.authority.authorityCertificate.maxIssuanceDays) {
+          if(!this.authority.maxIssuanceDays) {
             this.authority.authorityCertificate.maxValidityEnd = this.authority.authorityCertificate.notAfter;
           } else {
             // Move max end date by maxIssuanceDays
             let endDate = new Date(value);
-            endDate.setDate(endDate.getDate() + this.authority.authorityCertificate.maxIssuanceDays);
+            endDate.setDate(endDate.getDate() + this.authority.maxIssuanceDays);
             this.authority.authorityCertificate.maxValidityEnd = endDate;
           }
         }

--- a/lemur/static/app/angular/pending_certificates/services.js
+++ b/lemur/static/app/angular/pending_certificates/services.js
@@ -152,12 +152,12 @@ angular.module('lemur')
           // Minimum end date will be same as selected start date
           this.authority.authorityCertificate.minValidityEnd = value;
 
-          if(!this.authority.authorityCertificate || !this.authority.authorityCertificate.maxIssuanceDays) {
+          if(!this.authority.maxIssuanceDays) {
             this.authority.authorityCertificate.maxValidityEnd = this.authority.authorityCertificate.notAfter;
           } else {
             // Move max end date by maxIssuanceDays
             let endDate = new Date(value);
-            endDate.setDate(endDate.getDate() + this.authority.authorityCertificate.maxIssuanceDays);
+            endDate.setDate(endDate.getDate() + this.authority.maxIssuanceDays);
             this.authority.authorityCertificate.maxValidityEnd = endDate;
           }
         }


### PR DESCRIPTION
Removed PUBLIC_CA_AUTHORITY_NAMES and instead using option cab_compliant for authorities ( introduced in #3188 )