### PR TITLE
Reducing Travis CI email noise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,3 +51,4 @@ notifications:
       - lemur@netflix.com
     on_success: never
     on_failure: always
+    on_cancel:  never # Dependbot cancels Travis before rebase and triggers too many emails


### PR DESCRIPTION
Dependbot cancels Travis before rebase and triggers too many emails