### PR TITLE
Automate bump version

### DIFF
--- a/.github/workflows/lemur-publish-release-pypi.yml
+++ b/.github/workflows/lemur-publish-release-pypi.yml
@@ -18,6 +18,16 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
+    - name: Autobump version
+      run: |
+        # from refs/tags/v0.8.1 get 0.8.1
+        VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
+        PLACEHOLDER='__version__ = "develop"'
+        VERSION_FILE='lemur/__about__.py'
+        # in case placeholder is missing, exists with code 1 and github actions aborts the build
+        grep "$PLACEHOLDER" "$VERSION_FILE"
+        sed -i "s/$PLACEHOLDER/__version__ = \"${VERSION}\"/g" "$VERSION_FILE"
+      shell: bash
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/lemur/__about__.py
+++ b/lemur/__about__.py
@@ -15,7 +15,7 @@ __title__ = "lemur"
 __summary__ = "Certificate management and orchestration service"
 __uri__ = "https://github.com/Netflix/lemur"
 
-__version__ = "0.8.1"
+__version__ = "develop"
 
 __author__ = "The Lemur developers"
 __email__ = "security@netflix.com"

--- a/lemur/__about__.py
+++ b/lemur/__about__.py
@@ -15,7 +15,7 @@ __title__ = "lemur"
 __summary__ = "Certificate management and orchestration service"
 __uri__ = "https://github.com/Netflix/lemur"
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 __author__ = "The Lemur developers"
 __email__ = "security@netflix.com"


### PR DESCRIPTION
reducing the manual steps required to bump the version
now we take version from tag, replace the placeholder `__version__ = develop` with that version number