### PR TITLE
reverting Bump celery[redis] from 4.4.2 to 5.0.4 

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ arrow
 asyncpool
 boto3
 botocore
-celery[redis]
+celery[redis]==4.4.2 # need to first resolve the module not found error https://github.com/celery/celery/issues/6406
 certifi
 certsrv
 CloudFlare

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 acme==1.10.1              # via -r requirements.in
 alembic-autogenerate-enums==0.0.2  # via -r requirements.in
 alembic==1.4.2            # via flask-migrate
-amqp==5.0.2               # via kombu
+amqp==2.5.2               # via kombu
 aniso8601==8.0.0          # via flask-restful
 arrow==0.17.0             # via -r requirements.in
 asyncpool==1.0            # via -r requirements.in
@@ -17,15 +17,12 @@ billiard==3.6.3.0         # via celery
 blinker==1.4              # via flask-mail, flask-principal, raven
 boto3==1.16.35            # via -r requirements.in
 botocore==1.19.35         # via -r requirements.in, boto3, s3transfer
-celery[redis]==5.0.4      # via -r requirements.in
+celery[redis]==4.4.2      # via -r requirements.in
 certifi==2020.12.5        # via -r requirements.in, requests
 certsrv==2.1.1            # via -r requirements.in
 cffi==1.14.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
-click-didyoumean==0.0.3   # via celery
-click-plugins==1.1.1      # via celery
-click-repl==0.1.6         # via celery
-click==7.1.2              # via celery, click-didyoumean, click-plugins, click-repl, flask
+click==7.1.2              # flask
 cloudflare==2.8.14        # via -r requirements.in
 cryptography==3.3.1       # via -r requirements.in, acme, josepy, paramiko, pyopenssl, requests
 dnspython3==1.15.0        # via -r requirements.in
@@ -52,7 +49,7 @@ jinja2==2.11.2            # via -r requirements.in, flask
 jmespath==0.9.5           # via boto3, botocore
 josepy==1.3.0             # via acme
 jsonlines==1.2.0          # via cloudflare
-kombu==5.0.2              # via celery
+kombu==4.6.8              # via celery
 lockfile==0.12.2          # via -r requirements.in
 logmatic-python==0.1.7    # via -r requirements.in
 mako==1.1.2               # via alembic
@@ -62,7 +59,6 @@ marshmallow==2.20.4       # via -r requirements.in, marshmallow-sqlalchemy
 ndg-httpsclient==0.5.1    # via -r requirements.in
 paramiko==2.7.2           # via -r requirements.in
 pem==20.1.0               # via -r requirements.in
-prompt-toolkit==3.0.8     # via click-repl
 psycopg2==2.8.6           # via -r requirements.in
 pyasn1-modules==0.2.8     # via pyjks, python-ldap
 pyasn1==0.4.8             # via ndg-httpsclient, pyasn1-modules, pyjks, python-ldap
@@ -85,15 +81,14 @@ requests-toolbelt==0.9.1  # via acme
 requests[security]==2.25.0  # via -r requirements.in, acme, certsrv, cloudflare, hvac, requests-toolbelt
 retrying==1.3.3           # via -r requirements.in
 s3transfer==0.3.3         # via boto3
-six==1.15.0               # via -r requirements.in, acme, bcrypt, click-repl, cryptography, flask-cors, flask-restful, hvac, josepy, jsonlines, pynacl, pyopenssl, python-dateutil, retrying, sqlalchemy-utils
+six==1.15.0               # via -r requirements.in, acme, bcrypt, cryptography, flask-cors, flask-restful, hvac, josepy, jsonlines, pynacl, pyopenssl, python-dateutil, retrying, sqlalchemy-utils
 soupsieve==2.0.1          # via beautifulsoup4
 sqlalchemy-utils==0.36.8  # via -r requirements.in
 sqlalchemy==1.3.16        # via alembic, flask-sqlalchemy, marshmallow-sqlalchemy, sqlalchemy-utils
 tabulate==0.8.7           # via -r requirements.in
 twofish==0.3.0            # via pyjks
 urllib3==1.25.8           # via botocore, requests
-vine==5.0.0               # via amqp, celery
-wcwidth==0.2.5            # via prompt-toolkit
+vine==1.3.0               # via amqp, celery
 werkzeug==1.0.1           # via flask
 xmltodict==0.12.0         # via -r requirements.in
 


### PR DESCRIPTION
reverting https://github.com/Netflix/lemur/pull/3305

need to first resolve the module not found error https://github.com/celery/celery/issues/6406