### PR TITLE
Preselect ECCPRIME256V1 on UI for cert minting

### DIFF
--- a/lemur/static/app/angular/certificates/certificate/options.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/options.tpl.html
@@ -33,7 +33,7 @@
         <div class="col-sm-10">
           <select class="form-control" ng-model="certificate.keyType"
                   ng-options="option for option in ['RSA2048', 'RSA4096', 'ECCPRIME256V1', 'ECCSECP384R1']"
-                  ng-init="certificate.keyType = 'RSA2048'"></select>
+                  ng-init="certificate.keyType = 'ECCPRIME256V1'"></select>
         </div>
       </div>
       <div class="form-group">


### PR DESCRIPTION
This change is to pre-select **ECCPRIME256V1** algorithm on UI while creating a new certificate. Before this change, RSA2048 was default value of the algorithm. User can go to 'More Options' to select algorithm of choice (no change there).