### PR TITLE
Expanding the S3 plugin with acme-http01-token support

### DIFF
--- a/lemur/acme_providers/cli.py
+++ b/lemur/acme_providers/cli.py
@@ -128,7 +128,16 @@ def dnstest(domain, token):
     help="Bucket Name",
 )
 def upload_acme_token_s3(token, token_name, prefix, account_number, bucket_name):
-
+    """
+    This method serves for testing the upload_acme_token to S3, fetching the token to verify it, and then deleting it.
+    It mainly serves for testing purposes.
+    :param token:
+    :param token_name:
+    :param prefix:
+    :param account_number:
+    :param bucket_name:
+    :return:
+    """
     additional_options = [
         {
             "name": "bucket",

--- a/lemur/acme_providers/cli.py
+++ b/lemur/acme_providers/cli.py
@@ -10,7 +10,6 @@ from lemur.constants import SUCCESS_METRIC_STATUS
 from lemur.plugins import plugins
 from lemur.plugins.lemur_acme.plugin import AcmeHandler
 from lemur.plugins.lemur_aws import s3
-from lemur.utils import get_random_secret
 
 manager = Manager(
     usage="Handles all ACME related tasks"

--- a/lemur/acme_providers/cli.py
+++ b/lemur/acme_providers/cli.py
@@ -1,12 +1,16 @@
 import time
 import json
+import arrow
 
 from flask_script import Manager
 from flask import current_app
 
 from lemur.extensions import sentry
 from lemur.constants import SUCCESS_METRIC_STATUS
+from lemur.plugins import plugins
 from lemur.plugins.lemur_acme.plugin import AcmeHandler
+from lemur.plugins.lemur_aws import s3
+from lemur.utils import get_random_secret
 
 manager = Manager(
     usage="Handles all ACME related tasks"
@@ -84,3 +88,96 @@ def dnstest(domain, token):
 
     status = SUCCESS_METRIC_STATUS
     print("[+] Done with ACME Tests.")
+
+
+@manager.option(
+    "-t",
+    "--token",
+    dest="token",
+    default="date: " + arrow.utcnow().format("YYYY-MM-DDTHH-mm-ss"),
+    required=False,
+    help="Value of the Token",
+)
+@manager.option(
+    "-n",
+    "--token_name",
+    dest="token_name",
+    default="Token-" + arrow.utcnow().format("YYYY-MM-DDTHH-mm-ss"),
+    required=False,
+    help="path",
+)
+@manager.option(
+    "-p",
+    "--prefix",
+    dest="prefix",
+    default="test/",
+    required=False,
+    help="S3 bucket prefix",
+)
+@manager.option(
+    "-a",
+    "--account_number",
+    dest="account_number",
+    required=True,
+    help="AWS Account",
+)
+@manager.option(
+    "-b",
+    "--bucket_name",
+    dest="bucket_name",
+    required=True,
+    help="Bucket Name",
+)
+def upload_acme_token_s3(token, token_name, prefix, account_number, bucket_name):
+
+    additional_options = [
+        {
+            "name": "bucket",
+            "value": bucket_name,
+            "type": "str",
+            "required": True,
+            "validation": "[0-9a-z.-]{3,63}",
+            "helpMessage": "Must be a valid S3 bucket name!",
+        },
+        {
+            "name": "accountNumber",
+            "type": "str",
+            "value": account_number,
+            "required": True,
+            "validation": "[0-9]{12}",
+            "helpMessage": "A valid AWS account number with permission to access S3",
+        },
+        {
+            "name": "region",
+            "type": "str",
+            "default": "us-east-1",
+            "required": False,
+            "helpMessage": "Region bucket exists",
+            "available": ["us-east-1", "us-west-2", "eu-west-1"],
+        },
+        {
+            "name": "encrypt",
+            "type": "bool",
+            "value": False,
+            "required": False,
+            "helpMessage": "Enable server side encryption",
+            "default": True,
+        },
+        {
+            "name": "prefix",
+            "type": "str",
+            "value": prefix,
+            "required": False,
+            "helpMessage": "Must be a valid S3 object prefix!",
+        },
+    ]
+
+    p = plugins.get("aws-s3")
+    p.upload_acme_token(token_name, token, additional_options)
+
+    if not prefix.endswith("/"):
+        prefix + "/"
+
+    token_res = s3.get(bucket_name, prefix + token_name, account_number=account_number)
+    assert(token_res == token)
+    s3.delete(bucket_name, prefix + token_name, account_number=account_number)

--- a/lemur/acme_providers/cli.py
+++ b/lemur/acme_providers/cli.py
@@ -144,7 +144,7 @@ def upload_acme_token_s3(token, token_name, prefix, account_number, bucket_name)
             "value": bucket_name,
             "type": "str",
             "required": True,
-            "validation": "[0-9a-z.-]{3,63}",
+            "validation": r"[0-9a-z.-]{3,63}",
             "helpMessage": "Must be a valid S3 bucket name!",
         },
         {
@@ -152,7 +152,7 @@ def upload_acme_token_s3(token, token_name, prefix, account_number, bucket_name)
             "type": "str",
             "value": account_number,
             "required": True,
-            "validation": "[0-9]{12}",
+            "validation": r"[0-9]{12}",
             "helpMessage": "A valid AWS account number with permission to access S3",
         },
         {

--- a/lemur/plugins/lemur_aws/plugin.py
+++ b/lemur/plugins/lemur_aws/plugin.py
@@ -406,3 +406,25 @@ class S3DestinationPlugin(ExportDestinationPlugin):
                 self.get_option("encrypt", options),
                 account_number=self.get_option("accountNumber", options),
             )
+
+    def upload_acme_token(self, token_path, token, options, **kwargs):
+        """
+         This is called from the acme http challenge
+        :param self:
+        :param token_path:
+        :param token:
+        :param options:
+        :param kwargs:
+        :return:
+        """
+        current_app.logger.debug("S3 destination plugin is started for HTTP-01 challenge")
+
+        account_number = self.get_option("accountNumber", options)
+        bucket_name = self.get_option("bucket", options)
+        prefix = self.get_option("prefix", options)
+        region = self.get_option("region", options)
+        filename = token_path.split("/")[-1]
+        if not prefix.endswith("/"):
+            prefix + "/"
+
+        s3.put(bucket_name, region, prefix + filename, token, encrypt=False, account_number=account_number)

--- a/lemur/plugins/lemur_aws/plugin.py
+++ b/lemur/plugins/lemur_aws/plugin.py
@@ -427,4 +427,9 @@ class S3DestinationPlugin(ExportDestinationPlugin):
         if not prefix.endswith("/"):
             prefix + "/"
 
-        s3.put(bucket_name, region, prefix + filename, token, encrypt=False, account_number=account_number)
+        s3.put(bucket_name=bucket_name,
+               region_name=region,
+               prefix=prefix + filename,
+               data=token,
+               encrypt=False,
+               account_number=account_number)

--- a/lemur/plugins/lemur_aws/plugin.py
+++ b/lemur/plugins/lemur_aws/plugin.py
@@ -408,7 +408,6 @@ class S3DestinationPlugin(ExportDestinationPlugin):
                 account_number=self.get_option("accountNumber", options),
             )
 
-
     def upload_acme_token(self, token_path, token, options, **kwargs):
         """
          This is called from the acme http challenge
@@ -483,4 +482,3 @@ class SNSNotificationPlugin(ExpirationNotificationPlugin):
 
         current_app.logger.info(f"Publishing {notification_type} notification to topic {topic_arn}")
         sns.publish(topic_arn, message, notification_type, region_name=self.get_option("region", options))
-

--- a/lemur/plugins/lemur_aws/s3.py
+++ b/lemur/plugins/lemur_aws/s3.py
@@ -14,7 +14,7 @@ from .sts import sts_client
 
 
 @sts_client("s3", service_type="resource")
-def put(bucket_name, region, prefix, data, encrypt, **kwargs):
+def put(bucket_name, region_name, prefix, data, encrypt, **kwargs):
     """
     Use STS to write to an S3 bucket
     """

--- a/lemur/plugins/lemur_aws/s3.py
+++ b/lemur/plugins/lemur_aws/s3.py
@@ -14,7 +14,7 @@ from lemur.extensions import sentry
 
 
 @sts_client("s3", service_type="resource")
-def put(bucket_name, prefix, data, encrypt, **kwargs):
+def put(bucket_name, region, prefix, data, encrypt, **kwargs):
     """
     Use STS to write to an S3 bucket
     """

--- a/lemur/plugins/lemur_aws/s3.py
+++ b/lemur/plugins/lemur_aws/s3.py
@@ -9,9 +9,12 @@
 from flask import current_app
 from .sts import sts_client
 
+from botocore.exceptions import ClientError
+from lemur.extensions import sentry
+
 
 @sts_client("s3", service_type="resource")
-def put(bucket_name, region, prefix, data, encrypt, **kwargs):
+def put(bucket_name, prefix, data, encrypt, **kwargs):
     """
     Use STS to write to an S3 bucket
     """
@@ -32,4 +35,37 @@ def put(bucket_name, region, prefix, data, encrypt, **kwargs):
             ServerSideEncryption="AES256",
         )
     else:
-        bucket.put_object(Key=prefix, Body=data, ACL="bucket-owner-full-control")
+        try:
+            bucket.put_object(Key=prefix, Body=data, ACL="bucket-owner-full-control")
+        except ClientError:
+            sentry.captureException()
+
+
+@sts_client("s3", service_type="client")
+def delete(bucket_name, prefix, **kwargs):
+    """
+    Use STS to delete an object
+    """
+    try:
+        response = kwargs["client"].delete_object(Bucket=bucket_name, Key=prefix)
+        current_app.logger.debug(f"Delete data from S3."
+                                 f"Bucket: {bucket_name},"
+                                 f"Prefix: {prefix},"
+                                 f"Status_code: {response}")
+        return response['ResponseMetadata']['HTTPStatusCode'] < 300
+    except ClientError:
+        sentry.captureException()
+
+
+@sts_client("s3", service_type="client")
+def get(bucket_name, prefix, **kwargs):
+    """
+    Use STS to get an object
+    """
+    try:
+        response = kwargs["client"].get_object(Bucket=bucket_name, Key=prefix)
+        current_app.logger.debug(f"Get data from S3. Bucket: {bucket_name},"
+                                 f"Prefix: {prefix}")
+        return response['Body'].read().decode("utf-8")
+    except ClientError:
+        sentry.captureException()

--- a/lemur/plugins/lemur_aws/s3.py
+++ b/lemur/plugins/lemur_aws/s3.py
@@ -6,11 +6,11 @@
     :license: Apache, see LICENSE for more details.
 .. moduleauthor:: Kevin Glisson <kglisson@netflix.com>
 """
-from flask import current_app
-from .sts import sts_client
-
 from botocore.exceptions import ClientError
+from flask import current_app
 from lemur.extensions import sentry
+
+from .sts import sts_client
 
 
 @sts_client("s3", service_type="resource")

--- a/lemur/plugins/lemur_aws/s3.py
+++ b/lemur/plugins/lemur_aws/s3.py
@@ -44,15 +44,15 @@ def put(bucket_name, region_name, prefix, data, encrypt, **kwargs):
 
 
 @sts_client("s3", service_type="client")
-def delete(bucket_name, prefix, **kwargs):
+def delete(bucket_name, prefixed_object_name, **kwargs):
     """
     Use STS to delete an object
     """
     try:
-        response = kwargs["client"].delete_object(Bucket=bucket_name, Key=prefix)
+        response = kwargs["client"].delete_object(Bucket=bucket_name, Key=prefixed_object_name)
         current_app.logger.debug(f"Delete data from S3."
                                  f"Bucket: {bucket_name},"
-                                 f"Prefix: {prefix},"
+                                 f"Prefix: {prefixed_object_name},"
                                  f"Status_code: {response}")
         return response['ResponseMetadata']['HTTPStatusCode'] < 300
     except ClientError:
@@ -61,14 +61,14 @@ def delete(bucket_name, prefix, **kwargs):
 
 
 @sts_client("s3", service_type="client")
-def get(bucket_name, prefix, **kwargs):
+def get(bucket_name, prefixed_object_name, **kwargs):
     """
     Use STS to get an object
     """
     try:
-        response = kwargs["client"].get_object(Bucket=bucket_name, Key=prefix)
+        response = kwargs["client"].get_object(Bucket=bucket_name, Key=prefixed_object_name)
         current_app.logger.debug(f"Get data from S3. Bucket: {bucket_name},"
-                                 f"Prefix: {prefix}")
+                                 f"object_name: {prefixed_object_name}")
         return response['Body'].read().decode("utf-8")
     except ClientError:
         sentry.captureException()

--- a/lemur/plugins/lemur_aws/s3.py
+++ b/lemur/plugins/lemur_aws/s3.py
@@ -37,8 +37,10 @@ def put(bucket_name, region_name, prefix, data, encrypt, **kwargs):
     else:
         try:
             bucket.put_object(Key=prefix, Body=data, ACL="bucket-owner-full-control")
+            return True
         except ClientError:
             sentry.captureException()
+            return False
 
 
 @sts_client("s3", service_type="client")
@@ -55,6 +57,7 @@ def delete(bucket_name, prefix, **kwargs):
         return response['ResponseMetadata']['HTTPStatusCode'] < 300
     except ClientError:
         sentry.captureException()
+        return False
 
 
 @sts_client("s3", service_type="client")
@@ -69,3 +72,4 @@ def get(bucket_name, prefix, **kwargs):
         return response['Body'].read().decode("utf-8")
     except ClientError:
         sentry.captureException()
+        return None

--- a/lemur/plugins/lemur_aws/tests/test_plugin.py
+++ b/lemur/plugins/lemur_aws/tests/test_plugin.py
@@ -28,7 +28,7 @@ def test_upload_acme_token(app):
             "value": bucket,
             "type": "str",
             "required": True,
-            "validation": "[0-9a-z.-]{3,63}",
+            "validation": r"[0-9a-z.-]{3,63}",
             "helpMessage": "Must be a valid S3 bucket name!",
         },
         {
@@ -36,7 +36,7 @@ def test_upload_acme_token(app):
             "type": "str",
             "value": account,
             "required": True,
-            "validation": "[0-9]{12}",
+            "validation": r"[0-9]{12}",
             "helpMessage": "A valid AWS account number with permission to access S3",
         },
         {

--- a/lemur/plugins/lemur_aws/tests/test_plugin.py
+++ b/lemur/plugins/lemur_aws/tests/test_plugin.py
@@ -1,5 +1,82 @@
+import boto3
+from moto import mock_sts, mock_s3
+
+
 def test_get_certificates(app):
     from lemur.plugins.base import plugins
 
     p = plugins.get("aws-s3")
     assert p
+
+
+@mock_sts()
+@mock_s3()
+def test_upload_acme_token(app):
+    from lemur.plugins.base import plugins
+    from lemur.plugins.lemur_aws.s3 import get
+
+    bucket = "public-bucket"
+    account = "123456789012"
+    prefix = "some-path/more-path/"
+    token_content = "Challenge"
+    token_name = "TOKEN"
+    token_path = ".well-known/acme-challenge/" + token_name
+
+    additional_options = [
+        {
+            "name": "bucket",
+            "value": bucket,
+            "type": "str",
+            "required": True,
+            "validation": "[0-9a-z.-]{3,63}",
+            "helpMessage": "Must be a valid S3 bucket name!",
+        },
+        {
+            "name": "accountNumber",
+            "type": "str",
+            "value": account,
+            "required": True,
+            "validation": "[0-9]{12}",
+            "helpMessage": "A valid AWS account number with permission to access S3",
+        },
+        {
+            "name": "region",
+            "type": "str",
+            "default": "us-east-1",
+            "required": False,
+            "helpMessage": "Region bucket exists",
+            "available": ["us-east-1", "us-west-2", "eu-west-1"],
+        },
+        {
+            "name": "encrypt",
+            "type": "bool",
+            "value": False,
+            "required": False,
+            "helpMessage": "Enable server side encryption",
+            "default": True,
+        },
+        {
+            "name": "prefix",
+            "type": "str",
+            "value": prefix,
+            "required": False,
+            "helpMessage": "Must be a valid S3 object prefix!",
+        },
+    ]
+
+    s3_client = boto3.client('s3')
+    s3_client.create_bucket(Bucket=bucket)
+    p = plugins.get("aws-s3")
+
+    p.upload_acme_token(token_path=token_path,
+                        token_content=token_content,
+                        token=token_content,
+                        options=additional_options)
+
+    response = get(bucket_name=bucket,
+                   prefix=prefix + token_name,
+                   encrypt=False,
+                   account_number=account)
+
+    # put data, and getting the same data
+    assert (response == token_content)

--- a/lemur/plugins/lemur_aws/tests/test_plugin.py
+++ b/lemur/plugins/lemur_aws/tests/test_plugin.py
@@ -74,7 +74,7 @@ def test_upload_acme_token(app):
                         options=additional_options)
 
     response = get(bucket_name=bucket,
-                   prefix=prefix + token_name,
+                   prefixed_object_name=prefix + token_name,
                    encrypt=False,
                    account_number=account)
 

