### PR TITLE
Send a single email to multiple recipients instead of multiple emails

### DIFF
--- a/lemur/notifications/messaging.py
+++ b/lemur/notifications/messaging.py
@@ -161,8 +161,10 @@ def send_expiration_notifications(exclude):
                 success += len(email_recipients)
             else:
                 failure += len(email_recipients)
-            # If we're using an email plugin, we're done;
-            # if not, we also need to send an email notification to the security team and owner
+            # If we're using an email plugin, we're done,
+            #   since "security_email + [owner]" were added as email_recipients.
+            # If we're not using an email plugin, we also need to send an email to the security team and owner,
+            #   since the plugin notification didn't send anything to them.
             if notification.plugin.slug != "email-notification":
                 if send_default_notification(
                         "expiration", notification_data, email_recipients, notification.options

--- a/lemur/plugins/bases/notification.py
+++ b/lemur/plugins/bases/notification.py
@@ -20,14 +20,14 @@ class NotificationPlugin(Plugin):
     def send(self, notification_type, message, targets, options, **kwargs):
         raise NotImplementedError
 
-    def filter_recipients(self, options, excluded_recipients):
+    def get_recipients(self, options, additional_recipients):
         """
-        Given a set of options (which should include configured recipient info), filters out recipients that
-        we do NOT want to notify.
+        Given a set of options (which should include configured recipient info), returns the parsed list of recipients
+        from those options plus the additional recipients specified. The returned value has no duplicates.
 
-        For any notification types where recipients can't be dynamically modified, this returns an empty list.
+        For any notification types where recipients can't be dynamically modified, this returns only the additional recipients.
         """
-        return []
+        return additional_recipients
 
 
 class ExpirationNotificationPlugin(NotificationPlugin):

--- a/lemur/plugins/lemur_email/plugin.py
+++ b/lemur/plugins/lemur_email/plugin.py
@@ -105,6 +105,8 @@ class EmailNotificationPlugin(ExpirationNotificationPlugin):
 
     @staticmethod
     def send(notification_type, message, targets, options, **kwargs):
+        if not targets:
+            return
 
         subject = "Lemur: {0} Notification".format(notification_type.capitalize())
 
@@ -119,11 +121,9 @@ class EmailNotificationPlugin(ExpirationNotificationPlugin):
             send_via_smtp(subject, body, targets)
 
     @staticmethod
-    def filter_recipients(options, excluded_recipients, **kwargs):
+    def get_recipients(options, additional_recipients, **kwargs):
         notification_recipients = get_plugin_option("recipients", options)
         if notification_recipients:
             notification_recipients = notification_recipients.split(",")
-            # removing owner and security_email from notification_recipient
-            notification_recipients = [i for i in notification_recipients if i not in excluded_recipients]
 
-        return notification_recipients
+        return list(set(notification_recipients + additional_recipients))

--- a/lemur/plugins/lemur_email/tests/test_email.py
+++ b/lemur/plugins/lemur_email/tests/test_email.py
@@ -21,7 +21,6 @@ def get_options():
 
 
 def test_render_expiration(certificate, endpoint):
-
     new_cert = CertificateFactory()
     new_cert.replaces.append(certificate)
 
@@ -82,16 +81,14 @@ def test_send_pending_failure_notification(user, pending_certificate, async_issu
     assert send_pending_failure_notification(pending_certificate, False, False)
 
 
-def test_filter_recipients(certificate, endpoint):
+def test_get_recipients(certificate, endpoint):
     from lemur.plugins.lemur_email.plugin import EmailNotificationPlugin
 
     options = [{"name": "recipients", "value": "security@example.com,joe@example.com"}]
-    assert sorted(EmailNotificationPlugin.get_recipients(options, [])) == sorted([
-        "security@example.com", "joe@example.com"])
-    assert sorted(EmailNotificationPlugin.get_recipients(options, ["security@example.com"])) == sorted([
-        "security@example.com", "joe@example.com"])
-    assert sorted(EmailNotificationPlugin.get_recipients(options, ["bob@example.com"])) == sorted([
-        "security@example.com", "bob@example.com", "joe@example.com"])
-    assert sorted(EmailNotificationPlugin.get_recipients(options,
-                                                  ["security@example.com", "bob@example.com", "joe@example.com"])) == sorted([
-               "security@example.com", "bob@example.com", "joe@example.com"])
+    two_emails = sorted(["security@example.com", "joe@example.com"])
+    assert sorted(EmailNotificationPlugin.get_recipients(options, [])) == two_emails
+    assert sorted(EmailNotificationPlugin.get_recipients(options, ["security@example.com"])) == two_emails
+    three_emails = sorted(["security@example.com", "bob@example.com", "joe@example.com"])
+    assert sorted(EmailNotificationPlugin.get_recipients(options, ["bob@example.com"])) == three_emails
+    assert sorted(EmailNotificationPlugin.get_recipients(options, ["security@example.com", "bob@example.com",
+                                                                   "joe@example.com"])) == three_emails


### PR DESCRIPTION
Modify email notification logic to send a single email that combines owner, security, and notification recipients, instead of sending three separate emails.

The intent of this change is that sending a single email that includes the security team should make it more clear exactly which emails were sent, as (for now) the security team will receive a copy of each email.

Note: More extensive changes to security emails will be coming, but this a short-term fix to increase email visibility.