### PR TITLE
Updating includeCrlDp to includeCDP

### DIFF
--- a/lemur/schemas.py
+++ b/lemur/schemas.py
@@ -242,11 +242,11 @@ class CertificateInfoAccessSchema(BaseExtensionSchema):
 
 
 class CRLDistributionPointsSchema(BaseExtensionSchema):
-    include_crl_dp = fields.String()
+    include_cdp = fields.String()
 
     @post_dump
     def handle_keys(self, data):
-        return {"includeCRLDP": data["include_crl_dp"]}
+        return {"includeCDP": data["include_cdp"]}
 
 
 class SubjectKeyIdentifierSchema(BaseExtensionSchema):

--- a/lemur/static/app/angular/certificates/certificate/options.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/options.tpl.html
@@ -193,10 +193,10 @@
       </div>
       <div class="form-group">
         <label class="control-label col-sm-2">
-          cRL Distribution Points
+          CRL Distribution Points
         </label>
         <div class="col-sm-10">
-          <select class="form-control" ng-model="certificate.extensions.crlDistributionPoints.includeCrlDp"
+          <select class="form-control" ng-model="certificate.extensions.crlDistributionPoints.includeCDP"
                   ng-options="item for item in ['yes', 'no', 'default']"></select>
         </div>
       </div>


### PR DESCRIPTION
Makes it more obvious what the variable does, and ensures compatibility with some custom plugins.  It does not appear that any other plugins make use of this option, despite it being passed in options['extensions'] to issuerPlugins via create_certificates. 