### PR TITLE
Add subject for SNS messages and correct date format

### DIFF
--- a/lemur/plugins/lemur_aws/sns.py
+++ b/lemur/plugins/lemur_aws/sns.py
@@ -15,16 +15,18 @@ from flask import current_app
 def publish(topic_arn, certificates, notification_type, **kwargs):
     sns_client = boto3.client("sns", **kwargs)
     message_ids = {}
+    subject = "Lemur: {0} Notification".format(notification_type.capitalize())
     for certificate in certificates:
-        message_ids[certificate["name"]] = publish_single(sns_client, topic_arn, certificate, notification_type)
+        message_ids[certificate["name"]] = publish_single(sns_client, topic_arn, certificate, notification_type, subject)
 
     return message_ids
 
 
-def publish_single(sns_client, topic_arn, certificate, notification_type):
+def publish_single(sns_client, topic_arn, certificate, notification_type, subject):
     response = sns_client.publish(
         TopicArn=topic_arn,
         Message=format_message(certificate, notification_type),
+        Subject=subject,
     )
 
     response_code = response["ResponseMetadata"]["HTTPStatusCode"]
@@ -48,8 +50,9 @@ def format_message(certificate, notification_type):
     json_message = {
         "notification_type": notification_type,
         "certificate_name": certificate["name"],
-        "expires": arrow.get(certificate["validityEnd"]).format("YYYY-MM-ddTHH:mm:ss"),  # 2047-12-T22:00:00
+        "expires": arrow.get(certificate["validityEnd"]).format("YYYY-MM-DDTHH:mm:ss"),  # 2047-12-31T22:00:00
         "endpoints_detected": len(certificate["endpoints"]),
+        "owner": certificate["owner"],
         "details": create_certificate_url(certificate["name"])
     }
     return json.dumps(json_message)

--- a/lemur/plugins/lemur_aws/tests/test_sns.py
+++ b/lemur/plugins/lemur_aws/tests/test_sns.py
@@ -20,8 +20,9 @@ def test_format(certificate, endpoint):
         expected_message = {
             "notification_type": "expiration",
             "certificate_name": certificate["name"],
-            "expires": arrow.get(certificate["validityEnd"]).format("YYYY-MM-ddTHH:mm:ss"),
+            "expires": arrow.get(certificate["validityEnd"]).format("YYYY-MM-DDTHH:mm:ss"),
             "endpoints_detected": 0,
+            "owner": certificate["owner"],
             "details": "https://lemur.example.com/#/certificates/{name}".format(name=certificate["name"])
         }
         assert expected_message == json.loads(format_message(certificate, "expiration"))
@@ -57,7 +58,9 @@ def test_publish(certificate, endpoint):
         expected_message_id = message_ids[certificate["name"]]
         actual_message = next(
             (m for m in received_messages if json.loads(m["Body"])["MessageId"] == expected_message_id), None)
-        assert json.loads(actual_message["Body"])["Message"] == format_message(certificate, "expiration")
+        actual_json = json.loads(actual_message["Body"])
+        assert actual_json["Message"] == format_message(certificate, "expiration")
+        assert actual_json["Subject"] == "Lemur: Expiration Notification"
 
 
 def get_options():


### PR DESCRIPTION
Add subject for SNS messages and correct date format. Subject is only used for email subscriptions (according to [the documentation](https://docs.aws.amazon.com/sns/latest/api/API_Publish.html)).