### PR TITLE
Improve formatting for multiword email notification types

### DIFF
--- a/lemur/plugins/lemur_email/plugin.py
+++ b/lemur/plugins/lemur_email/plugin.py
@@ -108,7 +108,8 @@ class EmailNotificationPlugin(ExpirationNotificationPlugin):
         if not targets:
             return
 
-        subject = "Lemur: {0} Notification".format(notification_type.capitalize())
+        readable_notification_type = ' '.join(map(lambda x: x.capitalize(), notification_type.split('_')))
+        subject = f"Lemur: {readable_notification_type} Notification"
 
         body = render_html(notification_type, options, message)
 


### PR DESCRIPTION
This is a followup from #3281. Without this, the email subject shows up as "Lemur: Authority_expiration Notification"; with this change, it shows up as "Lemur: Authority Expiration Notification". There are no unit tests for email subjects, but I have verified in the debugger.