### PR TITLE
Small fixes

### DIFF
--- a/lemur/authorities/models.py
+++ b/lemur/authorities/models.py
@@ -93,9 +93,11 @@ class Authority(db.Model):
         if not self.options:
             return None
 
-        for option in json.loads(self.options):
-            if "name" in option and option["name"] == 'cab_compliant':
-                return option["value"]
+        options_array = json.loads(self.options)
+        if isinstance(options_array, list):
+            for option in options_array:
+                if "name" in option and option["name"] == 'cab_compliant':
+                    return option["value"]
 
         return None
 

--- a/lemur/migrations/versions/c301c59688d2_.py
+++ b/lemur/migrations/versions/c301c59688d2_.py
@@ -74,6 +74,7 @@ def downgrade():
         "update certificates set key_type=null where not_after > CURRENT_DATE - 32"
     )
     op.execute(stmt)
+    commit()
 
 
 """

--- a/lemur/static/app/angular/authorities/authority/options.tpl.html
+++ b/lemur/static/app/angular/authorities/authority/options.tpl.html
@@ -21,13 +21,7 @@
     </label>
     <div class="col-sm-10">
       <select class="form-control" ng-model="authority.keyType"
-              ng-options="option.value as option.name for option in [
-                      {'name': 'RSA-2048', 'value': 'RSA2048'},
-                      {'name': 'RSA-4096', 'value': 'RSA4096'},
-                      {'name': 'ECC-PRIME256V1', 'value': 'ECCPRIME256V1'},
-                      {'name': 'ECC-SECP384R1', 'value': 'ECCSECP384R1'},
-                      {'name': 'ECC-SECP521R1', 'value': 'ECCSECP521R1'}]"
-
+              ng-options="option for option in ['RSA2048', 'RSA4096', 'ECCPRIME256V1', 'ECCSECP384R1', 'ECCSECP521R1']"
               ng-init="authority.keyType = 'RSA2048'">
       </select>
     </div>

--- a/lemur/static/app/angular/certificates/certificate/options.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/options.tpl.html
@@ -32,12 +32,7 @@
         </label>
         <div class="col-sm-10">
           <select class="form-control" ng-model="certificate.keyType"
-                  ng-options="option.value as option.name for option in [
-                      {'name': 'RSA-2048', 'value': 'RSA2048'},
-                      {'name': 'RSA-4096', 'value': 'RSA4096'},
-                      {'name': 'ECC-PRIME256V1', 'value': 'ECCPRIME256V1'},
-                      {'name': 'ECC-SECP384R1', 'value': 'ECCSECP384R1'}]"
-
+                  ng-options="option for option in ['RSA2048', 'RSA4096', 'ECCPRIME256V1', 'ECCSECP384R1']"
                   ng-init="certificate.keyType = 'RSA2048'"></select>
         </div>
       </div>


### PR DESCRIPTION
1. Check if authority options is JSON Array
2. Added missing commit to downgrade() in migration file c301c59688d2_.py 
3. Consistent algo in UI and API : Given very few options displayed on UI, it is user-friendly to use same algorithm name strings in API and to display on UI. Thus removed hyphen.