### PR TITLE
Add config to uptake GitHub's native Dependabot with auto-merge action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+  version: 2
+  updates:
+    - directory: "/"
+      schedule:
+        interval: "weekly"
+        day: "monday"
+        time: "08:00"
+        timezone: "America/Los_Angeles"
+      package-ecosystem: "pip"
+      reviewers:
+        - "hosseinsh"
+        - "csine-nflx"
+        - "charhate"
+        - "jtschladen"
+      versioning-strategy: lockfile-only

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,14 @@
+name: dependabot-auto-merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.DEPENDABOT_GITHUB_TOKEN }}


### PR DESCRIPTION
GitHub's Dependabot configuration reference: https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates

Dependabot Auto Merge GitHub Action (and config): https://github.com/marketplace/actions/dependabot-auto-merge