### PR TITLE
Resolving inconsistency around idna in requirement-test

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -31,7 +31,7 @@ freezegun==1.0.0          # via -r requirements-tests.in
 future==0.18.2            # via aws-xray-sdk
 gitdb==4.0.4              # via gitpython
 gitpython==3.1.1          # via bandit
-idna==2.8                 # via moto, requests
+idna==2.9                 # via moto, requests
 importlib-metadata==1.6.0  # via jsonpickle
 iniconfig==1.0.1          # via pytest
 itsdangerous==1.1.0       # via flask


### PR DESCRIPTION
It is still unclear to me, why requirement-test was not bumped, though it is covered by dependbot.

This inconsistency might have been introduce with this PR https://github.com/Netflix/lemur/commit/cee81bd693dcc2df831f9652b727542f49de1d22, 9 month ago