### PR TITLE
Remove external_id requirement to revoke certificate

### DIFF
--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -1471,9 +1471,6 @@ class CertificateRevoke(AuthenticatedResource):
                     403,
                 )
 
-        if not cert.external_id:
-            return dict(message="Cannot revoke certificate. No external id found."), 400
-
         if cert.endpoints:
             for endpoint in cert.endpoints:
                 if service.is_attached_to_endpoint(cert.name, endpoint.name):


### PR DESCRIPTION
Certificate providers may use certificate.serial instead of certificate.external_id to identify certificates to revoke.