### PR TITLE
Do not add urlContextPath to relative path

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -237,7 +237,7 @@ gulp.task('addUrlContextPath',['addUrlContextPath:revreplace'], function(){
   .forEach(function(file){
     return gulp.src(file)
       .pipe(gulpif(urlContextPathExists, replace('api/', argv.urlContextPath + '/api/')))
-      .pipe(gulpif(urlContextPathExists, replace('angular/', argv.urlContextPath + '/angular/')))
+      .pipe(gulpif(urlContextPathExists, replace('/angular/', '/' + argv.urlContextPath + '/angular/')))
       .pipe(gulp.dest(function(file){
         return file.base;
       }))
@@ -256,7 +256,6 @@ gulp.task('addUrlContextPath:revreplace', ['addUrlContextPath:revision'], functi
   var manifest = gulp.src("lemur/static/dist/rev-manifest.json");
   var urlContextPathExists = argv.urlContextPath ? true : false;
   return gulp.src( "lemur/static/dist/index.html")
-    .pipe(gulpif(urlContextPathExists, revReplace({prefix: argv.urlContextPath + '/', manifest: manifest}, revReplace({manifest: manifest}))))
     .pipe(gulp.dest('lemur/static/dist'));
 })
 


### PR DESCRIPTION
If we want access to Lemur with an URL like http://domain/foobar/ we have to build Lemur with:

```
# node_modules/.bin/gulp package --urlContextPath=foobar
```

But footbar is also add to relative path:

```
# grep -RhEo "(.)foobar/[a-zA-Z0-9.?=_%:-]*/" | sort | uniq -c
     15 "foobar/angular/
     21 'foobar/angular/
     92 /foobar/angular/
      4 /foobar/api/
      2 "foobar/scripts/
      1 "foobar/styles/
```
Some path are invalid (somethink like http://domain/foobar/foobar/angular/xxxxxxx).

With this patch, only absolute path is modified:

```
# grep -RhEo "(.)foobar/[a-zA-Z0-9.?=_%:-]*/" | sort | uniq -c
     92 /foobar/angular/
      4 /foobar/api/
```

Every pages works fine now.