### PR TITLE
Miscellaneous notification fixes and tests

### DIFF
--- a/lemur/notifications/messaging.py
+++ b/lemur/notifications/messaging.py
@@ -101,8 +101,8 @@ def send_notification(event_type, data, targets, notification):
     log_data = {
         "function": function,
         "message": "Sending expiration notification for to targets {}".format(targets),
-        "notification_type": "rotation",
-        "targets": targets,
+        "notification_type": "expiration",
+        "certificate_targets": targets,
     }
     status = FAILURE_METRIC_STATUS
     try:
@@ -202,8 +202,8 @@ def send_rotation_notification(certificate, notification_plugin=None):
         "function": function,
         "message": "Sending rotation notification for certificate {}".format(certificate.name),
         "notification_type": "rotation",
-        "name": certificate.name,
-        "owner": certificate.owner,
+        "certificate_name": certificate.name,
+        "certificate_owner": certificate.owner,
     }
     status = FAILURE_METRIC_STATUS
     if not notification_plugin:
@@ -247,9 +247,9 @@ def send_pending_failure_notification(
     log_data = {
         "function": function,
         "message": "Sending pending failure notification for pending certificate {}".format(pending_cert.name),
-        "notification_type": "rotation",
-        "name": pending_cert.name,
-        "owner": pending_cert.owner,
+        "notification_type": "failed",
+        "certificate_name": pending_cert.name,
+        "certificate_owner": pending_cert.owner,
     }
     status = FAILURE_METRIC_STATUS
 

--- a/lemur/notifications/messaging.py
+++ b/lemur/notifications/messaging.py
@@ -100,7 +100,7 @@ def send_notification(event_type, data, targets, notification):
     function = f"{__name__}.{sys._getframe().f_code.co_name}"
     log_data = {
         "function": function,
-        "message": "Sending expiration notification for to targets {}".format(targets),
+        "message": f"Sending expiration notification for to targets {targets}",
         "notification_type": "expiration",
         "certificate_targets": targets,
     }
@@ -109,7 +109,7 @@ def send_notification(event_type, data, targets, notification):
         notification.plugin.send(event_type, data, targets, notification.options)
         status = SUCCESS_METRIC_STATUS
     except Exception as e:
-        log_data["message"] = "Unable to send expiration notification to targets {}".format(targets)
+        log_data["message"] = f"Unable to send expiration notification to targets {targets}"
         current_app.logger.error(log_data, exc_info=True)
         sentry.captureException()
 
@@ -200,7 +200,7 @@ def send_rotation_notification(certificate, notification_plugin=None):
     function = f"{__name__}.{sys._getframe().f_code.co_name}"
     log_data = {
         "function": function,
-        "message": "Sending rotation notification for certificate {}".format(certificate.name),
+        "message": f"Sending rotation notification for certificate {certificate.name}",
         "notification_type": "rotation",
         "certificate_name": certificate.name,
         "certificate_owner": certificate.owner,
@@ -217,8 +217,8 @@ def send_rotation_notification(certificate, notification_plugin=None):
         notification_plugin.send("rotation", data, [data["owner"]], [])
         status = SUCCESS_METRIC_STATUS
     except Exception as e:
-        log_data["message"] = "Unable to send rotation notification for certificate {0} to owner {1}" \
-            .format(certificate.name, data["owner"])
+        log_data["message"] = f"Unable to send rotation notification for certificate {certificate.name} " \
+                              f"to owner {data['owner']}"
         current_app.logger.error(log_data, exc_info=True)
         sentry.captureException()
 
@@ -246,7 +246,7 @@ def send_pending_failure_notification(
     function = f"{__name__}.{sys._getframe().f_code.co_name}"
     log_data = {
         "function": function,
-        "message": "Sending pending failure notification for pending certificate {}".format(pending_cert.name),
+        "message": f"Sending pending failure notification for pending certificate {pending_cert}"
         "notification_type": "failed",
         "certificate_name": pending_cert.name,
         "certificate_owner": pending_cert.owner,
@@ -269,8 +269,8 @@ def send_pending_failure_notification(
             status = SUCCESS_METRIC_STATUS
         except Exception as e:
             log_data["recipient"] = data["owner"]
-            log_data["message"] = "Unable to send pending failure notification for certificate {0} to owner {1}" \
-                .format(pending_cert.name, pending_cert.owner)
+            log_data["message"] = f"Unable to send pending failure notification for certificate {pending_cert.name} " \
+                                  f"to owner {pending_cert.owner}"
             current_app.logger.error(log_data, exc_info=True)
             sentry.captureException()
 
@@ -282,8 +282,8 @@ def send_pending_failure_notification(
             status = SUCCESS_METRIC_STATUS
         except Exception as e:
             log_data["recipient"] = data["security_email"]
-            log_data["message"] = "Unable to send pending failure notification for certificate {0} to security email " \
-                                  "{1}".format(pending_cert.name, pending_cert.owner)
+            log_data["message"] = f"Unable to send pending failure notification for certificate {pending_cert.name} " \
+                                  f"to security email {pending_cert.owner}"
             current_app.logger.error(log_data, exc_info=True)
             sentry.captureException()
 
@@ -291,7 +291,7 @@ def send_pending_failure_notification(
         "notification",
         "counter",
         1,
-        metric_tags={"status": status, "event_type": "rotation"},
+        metric_tags={"status": status, "event_type": "failed"},
     )
 
     if status == SUCCESS_METRIC_STATUS:
@@ -329,7 +329,7 @@ def needs_notification(certificate):
 
         else:
             raise Exception(
-                "Invalid base unit for expiration interval: {0}".format(unit)
+                f"Invalid base unit for expiration interval: {unit}"
             )
 
         if days == interval:

--- a/lemur/notifications/messaging.py
+++ b/lemur/notifications/messaging.py
@@ -246,7 +246,7 @@ def send_pending_failure_notification(
     function = f"{__name__}.{sys._getframe().f_code.co_name}"
     log_data = {
         "function": function,
-        "message": f"Sending pending failure notification for pending certificate {pending_cert}"
+        "message": f"Sending pending failure notification for pending certificate {pending_cert}",
         "notification_type": "failed",
         "certificate_name": pending_cert.name,
         "certificate_owner": pending_cert.owner,

--- a/lemur/notifications/messaging.py
+++ b/lemur/notifications/messaging.py
@@ -217,9 +217,9 @@ def send_rotation_notification(certificate, notification_plugin=None):
         notification_plugin.send("rotation", data, [data["owner"]], [])
         status = SUCCESS_METRIC_STATUS
     except Exception as e:
-        log_data["message"] = "Unable to send rotation notification for certificate {0} to ownner {1}" \
+        log_data["message"] = "Unable to send rotation notification for certificate {0} to owner {1}" \
             .format(certificate.name, data["owner"])
-        current_app.logger.error(log_data)
+        current_app.logger.error(log_data, exc_info=True)
         sentry.captureException()
 
     metrics.send(

--- a/lemur/plugins/lemur_email/plugin.py
+++ b/lemur/plugins/lemur_email/plugin.py
@@ -19,14 +19,16 @@ from lemur.plugins import lemur_email as email
 from lemur.plugins.lemur_email.templates.config import env
 
 
-def render_html(template_name, message):
+def render_html(template_name, options, certificates):
     """
     Renders the html for our email notification.
 
     :param template_name:
-    :param message:
+    :param options:
+    :param certificates:
     :return:
     """
+    message = {"options": options, "certificates": certificates}
     template = env.get_template("{}.html".format(template_name))
     return template.render(
         dict(message=message, hostname=current_app.config.get("LEMUR_HOSTNAME"))
@@ -100,8 +102,7 @@ class EmailNotificationPlugin(ExpirationNotificationPlugin):
 
         subject = "Lemur: {0} Notification".format(notification_type.capitalize())
 
-        data = {"options": options, "certificates": message}
-        body = render_html(notification_type, data)
+        body = render_html(notification_type, options, message)
 
         s_type = current_app.config.get("LEMUR_EMAIL_SENDER", "ses").lower()
 

--- a/lemur/plugins/lemur_email/templates/rotation.html
+++ b/lemur/plugins/lemur_email/templates/rotation.html
@@ -83,12 +83,12 @@
                                                                 <td width="32px"></td>
                                                                 <td width="16px"></td>
                                                                 <td style="line-height:1.2">
-                                                                    <span style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:20px;color:#202020">{{ certificate.name }}</span>
+                                                                    <span style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:20px;color:#202020">{{ message.certificates.name }}</span>
                                                                     <br>
                                                                     <span style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#727272">
-                                                                        <br>{{ certificate.owner }}
-                                                                        <br>{{ certificate.validityEnd | time }}
-                                                                        <a href="https://{{ hostname }}/#/certificates/{{ certificate.name }}" target="_blank">Details</a>
+                                                                        <br>{{ message.certificates.owner }}
+                                                                        <br>{{ message.certificates.validityEnd | time }}
+                                                                        <a href="https://{{ hostname }}/#/certificates/{{ message.certificates.name }}" target="_blank">Details</a>
                                                                     </span>
                                                                 </td>
                                                             </tr>
@@ -110,12 +110,12 @@
                                                             <td width="32px"></td>
                                                             <td width="16px"></td>
                                                             <td style="line-height:1.2">
-                                                                <span style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:20px;color:#202020">{{ certificate.replacedBy[0].name }}</span>
+                                                                <span style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:20px;color:#202020">{{ message.certificates.name }}</span>
                                                                 <br>
                                                                 <span style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#727272">
-                                                                        <br>{{ certificate.replacedBy[0].owner }}
-                                                                        <br>{{ certificate.replacedBy[0].validityEnd | time }}
-                                                                        <a href="https://{{ hostname }}/#/certificates/{{ certificate.replacedBy[0].name }}" target="_blank">Details</a>
+                                                                        <br>{{ message.certificates.owner }}
+                                                                        <br>{{ message.certificates.validityEnd | time }}
+                                                                        <a href="https://{{ hostname }}/#/certificates/{{ message.certificates.name }}" target="_blank">Details</a>
                                                                     </span>
                                                             </td>
                                                         </tr>
@@ -133,7 +133,7 @@
                                                     <table border="0" cellspacing="0" cellpadding="0"
                                                            style="margin-top:48px;margin-bottom:48px">
                                                         <tbody>
-                                                        {%  for endpoint in certificate.endpoints %}
+                                                        {%  for endpoint in message.certificates.endpoints %}
                                                             <tr valign="middle">
                                                                 <td width="32px"></td>
                                                                 <td width="16px"></td>

--- a/lemur/plugins/lemur_email/tests/test_email.py
+++ b/lemur/plugins/lemur_email/tests/test_email.py
@@ -1,36 +1,83 @@
 import os
-from lemur.plugins.lemur_email.templates.config import env
+from datetime import timedelta
 
+import arrow
+import boto3
+from moto import mock_ses
+
+from lemur.certificates.schemas import certificate_notification_output_schema
+from lemur.plugins.lemur_email.plugin import render_html
 from lemur.tests.factories import CertificateFactory
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
 
-def test_render(certificate, endpoint):
-    from lemur.certificates.schemas import certificate_notification_output_schema
+@mock_ses
+def verify_sender_email():
+    ses_client = boto3.client("ses", region_name="us-east-1")
+    ses_client.verify_email_identity(EmailAddress="lemur@example.com")
+
+
+def get_options():
+    return [
+        {"name": "interval", "value": 10},
+        {"name": "unit", "value": "days"},
+    ]
+
+
+def test_render_expiration(certificate, endpoint):
 
     new_cert = CertificateFactory()
     new_cert.replaces.append(certificate)
 
-    data = {
-        "certificates": [certificate_notification_output_schema.dump(certificate).data],
-        "options": [
-            {"name": "interval", "value": 10},
-            {"name": "unit", "value": "days"},
-        ],
-    }
+    assert render_html("expiration", get_options(), [certificate_notification_output_schema.dump(certificate).data])
 
-    template = env.get_template("{}.html".format("expiration"))
 
-    body = template.render(dict(message=data, hostname="lemur.test.example.com"))
-
-    template = env.get_template("{}.html".format("rotation"))
-
+def test_render_rotation(certificate, endpoint):
     certificate.endpoints.append(endpoint)
 
-    body = template.render(
-        dict(
-            certificate=certificate_notification_output_schema.dump(certificate).data,
-            hostname="lemur.test.example.com",
-        )
-    )
+    assert render_html("rotation", get_options(), certificate_notification_output_schema.dump(certificate).data)
+
+
+def test_render_rotation_failure(pending_certificate):
+    assert render_html("failed", get_options(), certificate_notification_output_schema.dump(pending_certificate).data)
+
+
+@mock_ses
+def test_send_expiration_notification():
+    from lemur.notifications.messaging import send_expiration_notifications
+    from lemur.tests.factories import CertificateFactory
+    from lemur.tests.factories import NotificationFactory
+
+    now = arrow.utcnow()
+    in_ten_days = now + timedelta(days=10, hours=1)  # a bit more than 10 days since we'll check in the future
+    certificate = CertificateFactory()
+    notification = NotificationFactory(plugin_name="email-notification")
+
+    certificate.not_after = in_ten_days
+    certificate.notifications.append(notification)
+    certificate.notifications[0].options = get_options()
+
+    verify_sender_email()
+    assert send_expiration_notifications([]) == (2, 0)
+
+
+@mock_ses
+def test_send_rotation_notification(endpoint, source_plugin):
+    from lemur.notifications.messaging import send_rotation_notification
+    from lemur.deployment.service import rotate_certificate
+
+    new_certificate = CertificateFactory()
+    rotate_certificate(endpoint, new_certificate)
+    assert endpoint.certificate == new_certificate
+
+    verify_sender_email()
+    assert send_rotation_notification(new_certificate)
+
+
+@mock_ses
+def test_send_pending_failure_notification(user, pending_certificate, async_issuer_plugin):
+    from lemur.notifications.messaging import send_pending_failure_notification
+
+    verify_sender_email()
+    assert send_pending_failure_notification(pending_certificate)

--- a/lemur/plugins/lemur_slack/plugin.py
+++ b/lemur/plugins/lemur_slack/plugin.py
@@ -58,26 +58,19 @@ def create_rotation_attachments(certificate):
         "title": certificate["name"],
         "title_link": create_certificate_url(certificate["name"]),
         "fields": [
+            {"title": "Owner", "value": certificate["owner"], "short": True},
             {
-                {"title": "Owner", "value": certificate["owner"], "short": True},
-                {
-                    "title": "Expires",
-                    "value": arrow.get(certificate["validityEnd"]).format(
-                        "dddd, MMMM D, YYYY"
-                    ),
-                    "short": True,
-                },
-                {
-                    "title": "Replaced By",
-                    "value": len(certificate["replaced"][0]["name"]),
-                    "short": True,
-                },
-                {
-                    "title": "Endpoints Rotated",
-                    "value": len(certificate["endpoints"]),
-                    "short": True,
-                },
-            }
+                "title": "Expires",
+                "value": arrow.get(certificate["validityEnd"]).format(
+                    "dddd, MMMM D, YYYY"
+                ),
+                "short": True,
+            },
+            {
+                "title": "Endpoints Rotated",
+                "value": len(certificate["endpoints"]),
+                "short": True,
+            },
         ],
     }
 

--- a/lemur/plugins/lemur_slack/tests/test_slack.py
+++ b/lemur/plugins/lemur_slack/tests/test_slack.py
@@ -21,3 +21,48 @@ def test_formatting(certificate):
     }
 
     assert attachment == create_expiration_attachments(data)[0]
+
+
+def get_options():
+    return [
+        {"name": "interval", "value": 10},
+        {"name": "unit", "value": "days"},
+    ]
+
+
+# Currently disabled as we have no good way to mock Slack webhooks
+# def test_send_expiration_notification():
+#     from lemur.notifications.messaging import send_expiration_notifications
+#     from lemur.tests.factories import CertificateFactory
+#
+#     now = arrow.utcnow()
+#     in_ten_days = now + timedelta(days=10, hours=1)  # a bit more than 10 days since we'll check in the future
+#     certificate = CertificateFactory()
+#     notification = NotificationFactory(plugin_name="slack-notification")
+#
+#     certificate.not_after = in_ten_days
+#     certificate.notifications.append(notification)
+#     certificate.notifications[0].options = get_options()
+#
+#     assert send_expiration_notifications([]) == (2, 0)
+
+
+# Currently disabled as we have no good way to mock Slack webhooks
+# def test_send_rotation_notification(endpoint, source_plugin):
+#     from lemur.notifications.messaging import send_rotation_notification
+#     from lemur.deployment.service import rotate_certificate
+#
+#     notification = NotificationFactory(plugin_name="slack-notification")
+#
+#     new_certificate = CertificateFactory()
+#     rotate_certificate(endpoint, new_certificate)
+#     assert endpoint.certificate == new_certificate
+#
+#     assert send_rotation_notification(new_certificate, notification_plugin=notification.plugin)
+
+
+# Currently disabled as the Slack plugin doesn't support this type of notification
+# def test_send_pending_failure_notification(user, pending_certificate, async_issuer_plugin):
+#     from lemur.notifications.messaging import send_pending_failure_notification
+#
+#     assert send_pending_failure_notification(pending_certificate, notification_plugin=plugins.get("slack-notification"))

--- a/lemur/tests/conf.py
+++ b/lemur/tests/conf.py
@@ -46,7 +46,7 @@ LEMUR_ALLOWED_DOMAINS = [
 
 # Lemur currently only supports SES for sending email, this address
 # needs to be verified
-LEMUR_EMAIL = ""
+LEMUR_EMAIL = "lemur@example.com"
 LEMUR_SECURITY_TEAM_EMAIL = ["security@example.com"]
 
 LEMUR_HOSTNAME = "lemur.example.com"

--- a/lemur/tests/test_messaging.py
+++ b/lemur/tests/test_messaging.py
@@ -1,8 +1,8 @@
+from datetime import timedelta
+
+import arrow
 import pytest
 from freezegun import freeze_time
-
-from datetime import timedelta
-import arrow
 from moto import mock_ses
 
 
@@ -105,4 +105,11 @@ def test_send_expiration_notification_with_no_notifications(
 def test_send_rotation_notification(notification_plugin, certificate):
     from lemur.notifications.messaging import send_rotation_notification
 
-    send_rotation_notification(certificate, notification_plugin=notification_plugin)
+    assert send_rotation_notification(certificate, notification_plugin=notification_plugin)
+
+
+@mock_ses
+def test_send_pending_failure_notification(notification_plugin, async_issuer_plugin, pending_certificate):
+    from lemur.notifications.messaging import send_pending_failure_notification
+
+    assert send_pending_failure_notification(pending_certificate, notification_plugin=notification_plugin)


### PR DESCRIPTION
This changes includes the following fixes:
- If multiple notifications were associated with a certificate, but _any_ of them was disabled, Lemur would stop iterating through the others, which could result in some notifications not being sent when they should have been.
- Rotation notifications and failed rotation notifications now work (only available via email). This involved a number of other changes, including some message template modifications.

Other changes:
- We now log when expiration notifications fail to be sent (previously the exception was swallowed, though metrics were sent).
- Added tests for messaging (in general) and email. Added a sample `LEMUR_EMAIL` in the config to support this.