### PR TITLE
Fix "ValueError: invalid interpolation syntax in" for special chars in SQLALCHEMY_DATABASE_URI

### DIFF
--- a/lemur/migrations/env.py
+++ b/lemur/migrations/env.py
@@ -20,8 +20,9 @@ fileConfig(config.config_file_name)
 # target_metadata = mymodel.Base.metadata
 from flask import current_app
 
+db_url_escaped = current_app.config.get('SQLALCHEMY_DATABASE_URI').replace('%', '%%')
 config.set_main_option(
-    "sqlalchemy.url", current_app.config.get("SQLALCHEMY_DATABASE_URI")
+    "sqlalchemy.url", db_url_escaped
 )
 target_metadata = current_app.extensions["migrate"].db.metadata
 


### PR DESCRIPTION
Currently, when you have special chars, that need to be URL escaped for the `SQLALCHEMY_DATABASE_URI`, `lemur init` will fail with a "ValueError: invalid interpolation syntax" during the alembic migragtions.

This is caused, by the fact that alembic uses the python configparser, which needs double `%` to properly escape them, as reported in miguelgrinberg/Flask-Migrate/issues/122

The workaround is to double escape the `%` sign, in the migrate/env.py, double escaping it directly in the  `SQLALCHEMY_DATABASE_URI` will result in other DB connections not working.