### PR TITLE
Fixing duplicate task execution

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -238,7 +238,7 @@ gulp.task('addUrlContextPath:revision', async function(){
 });
 
 gulp.task('addUrlContextPath:revreplace', gulp.series('addUrlContextPath:revision', function(){
-  var manifest = gulp.src("lemur/static/dist/rev-manifest.json");
+  var manifest = gulp.src("lemur/static/dist/rev-manifest.json", { allowEmpty: true });
   var urlContextPathExists = argv.urlContextPath ? true : false;
   return gulp.src( "lemur/static/dist/index.html")
     .pipe(gulp.dest('lemur/static/dist'));

--- a/gulp/build.js
+++ b/gulp/build.js
@@ -188,7 +188,7 @@ gulp.task('build:inject', gulp.series(['dev:styles', 'dev:scripts', 'build:ngvie
   return injectHtml(false);
 }));
 
-gulp.task('build:html', gulp.series(['dev:styles', 'dev:scripts', 'build:ngviews', 'build:inject'], function () {
+gulp.task('build:html', gulp.series('build:inject', function () {
   var jsFilter = filter(['**/*.js'], {'restore': true});
   var cssFilter = filter(['**/*.css'], {'restore': true});
 
@@ -238,8 +238,8 @@ gulp.task('addUrlContextPath:revision', async function(){
 });
 
 gulp.task('addUrlContextPath:revreplace', gulp.series('addUrlContextPath:revision', function(){
-  // var manifest = gulp.src("lemur/static/dist/rev-manifest.json");
-  // var urlContextPathExists = argv.urlContextPath ? true : false;
+  var manifest = gulp.src("lemur/static/dist/rev-manifest.json");
+  var urlContextPathExists = argv.urlContextPath ? true : false;
   return gulp.src( "lemur/static/dist/index.html")
     .pipe(gulp.dest('lemur/static/dist'));
 }));
@@ -259,5 +259,5 @@ gulp.task('addUrlContextPath', gulp.series('addUrlContextPath:revreplace', async
 }));
 
 
-gulp.task('build', gulp.series(['build:ngviews', 'build:inject', 'build:images', 'build:fonts', 'build:html', 'build:extras']));
+gulp.task('build', gulp.series(['build:images', 'build:fonts', 'build:html', 'build:extras']));
 gulp.task('package', gulp.series(['addUrlContextPath', 'package:strip']));

--- a/gulp/server.js
+++ b/gulp/server.js
@@ -38,7 +38,7 @@ function browserSyncInit(baseDir, files, browser) {
 
 }
 
-gulp.task('watch', gulp.series(['dev:styles', 'dev:scripts', 'dev:inject', 'dev:fonts'], function (done) {
+gulp.task('watch', gulp.series(['dev:inject', 'dev:fonts'], function (done) {
   gulp.watch('app/styles/**/*.less', gulp.parallel('dev:styles'));
   gulp.watch('app/styles/**/*.css', gulp.parallel('dev:styles'));
   gulp.watch('app/**/*.js', gulp.parallel('dev:scripts'));


### PR DESCRIPTION
Considering `'dev:inject', gulp.series(['dev:styles', 'dev:scripts']` and `'build:inject', gulp.series(['dev:styles', 'dev:scripts', 'build:ngviews']`, removing duplicate/explicit calls ([Ref](https://fettblog.eu/gulp-4-parallel-and-series/#migration))