### PR TITLE
Version updates

### DIFF
--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -12,6 +12,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from flask import current_app
 from sqlalchemy import func, or_, not_, cast, Integer
+from sqlalchemy.sql.expression import false, true
 
 from lemur import database
 from lemur.authorities.models import Authority
@@ -150,7 +151,7 @@ def get_all_certs_attached_to_endpoint_without_autorotate():
         """
     return (
         Certificate.query.filter(Certificate.endpoints.any())
-        .filter(Certificate.rotation == False)
+        .filter(Certificate.rotation == false())
         .filter(Certificate.not_after >= arrow.now())
         .filter(not_(Certificate.replaced.any()))
         .all()  # noqa
@@ -205,9 +206,9 @@ def get_all_pending_reissue():
     :return:
     """
     return (
-        Certificate.query.filter(Certificate.rotation == True)
+        Certificate.query.filter(Certificate.rotation == true())
         .filter(not_(Certificate.replaced.any()))
-        .filter(Certificate.in_rotation_window == True)
+        .filter(Certificate.in_rotation_window == true())
         .all()
     )  # noqa
 
@@ -525,7 +526,7 @@ def render(args):
         )
 
     if current_app.config.get("ALLOW_CERT_DELETION", False):
-        query = query.filter(Certificate.deleted == False)  # noqa
+        query = query.filter(Certificate.deleted == false())
 
     result = database.sort_and_page(query, Certificate, args)
     return result

--- a/lemur/certificates/utils.py
+++ b/lemur/certificates/utils.py
@@ -82,4 +82,4 @@ def get_key_type_from_csr(data):
             raise Exception("Unsupported key type")
 
     except NotImplemented:
-        raise NotImplemented()
+        raise NotImplementedError

--- a/lemur/notifications/messaging.py
+++ b/lemur/notifications/messaging.py
@@ -16,6 +16,7 @@ from itertools import groupby
 import arrow
 from flask import current_app
 from sqlalchemy import and_
+from sqlalchemy.sql.expression import false, true
 
 from lemur import database
 from lemur.certificates.models import Certificate
@@ -40,10 +41,10 @@ def get_certificates(exclude=None):
     q = (
         database.db.session.query(Certificate)
         .filter(Certificate.not_after <= max)
-        .filter(Certificate.notify == True)
-        .filter(Certificate.expired == False)
-        .filter(Certificate.revoked == False)
-    )  # noqa
+        .filter(Certificate.notify == true())
+        .filter(Certificate.expired == false())
+        .filter(Certificate.revoked == false())
+    )
 
     exclude_conditions = []
     if exclude:

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,6 +1,6 @@
 # Run `make up-reqs` to update pinned dependencies in requirement text files
 
-flake8==3.5.0 # flake8 3.6.0 is giving erroneous "W605 invalid escape sequence" errors.
+flake8==3.8.4 # flake8 latest version
 pre-commit
 invoke
 twine

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ cryptography==3.2.1       # via secretstorage
 distlib==0.3.0            # via virtualenv
 docutils==0.16            # via readme-renderer
 filelock==3.0.12          # via virtualenv
-flake8==3.5.0             # via -r requirements-dev.in
+flake8==3.8.0             # via -r requirements-dev.in
 identify==1.4.14          # via pre-commit
 idna==2.9                 # via requests
 invoke==1.4.1             # via -r requirements-dev.in
@@ -25,9 +25,9 @@ mccabe==0.6.1             # via flake8
 nodeenv==1.5.0            # via -r requirements-dev.in, pre-commit
 pkginfo==1.5.0.1          # via twine
 pre-commit==2.8.2         # via -r requirements-dev.in
-pycodestyle==2.3.1        # via flake8
+pycodestyle==2.6.0        # via flake8
 pycparser==2.20           # via cffi
-pyflakes==1.6.0           # via flake8
+pyflakes==2.2.0           # via flake8
 pygments==2.6.1           # via readme-renderer
 pyyaml==5.3.1             # via -r requirements-dev.in, pre-commit
 readme-renderer==25.0     # via twine

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,9 +15,9 @@ cryptography==3.2.1       # via secretstorage
 distlib==0.3.0            # via virtualenv
 docutils==0.16            # via readme-renderer
 filelock==3.0.12          # via virtualenv
-flake8==3.8.0             # via -r requirements-dev.in
 identify==1.4.14          # via pre-commit
 idna==2.9                 # via requests
+flake8==3.8.4             # via -r requirements-dev.in
 invoke==1.4.1             # via -r requirements-dev.in
 jeepney==0.4.3            # via keyring, secretstorage
 keyring==21.2.0           # via twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,14 +15,14 @@ bcrypt==3.1.7             # via flask-bcrypt, paramiko
 beautifulsoup4==4.9.1     # via cloudflare
 billiard==3.6.3.0         # via celery
 blinker==1.4              # via flask-mail, flask-principal, raven
-boto3==1.16.9             # via -r requirements.in
-botocore==1.19.9          # via -r requirements.in, boto3, s3transfer
+boto3==1.16.10            # via -r requirements.in
+botocore==1.19.10         # via -r requirements.in, boto3, s3transfer
 celery[redis]==4.4.2      # via -r requirements.in
 certifi==2020.6.20        # via -r requirements.in, requests
 certsrv==2.1.1            # via -r requirements.in
 cffi==1.14.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
-click==7.1.1              # via flask
+click==7.1.2              # black 20.8b1 has requirement click>=7.1.2
 cloudflare==2.8.13        # via -r requirements.in
 cryptography==3.2.1       # via -r requirements.in, acme, josepy, paramiko, pyopenssl, requests
 dnspython3==1.15.0        # via -r requirements.in


### PR DESCRIPTION
To fix build errors like :

```
ERROR: flake8 3.5.0 has requirement pyflakes<1.7.0,>=1.5.0, but you'll have pyflakes 2.2.0 which is incompatible.
ERROR: black 20.8b1 has requirement click>=7.1.2, but you'll have click 7.1.1 which is incompatible.
```