### PR TITLE
AWS STS regional config

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -209,6 +209,11 @@ Basic Configuration
         in the UI. When set to False (the default), the certificate delete API will always return "405 method not allowed"
         and deleted certificates will always be visible in the UI. (default: `False`)
 
+.. data:: LEMUR_AWS_REGION
+    :noindex:
+
+        This is an optional config applicable for settings where Lemur is deployed in AWS. For accessing regionalized
+        STS endpoints, LEMUR_AWS_REGION defines the region where Lemur is deployed.
 
 Certificate Default Options
 ---------------------------

--- a/lemur/plugins/lemur_aws/sts.py
+++ b/lemur/plugins/lemur_aws/sts.py
@@ -20,7 +20,13 @@ def sts_client(service, service_type="client"):
     def decorator(f):
         @wraps(f)
         def decorated_function(*args, **kwargs):
-            sts = boto3.client("sts", config=config)
+            if current_app.config.get("LEMUR_AWS_REGION"):
+                deployment_region = current_app.config.get("LEMUR_AWS_REGION")
+                sts = boto3.client('sts', region_name=deployment_region,
+                                   endpoint_url=f"https://sts.{deployment_region}.amazonaws.com/",
+                                   config=config)
+            else:
+                sts = boto3.client("sts", config=config)
             arn = "arn:aws:iam::{0}:role/{1}".format(
                 kwargs.pop("account_number"),
                 current_app.config.get("LEMUR_INSTANCE_PROFILE", "Lemur"),


### PR DESCRIPTION
This is an optional config applicable for settings where Lemur is deployed in AWS. For accessing regionalized STS endpoints, LEMUR_AWS_REGION defines the region where Lemur is deployed.