### PR TITLE
Fix group lookup when AD DNS Referal is in lookup path

### DIFF
--- a/lemur/auth/ldap.py
+++ b/lemur/auth/ldap.py
@@ -210,7 +210,8 @@ class LdapPrincipal:
             self.ldap_groups = []
             for group in lgroups:
                 (dn, values) = group
-                self.ldap_groups.append(values["cn"][0].decode("ascii"))
+                if type(values) == dict:
+                    self.ldap_groups.append(values["cn"][0].decode("ascii"))
         else:
             lgroups = self.ldap_client.search_s(
                 self.ldap_base_dn, ldap.SCOPE_SUBTREE, ldap_filter, self.ldap_attrs


### PR DESCRIPTION
Fix an issue when the DNS AD referal is in the path.
An Exception is raised, with the following stacktrace::

  Traceback (most recent call last):
    File "/www/lemur/lemur/auth/views.py", line 317, in post
      user = ldap_principal.authenticate()
    File "/www/lemur/lemur/auth/ldap.py", line 147, in authenticate
      self._bind()
    File "/www/lemur/lemur/auth/ldap.py", line 216, in _bind
      self.ldap_groups.append(values["cn"][0].decode("ascii"))
  TypeError: list indices must be integers or slices, not str

This is issue is trigerred by some extra rows that referrences
the DNS subtree::

   ['ldaps://DomainDnsZones.xxxx']

Limiting the extraction to the expected dicts fix this issue.