### PR TITLE
Paginate valid certificate fetch API

### DIFF
--- a/lemur/database.py
+++ b/lemur/database.py
@@ -225,7 +225,9 @@ def paginate(query, page, count):
     :param page:
     :param count:
     """
-    return query.paginate(page, count)
+    total = get_count(query)
+    items = query.paginate(page, count).items
+    return dict(items=items, total=total, current=len(items))
 
 
 def update_list(model, model_attr, item_model, items):


### PR DESCRIPTION
The API is modified to offer optional pagination. One can send page number(>=1) and desired count per page. The returned data contains total number of certificates which can help in determining the last page. Pagination will not be offered if page or count info is not sent (making it backward compatible) or if it is zero.