### PR TITLE
LDAP: error decoding CN when using Active Directory

### DIFF
--- a/lemur/auth/ldap.py
+++ b/lemur/auth/ldap.py
@@ -211,7 +211,7 @@ class LdapPrincipal:
             for group in lgroups:
                 (dn, values) = group
                 if type(values) == dict:
-                    self.ldap_groups.append(values["cn"][0].decode("ascii"))
+                    self.ldap_groups.append(values["cn"][0].decode("utf-8"))
         else:
             lgroups = self.ldap_client.search_s(
                 self.ldap_base_dn, ldap.SCOPE_SUBTREE, ldap_filter, self.ldap_attrs

--- a/lemur/common/utils.py
+++ b/lemur/common/utils.py
@@ -34,10 +34,12 @@ paginated_parser.add_argument("sortBy", type=str, dest="sort_by", location="args
 paginated_parser.add_argument("filter", type=str, location="args")
 paginated_parser.add_argument("owner", type=str, location="args")
 
+
 def base64encode(string):
     # Performs Base64 encoding of string to string using the base64.b64encode() function
     # which encodes bytes to bytes.
     return base64.b64encode(string.encode()).decode()
+
 
 def get_psuedo_random_string():
     """


### PR DESCRIPTION
I set up LDAP Authentication.
Certain users worked, but some not.
I got the following error:
ERROR in views: ldap error: 'ascii' codec can't decode byte 0xc3 in position 3: ordinal not in range(128)

Digging around I found the problem in auth/ldap.py:214.
There a decode with "ascii" is performed. When i changed this to "utf-8" it worked for the failing users as well.

self.ldap_groups.append(values["cn"][0].decode("utf-8"))

There is a similar code a few lines below, but I can only test AD.