### PR TITLE
Confirmation before delete

### DIFF
--- a/lemur/static/app/angular/api_keys/view/view.tpl.html
+++ b/lemur/static/app/angular/api_keys/view/view.tpl.html
@@ -36,7 +36,9 @@
                   <button uib-tooltip="Edit Key" ng-click="edit(apiKey.id)" class="btn btn-sm btn-info">
                     Edit
                   </button>
-                  <button uib-tooltip="Delete Key" ng-click="remove(apiKey)" type="button" class="btn btn-sm btn-danger pull-left">
+                  <button uib-tooltip="Delete Key" ng-click="remove(apiKey)"
+                          confirm-click="Proceed to remove the API Key {{ apiKey.name || 'Unnamed Api Key' }} (ID {{ apiKey.id }})?"
+                          type="button" class="btn btn-sm btn-danger pull-left">
                     Remove
                   </button>
                 </div>

--- a/lemur/static/app/angular/app.js
+++ b/lemur/static/app/angular/app.js
@@ -83,14 +83,14 @@
       restrict: 'A',
       link: function(scope, element, attrs){
         element.bind('click', function(e){
-          const message = attrs.confirmClick || "Are you sure?";
-          if(!confirm(message)){
+          const message = attrs.confirmClick || 'Are you sure?';
+          if(!window.confirm(message)){
             e.stopImmediatePropagation();
             e.preventDefault();
           }
         });
       }
-    }
+    };
   });
 
   lemur.service('MomentService', function () {

--- a/lemur/static/app/angular/app.js
+++ b/lemur/static/app/angular/app.js
@@ -77,6 +77,22 @@
     };
   });
 
+  lemur.directive('confirmClick', function(){
+    return {
+      priority: -1,
+      restrict: 'A',
+      link: function(scope, element, attrs){
+        element.bind('click', function(e){
+          const message = attrs.confirmClick || "Are you sure?";
+          if(!confirm(message)){
+            e.stopImmediatePropagation();
+            e.preventDefault();
+          }
+        });
+      }
+    }
+  });
+
   lemur.service('MomentService', function () {
     this.diffMoment = function (start, end) {
       if (end !== 'None') {

--- a/lemur/static/app/angular/destinations/view/view.tpl.html
+++ b/lemur/static/app/angular/destinations/view/view.tpl.html
@@ -35,7 +35,9 @@
                 <button uib-tooltip="Edit Destination" ng-click="edit(destination.id)" class="btn btn-sm btn-info">
                   Edit
                 </button>
-                <button uib-tooltip="Delete Destination" ng-click="remove(destination)" type="button" class="btn btn-sm btn-danger pull-left">
+                <button uib-tooltip="Delete Destination" ng-click="remove(destination)"
+                        confirm-click="Proceed to remove the destination {{ destination.label }}?"
+                        type="button" class="btn btn-sm btn-danger pull-left">
                   Remove
                 </button>
               </div>

--- a/lemur/static/app/angular/dns_providers/view/view.tpl.html
+++ b/lemur/static/app/angular/dns_providers/view/view.tpl.html
@@ -34,7 +34,9 @@
                 <button uib-tooltip="Edit DNS Provider" ng-click="edit(dns_provider.id)" class="btn btn-sm btn-info">
                   Edit
                 </button>
-                <button uib-tooltip="Delete DNS Provider" ng-click="remove(dns_provider)" type="button" class="btn btn-sm btn-danger pull-left">
+                <button uib-tooltip="Delete DNS Provider" ng-click="remove(dns_provider)"
+                        confirm-click="Proceed to remove the DNS Provider {{ dns_provider.name }}?"
+                        type="button" class="btn btn-sm btn-danger pull-left">
                   Remove
                 </button>
               </div>

--- a/lemur/static/app/angular/notifications/view/view.tpl.html
+++ b/lemur/static/app/angular/notifications/view/view.tpl.html
@@ -40,7 +40,9 @@
                                 <button uib-tooltip="Edit Notification" ng-click="edit(notification.id)" class="btn btn-sm btn-info">
                                     Edit
                                 </button>
-                                <button uib-tooltip="Delete Notification" ng-click="remove(notification)" type="button" class="btn btn-sm btn-danger pull-left">
+                                <button uib-tooltip="Delete Notification" ng-click="remove(notification)"
+                                        confirm-click="Proceed to remove the notification {{ notification.label }}?"
+                                        type="button" class="btn btn-sm btn-danger pull-left">
                                     Remove
                                 </button>
                             </div>

--- a/lemur/static/app/angular/roles/view/view.tpl.html
+++ b/lemur/static/app/angular/roles/view/view.tpl.html
@@ -29,7 +29,8 @@
                 <button ng-click="edit(role.id)" class="btn btn-sm btn-info">
                   Edit
                 </button>
-                <a ng-click="remove(role)" class="btn btn-sm btn-danger">
+                <a ng-click="remove(role)" confirm-click="Proceed to remove the role {{ role.name }}?"
+                   class="btn btn-sm btn-danger">
                   Remove
                 </a>
               </div>

--- a/lemur/static/app/angular/sources/view/view.tpl.html
+++ b/lemur/static/app/angular/sources/view/view.tpl.html
@@ -35,7 +35,9 @@
                 <button uib-tooltip="Edit Source" ng-click="edit(source.id)" class="btn btn-sm btn-info">
                   Edit
                 </button>
-                <button uib-tooltip="Delete Source" ng-click="remove(source)" type="button" class="btn btn-sm btn-danger pull-left">
+                <button uib-tooltip="Delete Source" ng-click="remove(source)"
+                        confirm-click="Proceed to remove the source {{ source.label }}?"
+                        type="button" class="btn btn-sm btn-danger pull-left">
                   Remove
                 </button>
               </div>


### PR DESCRIPTION
The `Remove` option on UI for API Keys, DNS Provider, Role etc does not ask for confirmation. One can accidentally click on Remove in the wrong row from the table and end up deleting wrong record. These changes will add a minimal confirmation box allowing to confirm the action. I've added the name/label of entity being removed to the message to make it more user friendly.
This change also allows adding confirmation to any action, simply add html attribute `confirm-click="<desired message here>"` to the submit button.