### PR TITLE
Add config option DISABLE_NOTIFICATION_PLUGINS to disable specific notification plugins

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -404,13 +404,14 @@ The following configuration options are supported:
 
        ::
 
-          DISABLE_NOTIFICATION_PLUGINS = ['exclude', 'also exclude']
+          EXCLUDE_CN_FROM_NOTIFICATION = ['exclude', 'also exclude']
 
 
 .. data:: DISABLE_NOTIFICATION_PLUGINS
     :noindex:
 
     Specifies a set of notification plugins to disable. Notifications will not be sent using these plugins. Currently only applies to expiration notifications, since they are the only type that utilize plugins.
+    This option may be particularly useful in a test environment, where you might wish to enable the notification job without actually sending notifications of a certain type (or all types).
 
     .. note::
         This is only used for celery. The equivalent for cron is '-d' or '--disabled-notification-plugins'.

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -390,6 +390,36 @@ This notification type also supports the same ``--exclude`` and ``EXCLUDE_CN_FRO
 NOTE: At present, this summary email essentially duplicates the certificate expiration notifications, since all
 certificate expiration notifications are also sent to the security team. This issue will be fixed in the future.
 
+**Notification configuration**
+
+The following configuration options are supported:
+
+.. data:: EXCLUDE_CN_FROM_NOTIFICATION
+    :noindex:
+
+    Specifies CNs to exclude from notifications. This includes both single notifications as well as the notification summary. The specified exclude pattern will match if found anywhere in the certificate name.
+
+    .. note::
+        This is only used for celery. The equivalent for cron is '-e' or '--exclude'.
+
+       ::
+
+          DISABLE_NOTIFICATION_PLUGINS = ['exclude', 'also exclude']
+
+
+.. data:: DISABLE_NOTIFICATION_PLUGINS
+    :noindex:
+
+    Specifies a set of notification plugins to disable. Notifications will not be sent using these plugins. Currently only applies to expiration notifications, since they are the only type that utilize plugins.
+
+    .. note::
+        This is only used for celery. The equivalent for cron is '-d' or '--disabled-notification-plugins'.
+
+       ::
+
+          DISABLE_NOTIFICATION_PLUGINS = ['email-notification']
+
+
 **Email notifications**
 
 Templates for emails are located under `lemur/plugins/lemur_email/templates` and can be modified for your needs.

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -810,7 +810,8 @@ def notify_expirations():
     current_app.logger.debug(log_data)
     try:
         cli_notification.expirations(
-            current_app.config.get("EXCLUDE_CN_FROM_NOTIFICATION", [])
+            current_app.config.get("EXCLUDE_CN_FROM_NOTIFICATION", []),
+            current_app.config.get("DISABLE_NOTIFICATION_PLUGINS", [])
         )
     except SoftTimeLimitExceeded:
         log_data["message"] = "Notify expiring Time limit exceeded."

--- a/lemur/notifications/cli.py
+++ b/lemur/notifications/cli.py
@@ -24,7 +24,15 @@ manager = Manager(usage="Handles notification related tasks.")
     default=[],
     help="Common name matching of certificates that should be excluded from notification",
 )
-def expirations(exclude):
+@manager.option(
+    "-d",
+    "--disabled-notification-plugins",
+    dest="disabled_notification_plugins",
+    action="append",
+    default=[],
+    help="List of notification plugins for which notifications should NOT be sent",
+)
+def expirations(exclude, disabled_notification_plugins):
     """
     Runs Lemur's notification engine, that looks for expiring certificates and sends
     notifications out to those that have subscribed to them.
@@ -39,7 +47,7 @@ def expirations(exclude):
     status = FAILURE_METRIC_STATUS
     try:
         print("Starting to notify subscribers about expiring certificates!")
-        success, failed = send_expiration_notifications(exclude)
+        success, failed = send_expiration_notifications(exclude, disabled_notification_plugins)
         print(
             f"Finished notifying subscribers about expiring certificates! Sent: {success} Failed: {failed}"
         )

--- a/lemur/plugins/lemur_email/tests/test_email.py
+++ b/lemur/plugins/lemur_email/tests/test_email.py
@@ -53,7 +53,26 @@ def test_send_expiration_notification():
     certificate.notifications[0].options = get_options()
 
     verify_sender_email()
-    assert send_expiration_notifications([]) == (4, 0)  # owner (1), recipients (2), and security (1)
+    assert send_expiration_notifications([], []) == (4, 0)  # owner (1), recipients (2), and security (1)
+
+
+@mock_ses
+def test_send_expiration_notification_disabled():
+    from lemur.notifications.messaging import send_expiration_notifications
+    from lemur.tests.factories import CertificateFactory
+    from lemur.tests.factories import NotificationFactory
+
+    now = arrow.utcnow()
+    in_ten_days = now + timedelta(days=10, hours=1)  # a bit more than 10 days since we'll check in the future
+    certificate = CertificateFactory()
+    notification = NotificationFactory(plugin_name="email-notification")
+
+    certificate.not_after = in_ten_days
+    certificate.notifications.append(notification)
+    certificate.notifications[0].options = get_options()
+
+    verify_sender_email()
+    assert send_expiration_notifications([], ['email-notification']) == (0, 0)
 
 
 @mock_ses


### PR DESCRIPTION
Provides a new config option `DISABLE_NOTIFICATION_PLUGINS` that disables *sending* notifications via the specified plugins. This does not prevent notifications from being *configured* with those plugins, but any configured ones will not be sent.