### PR TITLE
Fix usage of groupby in notifications logic

### DIFF
--- a/lemur/plugins/lemur_email/tests/test_email.py
+++ b/lemur/plugins/lemur_email/tests/test_email.py
@@ -1,4 +1,5 @@
 import os
+from collections import defaultdict
 from datetime import timedelta
 
 import arrow
@@ -7,7 +8,7 @@ from moto import mock_ses
 from lemur.certificates.schemas import certificate_notification_output_schema
 from lemur.plugins.lemur_email.plugin import render_html
 from lemur.tests.factories import CertificateFactory
-from lemur.tests.test_messaging import verify_sender_email
+from lemur.tests.test_messaging import verify_sender_email, create_cert_that_expires_in_days
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
@@ -35,6 +36,40 @@ def test_render_rotation(certificate, endpoint):
 
 def test_render_rotation_failure(pending_certificate):
     assert render_html("failed", get_options(), certificate_notification_output_schema.dump(pending_certificate).data)
+
+
+def test_render_expiration_summary(certificate, notification, notification_plugin):
+    from lemur.notifications.messaging import get_eligible_security_summary_certs
+    verify_sender_email()
+
+    expected_certs = defaultdict(list)
+    # weird order to ensure they're not all sequential in the DB
+    expected_certs["14"].append(create_cert_that_expires_in_days(14))
+    expected_certs["12"].append(create_cert_that_expires_in_days(12))
+    expected_certs["1"].append(create_cert_that_expires_in_days(1))
+    expected_certs["3"].append(create_cert_that_expires_in_days(3))
+    expected_certs["2"].append(create_cert_that_expires_in_days(2))
+    expected_certs["9"].append(create_cert_that_expires_in_days(9))
+    expected_certs["7"].append(create_cert_that_expires_in_days(7))
+    expected_certs["12"].append(create_cert_that_expires_in_days(12))
+    expected_certs["7"].append(create_cert_that_expires_in_days(7))
+    expected_certs["2"].append(create_cert_that_expires_in_days(2))
+    expected_certs["2"].append(create_cert_that_expires_in_days(2))
+    expected_certs["3"].append(create_cert_that_expires_in_days(3))
+    expected_certs["2"].append(create_cert_that_expires_in_days(2))
+    create_cert_that_expires_in_days(15)  # over the limit, won't be included
+    expected_certs["1"].append(create_cert_that_expires_in_days(1))
+
+    message_data = get_eligible_security_summary_certs(None)
+    assert len(message_data) == len(expected_certs)  # verify the expected number of intervals
+    for interval in expected_certs:
+        message_data_for_interval = [x for x in message_data if x['interval'] == int(interval)]
+        assert len(message_data_for_interval) > 0  # verify the interval is present in the message data
+        message_data_for_interval = message_data_for_interval[0]
+        assert message_data_for_interval['certificates']  # verify the interval in the message data has a certs field
+        for cert in expected_certs[interval]:
+            message_data_for_cert = [x for x in message_data_for_interval['certificates'] if x['name'] == cert.name]
+            assert message_data_for_cert  # verify the expected cert is present for the expected interval
 
 
 @mock_ses

--- a/lemur/tests/test_messaging.py
+++ b/lemur/tests/test_messaging.py
@@ -83,7 +83,6 @@ def test_get_eligible_certificates(app, certificate, notification):
         }
 
 
-
 def test_get_eligible_certificates_multiple(app, notification):
     from lemur.notifications.messaging import get_eligible_certificates
 


### PR DESCRIPTION
`groupby` requires the collection to be pre-sorted, as it simply groups the collection by contiguous chunks. Therefore, the prior logic would only include the _latest_ contiguous chunk of certs for each `groupby` operation performed. This changed sorts before calling `groupby` to ensure this isn't a problem.

Reference: https://docs.python.org/3/library/itertools.html#itertools.groupby
> Make an iterator that returns consecutive keys and groups from the _iterable_. The _key_ is a function computing a key value for each element. If not specified or is `None`, _key_ defaults to an identity function and returns the element unchanged. Generally, the iterable needs to already be sorted on the same key function.
> 
> The operation of `groupby()` is similar to the `uniq` filter in Unix. It generates a break or new group every time the value of the key function changes (which is why it is usually necessary to have sorted the data using the same key function). That behavior differs from SQL’s GROUP BY which aggregates common elements regardless of their input order.