### PR TITLE
Add ability to override SourceArn for SES

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -285,6 +285,16 @@ Lemur supports sending certificate expiration notifications through SES and SMTP
         you can send any mail. See: `Verifying Email Address in Amazon SES <http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html>`_
 
 
+.. data:: LEMUR_SES_SOURCE_ARN
+    :noindex:
+
+    Specifies an ARN to use as the SourceArn when sending emails via SES.
+
+    .. note::
+        This parameter is only required if you're using a sending authorization with SES.
+        See: `Using sending authorization with Amazon SES <https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html>`_
+
+
 .. data:: LEMUR_EMAIL
     :noindex:
 

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -295,6 +295,15 @@ Lemur supports sending certificate expiration notifications through SES and SMTP
         See: `Using sending authorization with Amazon SES <https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html>`_
 
 
+.. data:: LEMUR_SES_REGION
+    :noindex:
+
+    Specifies a region for sending emails via SES.
+
+    .. note::
+        This parameter defaults to us-east-1 and is only required if you wish to use a different region.
+
+
 .. data:: LEMUR_EMAIL
     :noindex:
 

--- a/lemur/plugins/lemur_email/plugin.py
+++ b/lemur/plugins/lemur_email/plugin.py
@@ -38,7 +38,7 @@ def render_html(template_name, options, certificates):
 
 def send_via_smtp(subject, body, targets):
     """
-    Attempts to deliver email notification via SES service.
+    Attempts to deliver email notification via SMTP.
 
     :param subject:
     :param body:
@@ -55,21 +55,25 @@ def send_via_smtp(subject, body, targets):
 
 def send_via_ses(subject, body, targets):
     """
-    Attempts to deliver email notification via SMTP.
+    Attempts to deliver email notification via SES service.
     :param subject:
     :param body:
     :param targets:
     :return:
     """
     client = boto3.client("ses", region_name="us-east-1")
-    client.send_email(
-        Source=current_app.config.get("LEMUR_EMAIL"),
-        Destination={"ToAddresses": targets},
-        Message={
+    source_arn = current_app.config.get("LEMUR_SES_SOURCE_ARN")
+    args = {
+        "Source": current_app.config.get("LEMUR_EMAIL"),
+        "Destination": {"ToAddresses": targets},
+        "Message": {
             "Subject": {"Data": subject, "Charset": "UTF-8"},
             "Body": {"Html": {"Data": body, "Charset": "UTF-8"}},
         },
-    )
+    }
+    if source_arn:
+        args["SourceArn"] = source_arn
+    client.send_email(**args)
 
 
 class EmailNotificationPlugin(ExpirationNotificationPlugin):

--- a/lemur/plugins/lemur_email/plugin.py
+++ b/lemur/plugins/lemur_email/plugin.py
@@ -61,9 +61,7 @@ def send_via_ses(subject, body, targets):
     :param targets:
     :return:
     """
-    ses_region = current_app.config.get("LEMUR_SES_REGION")
-    if not ses_region:
-        ses_region = "us-east-1"
+    ses_region = current_app.config.get("LEMUR_SES_REGION", "us-east-1")
     client = boto3.client("ses", region_name=ses_region)
     source_arn = current_app.config.get("LEMUR_SES_SOURCE_ARN")
     args = {

--- a/lemur/plugins/lemur_email/plugin.py
+++ b/lemur/plugins/lemur_email/plugin.py
@@ -61,7 +61,10 @@ def send_via_ses(subject, body, targets):
     :param targets:
     :return:
     """
-    client = boto3.client("ses", region_name="us-east-1")
+    ses_region = current_app.config.get("LEMUR_SES_REGION")
+    if not ses_region:
+        ses_region = "us-east-1"
+    client = boto3.client("ses", region_name=ses_region)
     source_arn = current_app.config.get("LEMUR_SES_SOURCE_ARN")
     args = {
         "Source": current_app.config.get("LEMUR_EMAIL"),


### PR DESCRIPTION
This is a requirement in order to use an [SES authorization policy](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-policies.html).