### PR TITLE
Use --no-emit-index-url instead of deprecated --no-index in pip-compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,10 +115,10 @@ endif
 	@echo "--> Updating Python requirements"
 	pip install --upgrade pip
 	pip install --upgrade pip-tools
-	pip-compile --output-file requirements.txt requirements.in -U --no-index
-	pip-compile --output-file requirements-docs.txt requirements-docs.in -U --no-index
-	pip-compile --output-file requirements-dev.txt requirements-dev.in -U --no-index
-	pip-compile --output-file requirements-tests.txt requirements-tests.in -U --no-index
+	pip-compile --output-file requirements.txt requirements.in -U --no-emit-index-url
+	pip-compile --output-file requirements-docs.txt requirements-docs.in -U --no-emit-index-url
+	pip-compile --output-file requirements-dev.txt requirements-dev.in -U --no-emit-index-url
+	pip-compile --output-file requirements-tests.txt requirements-tests.in -U --no-emit-index-url
 	@echo "--> Done updating Python requirements"
 	@echo "--> Removing python-ldap from requirements-docs.txt"
 	grep -v "python-ldap" requirements-docs.txt > tempreqs && mv tempreqs requirements-docs.txt


### PR DESCRIPTION
`pip-compile --no-index` is deprecated since [pip-tools==5.2.0](https://github.com/jazzband/pip-tools/releases/tag/5.2.0)