### PR TITLE
Fix cert reissue when L/OU is not set

### DIFF
--- a/lemur/certificates/schemas.py
+++ b/lemur/certificates/schemas.py
@@ -353,6 +353,12 @@ class CertificateOutputSchema(LemurOutputSchema):
                 data.pop("organization", None)
                 data.pop("organizational_unit", None)
 
+        # Removing optional fields if None, else it complains in de-serialization
+        if "location" in data and data["location"] is None:
+            data.pop("location")
+        if "organizational_unit" in data and data["organizational_unit"] is None:
+            data.pop("organizational_unit")
+
 
 class CertificateShortOutputSchema(LemurOutputSchema):
     id = fields.Integer()

--- a/lemur/certificates/schemas.py
+++ b/lemur/certificates/schemas.py
@@ -340,6 +340,8 @@ class CertificateOutputSchema(LemurOutputSchema):
 
     @post_dump
     def handle_subject_details(self, data):
+        subject_details = ["country", "state", "location", "organization", "organizational_unit"]
+
         # Remove subject details if authority is CA/Browser Forum compliant. The code will use default set of values in that case.
         # If CA/Browser Forum compliance of an authority is unknown (None), it is safe to fallback to default values. Thus below
         # condition checks for 'not False' ==> 'True or None'
@@ -347,17 +349,13 @@ class CertificateOutputSchema(LemurOutputSchema):
             is_cab_compliant = data.get("authority").get("isCabCompliant")
 
             if is_cab_compliant is not False:
-                data.pop("country", None)
-                data.pop("state", None)
-                data.pop("location", None)
-                data.pop("organization", None)
-                data.pop("organizational_unit", None)
+                for field in subject_details:
+                    data.pop(field, None)
 
-        # Removing optional fields if None, else it complains in de-serialization
-        if "location" in data and data["location"] is None:
-            data.pop("location")
-        if "organizational_unit" in data and data["organizational_unit"] is None:
-            data.pop("organizational_unit")
+        # Removing subject fields if None, else it complains in de-serialization
+        for field in subject_details:
+            if field in data and data[field] is None:
+                data.pop(field)
 
 
 class CertificateShortOutputSchema(LemurOutputSchema):


### PR DESCRIPTION
get_certificate_primitives complains for None Location or Organizational Unit. These are optional fields that were added to [CertificateOutputSchema](https://github.com/Netflix/lemur/pull/3188/files#diff-20fb502199efa396152865a53b5a740e34917598249c46509a9a59c4fc8c3c50R335-R339)