### PR TITLE
Update default signing and key types for new CAs

### DIFF
--- a/lemur/static/app/angular/authorities/authority/options.tpl.html
+++ b/lemur/static/app/angular/authorities/authority/options.tpl.html
@@ -4,7 +4,10 @@
       Signing Algorithm
     </label>
     <div class="col-sm-10">
-      <select class="form-control" ng-model="authority.signingAlgorithm" ng-options="option for option in ['sha1WithRSA', 'sha256WithRSA', 'sha256WithECDSA', 'SHA384withECDSA', 'SHA512withECDSA']" ng-init="authority.signingAlgorithm = 'sha256WithRSA'"></select>
+      <select class="form-control" ng-model="authority.signingAlgorithm"
+              ng-options="option for option in ['sha1WithRSA', 'sha256WithRSA', 'sha256WithECDSA', 'SHA384withECDSA', 'SHA512withECDSA']"
+              ng-init="authority.signingAlgorithm = 'sha256WithECDSA'">
+      </select>
     </div>
   </div>
   <div class="form-group">
@@ -12,7 +15,10 @@
       Sensitivity
     </label>
     <div class="col-sm-10">
-      <select class="form-control" ng-model="authority.sensitivity" ng-options="option for option in ['medium', 'high']" ng-init="authority.sensitivity = 'medium'"></select>
+      <select class="form-control" ng-model="authority.sensitivity"
+              ng-options="option for option in ['medium', 'high']"
+              ng-init="authority.sensitivity = 'medium'">
+      </select>
     </div>
   </div>
   <div class="form-group">
@@ -22,7 +28,7 @@
     <div class="col-sm-10">
       <select class="form-control" ng-model="authority.keyType"
               ng-options="option for option in ['RSA2048', 'RSA4096', 'ECCPRIME256V1', 'ECCSECP384R1', 'ECCSECP521R1']"
-              ng-init="authority.keyType = 'RSA2048'">
+              ng-init="authority.keyType = 'ECCPRIME256V1'">
       </select>
     </div>
   </div>


### PR DESCRIPTION
The default settings for new CAs created via Lemur UI use RSA.  Lets make the defaults EC-based.

Current:
Signing Algorithm: sha256withRSA
Key Type: RSA2048

Updated:
Signing Algorithm: sha256withECDSA
Key Type: ECCPRIME256V1