### PR TITLE
Remove python-ldap from requirements-docs.txt

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -79,7 +79,6 @@ pyrfc3339==1.1            # via -r requirements.txt, acme
 python-dateutil==2.8.1    # via -r requirements.txt, alembic, arrow, botocore
 python-editor==1.0.4      # via -r requirements.txt, alembic
 python-json-logger==0.1.11  # via -r requirements.txt, logmatic-python
-python-ldap==3.3.1        # via -r requirements.txt
 pytz==2019.3              # via -r requirements.txt, acme, babel, celery, flask-restful, pyrfc3339
 pyyaml==5.3.1             # via -r requirements.txt, cloudflare
 raven[flask]==6.10.0      # via -r requirements.txt


### PR DESCRIPTION
The [doc build](https://readthedocs.org/projects/lemur/builds/) is failing due to the following:

```
  gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DHAVE_SASL -DHAVE_TLS -DHAVE_LIBLDAP_R -DHAVE_LIBLDAP_R -DLDAPMODULE_VERSION=3.3.1 -DLDAPMODULE_AUTHOR=python-ldap project -DLDAPMODULE_LICENSE=Python style -IModules -I/home/docs/.pyenv/versions/3.7.9/include/python3.7m -c Modules/LDAPObject.c -o build/temp.linux-x86_64-3.7/Modules/LDAPObject.o
  In file included from Modules/LDAPObject.c:3:0:
  Modules/common.h:15:10: fatal error: lber.h: No such file or directory
   #include <lber.h>
            ^~~~~~~~
  compilation terminated.
  error: command 'gcc' failed with exit status 1
```

There is logic to remove `python-ldap` from `requirements-docs.txt` already: https://github.com/Netflix/lemur/blob/master/Makefile#L124
(More explanation [here](https://github.com/Netflix/lemur/blob/master/requirements-docs.in#L1-L3).)

The original build failure started with commit 2d2ecde, which notably [added python-ldap back to `requirements-docs.txt`](https://github.com/Netflix/lemur/commit/daafb5ddd4e482bc5ca940ffcbdac395e820476d#diff-869e5cd1317744d01f3b4e41d5a6b38d89ee33a279ada740515a9dff20659571R82). It has never since been removed.

I'm not certain if there's a flaw in the dependency upgrade process (is the auto-remove logic broken?), so open to feedback there, but I'm hoping this may fix the immediate issue until the next upgrade, at least.