### PR TITLE
Add Content-Type to all sample requests

### DIFF
--- a/lemur/api_keys/views.py
+++ b/lemur/api_keys/views.py
@@ -105,6 +105,7 @@ class ApiKeyList(AuthenticatedResource):
               POST /keys HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                 "name": "my custom name",
@@ -225,6 +226,7 @@ class ApiKeyUserList(AuthenticatedResource):
               POST /users/1/keys HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                 "name": "my custom name"
@@ -332,6 +334,7 @@ class ApiKeys(AuthenticatedResource):
               PUT /keys/1 HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                   "name": "new_name",
@@ -474,6 +477,7 @@ class UserApiKeys(AuthenticatedResource):
               PUT /users/1/keys/1 HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                   "name": "new_name",

--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -268,6 +268,7 @@ class Login(Resource):
               POST /auth/login HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                 "username": "test",

--- a/lemur/authorities/views.py
+++ b/lemur/authorities/views.py
@@ -130,6 +130,7 @@ class AuthoritiesList(AuthenticatedResource):
               POST /authorities HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
              {
                 "country": "US",
@@ -301,6 +302,7 @@ class Authorities(AuthenticatedResource):
               PUT /authorities/1 HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                 "name": "TestAuthority5",

--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -377,6 +377,7 @@ class CertificatesList(AuthenticatedResource):
               POST /certificates HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                   "owner": "secure@example.net",
@@ -526,6 +527,7 @@ class CertificatesUpload(AuthenticatedResource):
               POST /certificates/upload HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                  "owner": "joe@example.com",
@@ -792,6 +794,7 @@ class Certificates(AuthenticatedResource):
               PUT /certificates/1 HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                  "owner": "jimbob@example.com",
@@ -931,6 +934,7 @@ class Certificates(AuthenticatedResource):
               POST /certificates/1/update/notify HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                  "notify": false
@@ -1299,6 +1303,7 @@ class CertificateExport(AuthenticatedResource):
               PUT /certificates/1/export HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                 "export": {
@@ -1420,6 +1425,7 @@ class CertificateRevoke(AuthenticatedResource):
               POST /certificates/1/revoke HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                 "crlReason": "affiliationChanged",

--- a/lemur/destinations/views.py
+++ b/lemur/destinations/views.py
@@ -113,6 +113,7 @@ class DestinationsList(AuthenticatedResource):
               POST /destinations HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                 "description": "test33",
@@ -264,6 +265,7 @@ class Destinations(AuthenticatedResource):
               POST /destinations/1 HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
 
               {

--- a/lemur/notifications/views.py
+++ b/lemur/notifications/views.py
@@ -126,6 +126,7 @@ class NotificationsList(AuthenticatedResource):
               POST /notifications HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                 "description": "a test",
@@ -314,6 +315,7 @@ class Notifications(AuthenticatedResource):
               POST /notifications/1 HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
 
            **Example response**:

--- a/lemur/pending_certificates/views.py
+++ b/lemur/pending_certificates/views.py
@@ -224,6 +224,7 @@ class PendingCertificates(AuthenticatedResource):
               PUT /pending certificates/1 HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                  "owner": "jimbob@example.com",
@@ -465,6 +466,7 @@ class PendingCertificatesUpload(AuthenticatedResource):
               POST /certificates/1/upload HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                  "body": "-----BEGIN CERTIFICATE-----...",

--- a/lemur/roles/views.py
+++ b/lemur/roles/views.py
@@ -106,6 +106,7 @@ class RolesList(AuthenticatedResource):
               POST /roles HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                  "name": "role3",
@@ -265,6 +266,7 @@ class Roles(AuthenticatedResource):
               PUT /roles/1 HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                  "name": "role1",

--- a/lemur/sources/views.py
+++ b/lemur/sources/views.py
@@ -106,6 +106,7 @@ class SourcesList(AuthenticatedResource):
               POST /sources HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                 "options": [
@@ -237,6 +238,7 @@ class Sources(AuthenticatedResource):
               POST /sources/1 HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                 "options": [

--- a/lemur/users/views.py
+++ b/lemur/users/views.py
@@ -108,6 +108,7 @@ class UsersList(AuthenticatedResource):
               POST /users HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                  "username": "user3",
@@ -208,6 +209,7 @@ class Users(AuthenticatedResource):
               PUT /users/1 HTTP/1.1
               Host: example.com
               Accept: application/json, text/javascript
+              Content-Type: application/json;charset=UTF-8
 
               {
                  "username": "user1",


### PR DESCRIPTION
Content-Type is required when making JSON requests, so add it to all the sample requests.

These samples are used in the docs: https://lemur.readthedocs.io/en/0.8.0/developer/index.html#rest-api