### PR TITLE
Expiration summary email fixes

### DIFF
--- a/lemur/notifications/cli.py
+++ b/lemur/notifications/cli.py
@@ -85,15 +85,13 @@ def security_expiration_summary(exclude):
     status = FAILURE_METRIC_STATUS
     try:
         print("Starting to notify security team about expiring certificates!")
-        success, failed = send_security_expiration_summary(exclude)
+        status = send_security_expiration_summary(exclude)
         print(
-            "Finished notifying security team about expiring certificates! "
-            f"Sent: {success} Failed: {failed}"
+            "Finished notifying security team about expiring certificates!"
         )
-        status = SUCCESS_METRIC_STATUS
     except Exception:
         sentry.captureException()
 
     metrics.send(
-        "security_expiration_notification_job", "counter", 1, metric_tags={"status": status}
+        "security_expiration_summary_notification_job", "counter", 1, metric_tags={"status": status}
     )

--- a/lemur/notifications/cli.py
+++ b/lemur/notifications/cli.py
@@ -93,5 +93,5 @@ def security_expiration_summary(exclude):
         sentry.captureException()
 
     metrics.send(
-        "security_expiration_summary_notification_job", "counter", 1, metric_tags={"status": status}
+        "security_expiration_notification_job", "counter", 1, metric_tags={"status": status}
     )

--- a/lemur/notifications/cli.py
+++ b/lemur/notifications/cli.py
@@ -85,10 +85,12 @@ def security_expiration_summary(exclude):
     status = FAILURE_METRIC_STATUS
     try:
         print("Starting to notify security team about expiring certificates!")
-        status = send_security_expiration_summary(exclude)
+        success = send_security_expiration_summary(exclude)
         print(
-            "Finished notifying security team about expiring certificates!"
+            f"Finished notifying security team about expiring certificates! Success: {success}"
         )
+        if success:
+            status = SUCCESS_METRIC_STATUS
     except Exception:
         sentry.captureException()
 

--- a/lemur/plugins/lemur_email/templates/expiration_summary.html
+++ b/lemur/plugins/lemur_email/templates/expiration_summary.html
@@ -77,7 +77,6 @@
                                             <tr>
                                                 <td style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#202020;line-height:1.5">
                                                     <br>This is a summary of all certificates expiring soon.
-                                                    Only certificates matching the configured expiration intervals are included here.
                                                     Certificates with notifications disabled have been omitted.
                                                     <table border="0" cellspacing="0" cellpadding="0" style="margin-top:12px;margin-bottom:48px">
                                                         <tbody>
@@ -87,7 +86,7 @@
                                                                 <td width="16px"></td>
                                                                 <td style="line-height:1.2">
                                                                    <span style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:24px;color:#202020">
-                                                                         <br>Expiring in {{ interval_and_certs["interval"] }} days<br>
+                                                                         <br>Expiring in {{ interval_and_certs["interval"] + 1 }} days<br>
                                                                     </span>
                                                                 </td>
                                                             </tr>


### PR DESCRIPTION
1. Fix incorrect expectation of return type for summary emails in notification cli
2. Add 1 to days in summary email (as written, it ranges from 0 to 13 instead of 1 to 14)