### PR TITLE
remove gulp-replace-task

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "gulp-print": "^2.0.1",
     "gulp-protractor": "^4.1.1",
     "gulp-replace": "~0.5.3",
-    "gulp-replace-task": "~0.11.0",
     "gulp-rev": "^7.1.2",
     "gulp-rev-replace": "^0.4.3",
     "gulp-serve": "~1.4.0",


### PR DESCRIPTION
`gulp-replace-task` does not seem to be used.`npm audit` is showing [2 High vulnerabilities](https://snyk.io/test/npm/gulp-replace-task) with use of it's highest version:

```
High: Prototype Pollution
Package: lodash
Path: gulp-replace-task > applause > lodash 
```
https://npmjs.com/advisories/782
https://npmjs.com/advisories/1065 