### PR TITLE
Back to using LEMUR_DEFAULT_LOCATION if missing

### DIFF
--- a/lemur/authorities/schemas.py
+++ b/lemur/authorities/schemas.py
@@ -43,7 +43,9 @@ class AuthorityInputSchema(LemurInputSchema):
     organization = fields.String(
         missing=lambda: current_app.config.get("LEMUR_DEFAULT_ORGANIZATION")
     )
-    location = fields.String()
+    location = fields.String(
+        missing=lambda: current_app.config.get("LEMUR_DEFAULT_LOCATION")
+    )
     country = fields.String(
         missing=lambda: current_app.config.get("LEMUR_DEFAULT_COUNTRY")
     )

--- a/lemur/certificates/schemas.py
+++ b/lemur/certificates/schemas.py
@@ -108,7 +108,9 @@ class CertificateInputSchema(CertificateCreationSchema):
     organization = fields.String(
         missing=lambda: current_app.config.get("LEMUR_DEFAULT_ORGANIZATION")
     )
-    location = fields.String()
+    location = fields.String(
+        missing=lambda: current_app.config.get("LEMUR_DEFAULT_LOCATION")
+    )
     country = fields.String(
         missing=lambda: current_app.config.get("LEMUR_DEFAULT_COUNTRY")
     )

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -196,8 +196,8 @@ def test_get_certificate_primitives(certificate):
 
     with freeze_time(datetime.date(year=2016, month=10, day=30)):
         primitives = get_certificate_primitives(certificate)
-        assert len(primitives) == 25
-        assert (primitives["key_type"] == "RSA2048")
+        assert len(primitives) == 26
+        assert primitives["key_type"] == "RSA2048"
 
 
 def test_certificate_output_schema(session, certificate, issuer_plugin):
@@ -347,6 +347,32 @@ def test_certificate_input_schema(client, authority):
     assert data["key_type"] == "ECCPRIME256V1"
 
     assert len(data.keys()) == 19
+
+
+def test_certificate_input_schema_empty_location(client, authority):
+    from lemur.certificates.schemas import CertificateInputSchema
+
+    input_data = {
+        "commonName": "test.example.com",
+        "owner": "jim@example.com",
+        "authority": {"id": authority.id},
+        "description": "testtestest",
+        "validityStart": arrow.get(2018, 11, 9).isoformat(),
+        "validityEnd": arrow.get(2019, 11, 9).isoformat(),
+        "dnsProvider": None,
+        "location": ""
+    }
+
+    data, errors = CertificateInputSchema().load(input_data)
+
+    assert not errors
+    assert len(data.keys()) == 19
+    assert data["location"] == ""
+
+    # make sure the defaults got set
+    assert data["common_name"] == "test.example.com"
+    assert data["country"] == "US"
+    assert data["key_type"] == "ECCPRIME256V1"
 
 
 def test_certificate_input_with_extensions(client, authority):


### PR DESCRIPTION
Undo the location field change from PR #3174 .
It seems that this change was unintended, thus adding it back. The lemur API will again add location, if missing, honoring the config value LEMUR_DEFAULT_LOCATION.
