### PR TITLE
Stop repeating certs when sending expiration notifications to security team email

### DIFF
--- a/lemur/notifications/messaging.py
+++ b/lemur/notifications/messaging.py
@@ -137,11 +137,11 @@ def send_expiration_notifications(exclude):
     # security team gets all
     security_email = current_app.config.get("LEMUR_SECURITY_TEAM_EMAIL")
 
-    security_data = []
     for owner, notification_group in get_eligible_certificates(exclude=exclude).items():
 
         for notification_label, certificates in notification_group.items():
             notification_data = []
+            security_data = []
 
             notification = certificates[0][0]
 


### PR DESCRIPTION
This solves #2635. There remains an open question (raised in that issue) as to whether we should be sending a single email to the security team with all expiring certs, or if it should one email per cert-owner-notification group, as it is now. For the moment, I'm taking the easier approach and leaving it a single email per cert, but may revisit later.