### PR TITLE
Configurable endpoint expiration time

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -506,6 +506,12 @@ need to configure celery. See :ref:`Periodic Tasks <PeriodicTasks>` for more in 
 
         This defines the schedule, with which the celery beat makes the worker run the specified tasks.
 
+.. data:: CELERY_ENDPOINTS_EXPIRE_TIME_IN_HOURS
+    :noindex:
+
+        This is an optional parameter that defines the expiration time for endpoints when the endpoint expiration celery task is running. Default value is set to 2h.
+
+
 Since the celery module, relies on the RedisHandler, the following options also need to be set.
 
 .. data:: REDIS_HOST

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -701,7 +701,7 @@ def endpoints_expire():
 
     current_app.logger.debug(log_data)
     try:
-        cli_endpoints.expire(2)  # Time in hours
+        cli_endpoints.expire(current_app.config.get("CELERY_ENDPOINTS_EXPIRE_TIME_IN_HOURS", 2))
     except SoftTimeLimitExceeded:
         log_data["message"] = "endpoint expire: Time limit exceeded."
         current_app.logger.error(log_data)


### PR DESCRIPTION
This is an optional parameter that defines the expiration time for endpoints when the endpoint expiration celery task is running. Default value is set to 2h.
