### PR TITLE
Fix the docs, attempt #2

### DIFF
--- a/requirements-docs.in
+++ b/requirements-docs.in
@@ -1,7 +1,7 @@
 # Note: python-ldap from requirements breaks due to readthedocs.io not having the correct header files
 # The `make up-reqs` will update all requirement text files, and forcibly remove python-ldap
 # from requirements-docs.txt
--r requirements.txt
+# However, dependabot doesn't use `make up-reqs`, so `-r requirements.txt` has been removed completely.
 sphinx
 sphinxcontrib-httpdomain
 sphinx-rtd-theme

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -79,7 +79,6 @@ pyrfc3339==1.1            # via -r requirements.txt, acme
 python-dateutil==2.8.1    # via -r requirements.txt, alembic, arrow, botocore
 python-editor==1.0.4      # via -r requirements.txt, alembic
 python-json-logger==0.1.11  # via -r requirements.txt, logmatic-python
-python-ldap==3.3.1        # via -r requirements.txt
 pytz==2019.3              # via -r requirements.txt, acme, babel, celery, flask-restful, pyrfc3339
 pyyaml==5.3.1             # via -r requirements.txt, cloudflare
 raven[flask]==6.10.0      # via -r requirements.txt


### PR DESCRIPTION
[The docs](https://readthedocs.org/projects/lemur/builds/) once again broke from commit 12b2069 by dependabot. Since the workaround that was originally in place doesn't seem to work for dependabot, I wanted to take a different approach.

I am not deeply familiar with Python dependency management, so please let me know if this doesn't make sense.