### PR TITLE
Config to change algo to ECC during reissue

### DIFF
--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -795,6 +795,15 @@ def reissue_certificate(certificate, replace=None, user=None):
     else:
         primitives["description"] = f"{reissue_message_prefix}{certificate.id}"
 
+    # Rotate the certificate to ECCPRIME256V1 if cert owner is present in the configured list
+    # This is a temporary change intending to rotate certificates to ECC, if opted in by certificate owners
+    # Unless identified a use case, this will be removed in mid-Q2 2021
+    ecc_reissue_owner_list = current_app.config.get("ROTATE_TO_ECC_OWNER_LIST", [])
+    ecc_reissue_exclude_cn_list = current_app.config.get("ECC_NON_COMPATIBLE_COMMON_NAMES", [])
+
+    if (certificate.owner in ecc_reissue_owner_list) and (certificate.cn not in ecc_reissue_exclude_cn_list):
+        primitives["key_type"] = "ECCPRIME256V1"
+
     new_cert = create(**primitives)
 
     return new_cert

--- a/lemur/tests/conftest.py
+++ b/lemur/tests/conftest.py
@@ -56,7 +56,7 @@ def pytest_runtest_makereport(item, call):
             parent._previousfailed = item
 
 
-@pytest.yield_fixture(scope="session")
+@pytest.fixture(scope="session")
 def app(request):
     """
     Creates a new Flask application for a test duration.
@@ -73,7 +73,7 @@ def app(request):
     ctx.pop()
 
 
-@pytest.yield_fixture(scope="session")
+@pytest.fixture(scope="session")
 def db(app, request):
     _db.drop_all()
     _db.engine.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
@@ -92,7 +92,7 @@ def db(app, request):
     _db.drop_all()
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def session(db, request):
     """
     Creates a new database session with (with working transaction)
@@ -103,7 +103,7 @@ def session(db, request):
     db.session.rollback()
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def client(app, session, client):
     yield client
 
@@ -276,14 +276,14 @@ def source_plugin():
     return TestSourcePlugin
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def logged_in_user(session, app):
     with app.test_request_context():
         identity_changed.send(current_app._get_current_object(), identity=Identity(1))
         yield
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def logged_in_admin(session, app):
     with app.test_request_context():
         identity_changed.send(current_app._get_current_object(), identity=Identity(2))


### PR DESCRIPTION
1. Allow certificates to start using **ECCPRIME256V1** key_type during certificate reissue/rotate. This will apply to certificates with owners configured as part of **ROTATE_TO_ECC_OWNER_LIST** only if the common name is not present in exclusion list **ECC_NON_COMPATIBLE_COMMON_NAMES** (to allow flexibility of making exceptions).

This may not be a widely needed feature, thus may be removed in mid-Q2 2021 (unless identified a use case)

2. Fix @pytest.yield_fixture deprecation warning