--- a/lemur/plugins/lemur_aws/tests/test_s3.py
+++ b/lemur/plugins/lemur_aws/tests/test_s3.py
@@ -9,16 +9,16 @@ def test_put_delete_s3_object(app):
 
     bucket = "public-bucket"
     account = "123456789012"
-    path = "some_path/foo"
+    path = "some-path/foo"
+    data = "dummy data"
 
     s3_client = boto3.client('s3')
     s3_client.create_bucket(Bucket=bucket)
 
-    data = "dummy data"
     put(bucket_name=bucket,
         prefix=path,
         data=data,
-        encrypt=None,
+        encrypt=False,
         account_number=account)
 
     response = get(bucket_name=bucket, prefix=path, account_number=account)

--- a/lemur/plugins/lemur_aws/tests/test_s3.py
+++ b/lemur/plugins/lemur_aws/tests/test_s3.py
@@ -8,6 +8,7 @@ def test_put_delete_s3_object(app):
     from lemur.plugins.lemur_aws.s3 import put, delete, get
 
     bucket = "public-bucket"
+    region = "us-east-1"
     account = "123456789012"
     path = "some-path/foo"
     data = "dummy data"
@@ -16,11 +17,12 @@ def test_put_delete_s3_object(app):
     s3_client.create_bucket(Bucket=bucket)
 
     put(bucket_name=bucket,
-        region=None,
+        region_name=region,
         prefix=path,
         data=data,
         encrypt=False,
-        account_number=account)
+        account_number=account,
+        region=region)
 
     response = get(bucket_name=bucket, prefix=path, account_number=account)
 

