### PR TITLE
Entrust default client

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -941,6 +941,12 @@ The following parameters have to be set in the configuration files.
 
         If there is a config variable ENTRUST_PRODUCT_<upper(authority.name)> take the value as cert product name else default to "STANDARD_SSL". Refer to the API documentation for valid products names.
 
+.. data:: ENTRUST_USE_DEFAULT_CLIENT_ID
+    :noindex:
+
+        If set to True, Entrust will use the primary client ID of 1, which applies to most use-case.
+        Otherwise, Entrust will first lookup the clientId before ordering the certificate.
+
 Verisign Issuer Plugin
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/lemur/plugins/lemur_entrust/plugin.py
+++ b/lemur/plugins/lemur_entrust/plugin.py
@@ -80,7 +80,6 @@ def process_options(options, client_id):
         "eku": "SERVER_AND_CLIENT_AUTH",
         "certType": product_type,
         "certExpiryDate": validity_end,
-        # "keyType": "RSA", Entrust complaining about this parameter
         "tracking": tracking_data,
         "org": options.get("organization"),
         "clientId": client_id
@@ -229,7 +228,11 @@ class EntrustIssuerPlugin(IssuerPlugin):
         except requests.exceptions.RequestException as e:
             raise Exception(f"Error for Getting Organization {e}")
 
-        client_id = get_client_id(response, issuer_options.get("organization"))
+        if current_app.config.get("ENTRUST_USE_DEFAULT_CLIENT_ID"):
+            # The ID of the primary client is 1.
+            client_id = 1
+        else:
+            client_id = get_client_id(response, issuer_options.get("organization"))
         log_data = {
             "function": f"{__name__}.{sys._getframe().f_code.co_name}",
             "message": f"Organization id: {client_id}"

--- a/lemur/plugins/lemur_entrust/plugin.py
+++ b/lemur/plugins/lemur_entrust/plugin.py
@@ -87,6 +87,7 @@ def process_options(options, client_id):
     return data
 
 
+@retry(stop_max_attempt_number=5, wait_fixed=1000)
 def get_client_id(my_response, organization):
     """
     Helper function for parsing responses from the Entrust API.


### PR DESCRIPTION
Allow Entrust to use the primary client ID and avoid an extra round for resolving the clientID.

Also this Entrust Endpoint is not reliable, and often results into a Client Reset error.