### PR TITLE
Exclude revoked certs from defaulting them to auto-rotate

### DIFF
--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -153,6 +153,7 @@ def get_all_certs_attached_to_endpoint_without_autorotate():
     return (
         Certificate.query.filter(Certificate.endpoints.any())
         .filter(Certificate.rotation == false())
+        .filter(Certificate.revoked == false())
         .filter(Certificate.not_after >= arrow.now())
         .filter(not_(Certificate.replaced.any()))
         .all()  # noqa

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -87,7 +87,7 @@ def test_get_by_serial(session, certificate):
 def test_get_all_certs_attached_to_endpoint_without_autorotate(session):
     from lemur.certificates.service import get_all_certs_attached_to_endpoint_without_autorotate, \
         cleanup_after_revoke
-    from lemur.tests.factories import EndpointFactory, CertificateFactory
+    from lemur.tests.factories import EndpointFactory
 
     # add a certificate with endpoint
     EndpointFactory()

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -90,16 +90,14 @@ def test_get_all_certs_attached_to_endpoint_without_autorotate(session):
     from lemur.tests.factories import EndpointFactory, CertificateFactory
 
     # add a certificate with endpoint
-    s = EndpointFactory()
-    CertificateFactory(endpoint=s)
-    session.commit()
+    EndpointFactory()
 
     list_before = get_all_certs_attached_to_endpoint_without_autorotate()
     len_list_before = len(list_before)
     assert len_list_before > 0
     # revoked the first certificate
-    first_cert_with_endpoitn = list_before[0]
-    cleanup_after_revoke(first_cert_with_endpoitn)
+    first_cert_with_endpoint = list_before[0]
+    cleanup_after_revoke(first_cert_with_endpoint)
 
     list_after = get_all_certs_attached_to_endpoint_without_autorotate()
     assert len(list_after) + 1 == len_list_before

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -84,6 +84,27 @@ def test_get_by_serial(session, certificate):
     assert found
 
 
+def test_get_all_certs_attached_to_endpoint_without_autorotate(session):
+    from lemur.certificates.service import get_all_certs_attached_to_endpoint_without_autorotate, \
+        cleanup_after_revoke
+    from lemur.tests.factories import EndpointFactory, CertificateFactory
+
+    # add a certificate with endpoint
+    s = EndpointFactory()
+    CertificateFactory(endpoint=s)
+    session.commit()
+
+    list_before = get_all_certs_attached_to_endpoint_without_autorotate()
+    len_list_before = len(list_before)
+    assert len_list_before > 0
+    # revoked the first certificate
+    first_cert_with_endpoitn = list_before[0]
+    cleanup_after_revoke(first_cert_with_endpoitn)
+
+    list_after = get_all_certs_attached_to_endpoint_without_autorotate()
+    assert len(list_after) + 1 == len_list_before
+
+
 def test_delete_cert(session):
     from lemur.certificates.service import delete, get
     from lemur.tests.factories import CertificateFactory

--- a/lemur/tests/test_endpoints.py
+++ b/lemur/tests/test_endpoints.py
@@ -32,7 +32,7 @@ def test_rotate_certificate(client, source_plugin):
 )
 def test_endpoint_get(client, token, status):
     assert (
-        client.get(api.url_for(Endpoints, endpoint_id=1), headers=token).status_code
+        client.get(api.url_for(Endpoints, endpoint_id=2), headers=token).status_code
         == status
     )
 


### PR DESCRIPTION
Service owners can revoke a certificate and signal that the certificate is no longer in use.
For these certificates, Lemur will no longer default them to auto-rotate, in case attached to a load balancer