--- a/lemur/plugins/lemur_aws/tests/test_s3.py
+++ b/lemur/plugins/lemur_aws/tests/test_s3.py
@@ -24,18 +24,18 @@ def test_put_delete_s3_object(app):
         account_number=account,
         region=region)
 
-    response = get(bucket_name=bucket, prefix=path, account_number=account)
+    response = get(bucket_name=bucket, prefixed_object_name=path, account_number=account)
 
     # put data, and getting the same data
     assert (response == data)
 
-    response = get(bucket_name="wrong-bucket", prefix=path, account_number=account)
+    response = get(bucket_name="wrong-bucket", prefixed_object_name=path, account_number=account)
 
     # attempting to get thccle wrong data
     assert (response is None)
 
-    delete(bucket_name=bucket, prefix=path, account_number=account)
-    response = get(bucket_name=bucket, prefix=path, account_number=account)
+    delete(bucket_name=bucket, prefixed_object_name=path, account_number=account)
+    response = get(bucket_name=bucket, prefixed_object_name=path, account_number=account)
 
     # delete data, and getting the same data
     assert (response is None)

--- a/lemur/plugins/lemur_aws/tests/test_s3.py
+++ b/lemur/plugins/lemur_aws/tests/test_s3.py
@@ -16,6 +16,7 @@ def test_put_delete_s3_object(app):
     s3_client.create_bucket(Bucket=bucket)
 
     put(bucket_name=bucket,
+        region=None,
         prefix=path,
         data=data,
         encrypt=False,

--- a/lemur/plugins/lemur_aws/tests/test_s3.py
+++ b/lemur/plugins/lemur_aws/tests/test_s3.py
@@ -1,0 +1,38 @@
+import boto3
+from moto import mock_sts, mock_s3
+
+
+@mock_sts()
+@mock_s3()
+def test_put_delete_s3_object(app):
+    from lemur.plugins.lemur_aws.s3 import put, delete, get
+
+    bucket = "public-bucket"
+    account = "123456789012"
+    path = "some_path/foo"
+
+    s3_client = boto3.client('s3')
+    s3_client.create_bucket(Bucket=bucket)
+
+    data = "dummy data"
+    put(bucket_name=bucket,
+        prefix=path,
+        data=data,
+        encrypt=None,
+        account_number=account)
+
+    response = get(bucket_name=bucket, prefix=path, account_number=account)
+
+    # put data, and getting the same data
+    assert (response == data)
+
+    response = get(bucket_name="wrong-bucket", prefix=path, account_number=account)
+
+    # attempting to get thccle wrong data
+    assert (response is None)
+
+    delete(bucket_name=bucket, prefix=path, account_number=account)
+    response = get(bucket_name=bucket, prefix=path, account_number=account)
+
+    # delete data, and getting the same data
+    assert (response is None)


### PR DESCRIPTION
The S3 Destination plugin can be employed for uploading acme-http01 to a defined S3 bucket. 
For this domain validation to work the domain to be validated needs to redirect to the  respective S3 bucket/path.

https://letsencrypt.org/docs/challenge-types/#http-01-challenge
```
http://<YOUR_DOMAIN>/.well-known/acme-challenge/<TOKEN>
```
The S3 bucket will be hosting `<TOKEN>`, where the file name is a uid, and the body of the file contains the expected challenge.