### PR TITLE
Removing ECC 192 and 521 from UI

### DIFF
--- a/lemur/static/app/angular/authorities/authority/options.tpl.html
+++ b/lemur/static/app/angular/authorities/authority/options.tpl.html
@@ -24,7 +24,6 @@
               ng-options="option.value as option.name for option in [
                       {'name': 'RSA-2048', 'value': 'RSA2048'},
                       {'name': 'RSA-4096', 'value': 'RSA4096'},
-                      {'name': 'ECC-PRIME192V1', 'value': 'ECCPRIME192V1'},
                       {'name': 'ECC-PRIME256V1', 'value': 'ECCPRIME256V1'},
                       {'name': 'ECC-SECP384R1', 'value': 'ECCSECP384R1'},
                       {'name': 'ECC-SECP521R1', 'value': 'ECCSECP521R1'}]"

--- a/lemur/static/app/angular/certificates/certificate/options.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/options.tpl.html
@@ -35,10 +35,8 @@
                   ng-options="option.value as option.name for option in [
                       {'name': 'RSA-2048', 'value': 'RSA2048'},
                       {'name': 'RSA-4096', 'value': 'RSA4096'},
-                      {'name': 'ECC-PRIME192V1', 'value': 'ECCPRIME192V1'},
                       {'name': 'ECC-PRIME256V1', 'value': 'ECCPRIME256V1'},
-                      {'name': 'ECC-SECP384R1', 'value': 'ECCSECP384R1'},
-                      {'name': 'ECC-SECP521R1', 'value': 'ECCSECP521R1'}]"
+                      {'name': 'ECC-SECP384R1', 'value': 'ECCSECP384R1'}]"
 
                   ng-init="certificate.keyType = 'RSA2048'"></select>
         </div>


### PR DESCRIPTION
ECC 192 and 521 certificates are not supported by CA/Browser forum. Keeping 521 for authority creation though if higher strength algo is needed. Similar to #3194, no backend changes done.