### PR TITLE
CNAME Delegation Cleanup

### DIFF
--- a/lemur/plugins/lemur_acme/tests/test_acme_handler.py
+++ b/lemur/plugins/lemur_acme/tests/test_acme_handler.py
@@ -30,7 +30,7 @@ class TestAcmeHandler(unittest.TestCase):
         self.assertEqual(expected, result)
 
     def test_authz_record(self):
-        a = acme_handlers.AuthorizationRecord("domain", "host", "authz", "challenge", "id")
+        a = acme_handlers.AuthorizationRecord("domain", "host", "authz", "challenge", "id", "cname_delegation")
         self.assertEqual(type(a), acme_handlers.AuthorizationRecord)
 
     def test_setup_acme_client_fail(self):


### PR DESCRIPTION
Makes two changes to CNAME delegation

- Adds cname_delegation to AuthorizationRecord, to track whether the current record is using delegation
- Emit a metric when a request is received and configured for cname_delegation. 