### PR TITLE
Doc fix

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -875,7 +875,7 @@ account. See :ref:`Using a pre-existing ACME account <AcmeAccountReuse>` for mor
     :noindex:
 
             This is an optional parameter to indicate the preferred chain to retrieve from ACME when finalizing the order.
-            This is applicable to Let's Encrypts recent `migration https://letsencrypt.org/certificates/`_ to their
+            This is applicable to Let's Encrypts recent `migration <https://letsencrypt.org/certificates/>`_ to their
             own root, where they provide two distinct certificate chains (fullchain_pem vs. alternative_fullchains_pem);
             the main chain will be the long chain that is rooted in the expiring DTS root, whereas the alternative chain
             is rooted in X1 root CA.

--- a/requirements-docs.in
+++ b/requirements-docs.in
@@ -7,6 +7,7 @@ acme
 arrow
 boto3
 botocore
+certbot
 certsrv
 CloudFlare
 cryptography

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -66,6 +66,7 @@ botocore==1.20.22
     #   boto3
     #   moto
     #   s3transfer
+certbot==1.13.0
 certifi==2020.12.5
     # via
     #   -r requirements-tests.txt


### PR DESCRIPTION
Fixing the broken ReadTheDocs build using external link syntax ([reference](https://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html#internal-and-external-links)).