### PR TITLE
Entrust cross signed sub ca

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -941,6 +941,12 @@ The following parameters have to be set in the configuration files.
 
         If there is a config variable ENTRUST_PRODUCT_<upper(authority.name)> take the value as cert product name else default to "STANDARD_SSL". Refer to the API documentation for valid products names.
 
+.. data:: ENTRUST_CROSS_SIGNED_RSA
+    :noindex:
+
+        This is optional. Entrut provides support for cross-signed subCAS. One can set ENTRUST_CROSS_SIGNED_RSA to the respective cross-signed subCA PEM, such as L1K, Lemur will replace the retrieved subCA with ENTRUST_CROSS_SIGNED_RSA.
+
+
 Verisign Issuer Plugin
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -944,7 +944,7 @@ The following parameters have to be set in the configuration files.
 .. data:: ENTRUST_CROSS_SIGNED_RSA
     :noindex:
 
-        This is optional. Entrut provides support for cross-signed subCAS. One can set ENTRUST_CROSS_SIGNED_RSA to the respective cross-signed subCA PEM, such as L1K, Lemur will replace the retrieved subCA with ENTRUST_CROSS_SIGNED_RSA.
+        This is optional. Entrust provides support for cross-signed subCAS. One can set ENTRUST_CROSS_SIGNED_RSA to the respective cross-signed subCA PEM, such as L1K, Lemur will replace the retrieved subCA with ENTRUST_CROSS_SIGNED_RSA.
 
 
 Verisign Issuer Plugin

--- a/lemur/plugins/lemur_entrust/plugin.py
+++ b/lemur/plugins/lemur_entrust/plugin.py
@@ -9,7 +9,7 @@ from lemur.constants import CRLReason
 from lemur.plugins import lemur_entrust as entrust
 from lemur.plugins.bases import IssuerPlugin, SourcePlugin
 from lemur.extensions import metrics
-from lemur.common.utils import validate_conf
+from lemur.common.utils import validate_conf, get_key_type_from_certificate
 
 
 def log_status_code(r, *args, **kwargs):
@@ -250,6 +250,9 @@ class EntrustIssuerPlugin(IssuerPlugin):
             chain = None
         else:
             chain = response_dict['chainCerts'][1]
+
+        if current_app.config.get("ENTRUST_CROSS_SIGNED_RSA") and get_key_type_from_certificate(cert) == "RSA2048":
+            chain = current_app.config.get("ENTRUST_CROSS_SIGNED_RSA")
 
         log_data["message"] = "Received Chain"
         log_data["options"] = f"chain: {chain}"


### PR DESCRIPTION
Entrust provides support for cross-signed subCAS. One can set ENTRUST_CROSS_SIGNED_RSA to the respective cross-signed subCA PEM, such as L1K, Lemur will replace the retrieved subCA with ENTRUST_CROSS_SIGNED_RSA.