### PR TITLE
Digicert time bug fix

### DIFF
--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -177,7 +177,7 @@ def map_cis_fields(options, csr):
         "csr": csr,
         "signature_hash": signature_hash(options.get("signing_algorithm")),
         "validity": {
-            "valid_to": validity_end.format("YYYY-MM-DDTHH:MM:ss") + "Z"
+            "valid_to": validity_end.format("YYYY-MM-DDTHH:mm:ss") + "Z"
         },
         "organization": {
             "name": options["organization"],

--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -177,7 +177,7 @@ def map_cis_fields(options, csr):
         "csr": csr,
         "signature_hash": signature_hash(options.get("signing_algorithm")),
         "validity": {
-            "valid_to": validity_end.format("YYYY-MM-DDTHH:MM:SS") + "Z"
+            "valid_to": validity_end.format("YYYY-MM-DDTHH:MM:ss") + "Z"
         },
         "organization": {
             "name": options["organization"],

--- a/lemur/plugins/lemur_digicert/tests/test_digicert.py
+++ b/lemur/plugins/lemur_digicert/tests/test_digicert.py
@@ -123,7 +123,7 @@ def test_map_cis_fields_with_validity_years(mock_current_app, authority):
             "signature_hash": "sha256",
             "organization": {"name": "Example, Inc."},
             "validity": {
-                "valid_to": arrow.get(2018, 11, 3).format("YYYY-MM-DDTHH:MM:SS") + "Z"
+                "valid_to": arrow.get(2018, 11, 3).format("YYYY-MM-DDTHH:mm:ss") + "Z"
             },
             "profile_name": None,
         }
@@ -159,7 +159,7 @@ def test_map_cis_fields_with_validity_end_and_start(mock_current_app, app, autho
             "signature_hash": "sha256",
             "organization": {"name": "Example, Inc."},
             "validity": {
-                "valid_to": arrow.get(2017, 5, 7).format("YYYY-MM-DDTHH:MM:SS") + "Z"
+                "valid_to": arrow.get(2017, 5, 7).format("YYYY-MM-DDTHH:mm:ss") + "Z"
             },
             "profile_name": None,
         }


### PR DESCRIPTION
fixing a nasty old bug in the date for valid_to:  where `MM` stands for month, and needed to be `mm`
we introduced a new bug with `SS` fo sub-seconds, which needed to be `ss`.
https://arrow.readthedocs.io/en/stable/#supported-tokens

DigiCert currently does not honor the requested date, and sets the expiration to last second of previous day, from valid_to.