### PR TITLE
Fix ACME revoke_certificate

### DIFF
--- a/lemur/plugins/lemur_acme/acme_handlers.py
+++ b/lemur/plugins/lemur_acme/acme_handlers.py
@@ -224,7 +224,7 @@ class AcmeHandler(object):
     def revoke_certificate(self, certificate):
         if not self.reuse_account(certificate.authority):
             raise InvalidConfiguration("There is no ACME account saved, unable to revoke the certificate.")
-        acme_client, _ = self.acme.setup_acme_client(certificate.authority)
+        acme_client, _ = self.setup_acme_client(certificate.authority)
 
         fullchain_com = jose.ComparableX509(
             OpenSSL.crypto.load_certificate(


### PR DESCRIPTION
Fixes #3255

I fixed the issue, but wasn't able to implement proper tests for it in the short amount of time I had.

It's necessary to mock quite a few things within the AcmeHandler, to make sure we don't test too much of the 3rd party libraries.
For now I recommend to merge the PR, and hopefully I can find time to writer proper tests at a later time.