### PR TITLE
Automate Lemur release

### DIFF
--- a/.github/workflows/lemur-publish-release-pypi.yml
+++ b/.github/workflows/lemur-publish-release-pypi.yml
@@ -1,0 +1,31 @@
+# This workflow will upload a Python Package using Twine when a Lemur release is created via github
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Publish Lemur's latest package to PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.LEMUR_PYPI_API_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.LEMUR_PYPI_API_TOKEN }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*


### PR DESCRIPTION
Lemur's current release publishing is done manual, which comes with overheads and slows down the release cycle.

Automating this operation would allow Lemur to make more frequent releases, for instance at least once a week to pick up the latest dependency updates.