### PR TITLE
Change certificate status to revoked after ACME revoke_certificate

### DIFF
--- a/lemur/plugins/lemur_acme/acme_handlers.py
+++ b/lemur/plugins/lemur_acme/acme_handlers.py
@@ -240,6 +240,7 @@ class AcmeHandler(object):
 
         current_app.logger.warning("Certificate succesfully revoked: " + certificate.name)
         metrics.send("acme_revoke_certificate_success", "counter", 1)
+        certificate.status = "revoked"
         return True
 
 


### PR DESCRIPTION
On successful completion of ACME revoke_certificate, change
certificate.status to revoked

Changes validity as Revoked
![image](https://user-images.githubusercontent.com/42279685/100319362-7ad92700-2fe5-11eb-9466-6785c7ed90c1.png)
