### PR TITLE
Addressing Gulp Deprecation warning 

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -40,7 +40,7 @@ function replaceAll(string, find, replace) {
 function stringSrc(filename, string) {
   let src = require('stream').Readable({objectMode: true});
   src._read = function () {
-    this.push(new gutil.File({cwd: '', base: '', path: filename, contents: new Buffer(string)}));
+    this.push(new gutil.File({cwd: '', base: '', path: filename, contents: Buffer.from(string)}));
     this.push(null);
   };
   return src;


### PR DESCRIPTION
(node:73186) [DEP0005] DeprecationWarning: Buffer() is deprecated du to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.