### PR TITLE
Corrected delivery of TLS format

### DIFF
--- a/lemur/plugins/lemur_kubernetes/plugin.py
+++ b/lemur/plugins/lemur_kubernetes/plugin.py
@@ -10,6 +10,7 @@
 
 .. moduleauthor:: Mikhail Khodorovskiy <mikhail.khodorovskiy@jivesoftware.com>
 """
+import base64
 import itertools
 import os
 
@@ -17,7 +18,7 @@ import requests
 from flask import current_app
 
 from lemur.common.defaults import common_name
-from lemur.common.utils import parse_certificate, base64encode
+from lemur.common.utils import parse_certificate
 from lemur.plugins.bases import DestinationPlugin
 
 DEFAULT_API_VERSION = "v1"
@@ -72,6 +73,12 @@ def _resolve_uri(k8s_base_uri, namespace, kind, name=None, api_ver=DEFAULT_API_V
     )
 
 
+# Performs Base64 encoding of string to string using the base64.b64encode() function
+# which encodes bytes to bytes.
+def base64encode(string):
+    return base64.b64encode(string.encode()).decode()
+
+
 def build_secret(secret_format, secret_name, body, private_key, cert_chain):
     secret = {
         "apiVersion": "v1",
@@ -89,7 +96,7 @@ def build_secret(secret_format, secret_name, body, private_key, cert_chain):
     if secret_format == "TLS":
         secret["type"] = "kubernetes.io/tls"
         secret["data"] = {
-            "tls.crt": base64encode(body),
+            "tls.crt": base64encode("%s\n%s" % (body, cert_chain)),
             "tls.key": base64encode(private_key),
         }
     if secret_format == "Certificate":

--- a/lemur/plugins/lemur_kubernetes/plugin.py
+++ b/lemur/plugins/lemur_kubernetes/plugin.py
@@ -10,7 +10,6 @@
 
 .. moduleauthor:: Mikhail Khodorovskiy <mikhail.khodorovskiy@jivesoftware.com>
 """
-import base64
 import itertools
 import os
 
@@ -18,7 +17,7 @@ import requests
 from flask import current_app
 
 from lemur.common.defaults import common_name
-from lemur.common.utils import parse_certificate
+from lemur.common.utils import parse_certificate, base64encode
 from lemur.plugins.bases import DestinationPlugin
 
 DEFAULT_API_VERSION = "v1"
@@ -71,12 +70,6 @@ def _resolve_uri(k8s_base_uri, namespace, kind, name=None, api_ver=DEFAULT_API_V
             ]
         )
     )
-
-
-# Performs Base64 encoding of string to string using the base64.b64encode() function
-# which encodes bytes to bytes.
-def base64encode(string):
-    return base64.b64encode(string.encode()).decode()
 
 
 def build_secret(secret_format, secret_name, body, private_key, cert_chain):


### PR DESCRIPTION
While testing we found out that kubernetes expects the intermediate certificates together with the public key in one file when using the "TLS" format.
This change contains the correct code for achieving this !