### PR TITLE
Change ssh missing host key policy used by sftp plugin from AutoAddPolicy

### DIFF
--- a/lemur/plugins/lemur_sftp/plugin.py
+++ b/lemur/plugins/lemur_sftp/plugin.py
@@ -113,7 +113,7 @@ class SFTPDestinationPlugin(DestinationPlugin):
             ssh = paramiko.SSHClient()
 
             # allow connection to the new unknown host
-            ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            ssh.set_missing_host_key_policy(paramiko.RejectPolicy())
 
             # open the ssh connection
             if password:


### PR DESCRIPTION
This change is a result of this CodeQL error: 
https://github.com/Netflix/lemur/security/code-scanning/8?query=ref%3Arefs%2Fheads%2Fmaster

The comment above the line flagged by the scanner seems to indicate that allowing unknown hosts is intentional, but this isn't ideal from a security perspective. 