### PR TITLE
Task to disable auto-rotation of duplicate certificates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ jobs:
       services:
         - postgresql
         - xvfb
-    - name: "python3.8-postgresql-12-bionic"
-      dist: bionic
+    - name: "python3.8-postgresql-12-focal"
+      dist: focal
       language: python
-      python: "3.7"
-      env: TOXENV=py37
+      python: "3.8"
+      env: TOXENV=py38
       addons:
         postgresql: '12'
         chrome: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
         - postgresql
         - xvfb
     - name: "python3.8-postgresql-12-focal"
-      dist: focal
+      dist: bionic
       language: python
       python: "3.8"
       env: TOXENV=py38
@@ -39,7 +39,6 @@ jobs:
         chrome: stable
         apt:
           packages:
-            - clang-10
             - postgresql-12
             - postgresql-client-12
             - postgresql-server-dev-12

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ jobs:
         chrome: stable
         apt:
           packages:
+            - clang-10
             - postgresql-12
             - postgresql-client-12
             - postgresql-server-dev-12

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       services:
         - postgresql
         - xvfb
-    - name: "python3.8-postgresql-12-focal"
+    - name: "python3.8-postgresql-12-bionic"
       dist: bionic
       language: python
       python: "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ jobs:
     - name: "python3.8-postgresql-12-bionic"
       dist: bionic
       language: python
-      python: "3.8"
-      env: TOXENV=py38
+      python: "3.7"
+      env: TOXENV=py37
       addons:
         postgresql: '12'
         chrome: stable

--- a/lemur/authorities/service.py
+++ b/lemur/authorities/service.py
@@ -187,6 +187,16 @@ def get_by_name(authority_name):
     return database.get(Authority, authority_name, field="name")
 
 
+def get_authorities_by_name(authority_names):
+    """
+    Retrieves an authority given it's name.
+
+    :param authority_names: list with authority names to match
+    :return:
+    """
+    return Authority.query.filter(Authority.name.in_(authority_names)).all()
+
+
 def get_authority_role(ca_name, creator=None):
     """
     Attempts to get the authority role for a given ca uses current_user

--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -16,6 +16,7 @@ from time import sleep
 from lemur import database
 from lemur.authorities.models import Authority
 from lemur.authorities.service import get as authorities_get_by_id
+from lemur.authorities.service import get_authorities_by_name
 from lemur.certificates.models import Certificate
 from lemur.certificates.schemas import CertificateOutputSchema
 from lemur.certificates.service import (
@@ -797,7 +798,7 @@ def disable_rotation_of_duplicate_certificates(commit):
 
     log_data["authorities"] = authority_names
 
-    authority_ids = [a.id for a in Authority.query.filter(Authority.name.in_(authority_names)).all()]
+    authority_ids = [a.id for a in get_authorities_by_name(authority_names)]
     duplicate_candidate_certs = list_duplicate_certs_by_authority(authority_ids)
 
     log_data["certs_with_serial_number_count"] = len(duplicate_candidate_certs)

--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -896,9 +896,9 @@ def process_duplicates(duplicate_candidate_cert, skipped_certs, rotation_disable
                          )
         else:
             # disable rotation and update DB
-            # matching_cert.rotation = False
-            # if commit:
-                # database.update(matching_cert)
+            matching_cert.rotation = False
+            if commit:
+                database.update(matching_cert)
             rotation_disabled_certs.append(matching_cert.name)
             metrics.send("disable_rotation_duplicates", "counter", 1,
                          metric_tags={"status": "success", "certificate": matching_cert.name}

--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -836,8 +836,8 @@ def process_duplicates(duplicate_candidate_cert, skipped_certs, rotation_disable
     Process duplicates with same prefix as duplicate_candidate_cert
 
     :param duplicate_candidate_cert: Name of the certificate which has duplicates
-    :param continue_with_auto_rotate: List of certificates which will continue to have rotation on (no change)
-    :param disable_auto_rotate: List of certificates for which rotation got disabled as part of this job
+    :param skipped_certs: List of certificates which will continue to have rotation on (no change)
+    :param rotation_disabled_certs: List of certificates for which rotation got disabled as part of this job
     :param unique_prefix: List of uniq prefixes to avoid rework
     :return: Success - True or False; If False, set of duplicates which were not processed
     """

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -247,6 +247,7 @@ def list_duplicate_certs_by_authority(authortiy_ids):
         Certificate.query.filter(Certificate.authority_id.in_(authortiy_ids))
         .filter(Certificate.not_after >= now)
         .filter(Certificate.rotation == true())
+        .filter(not_(Certificate.replaced.any()))
         .filter(text("name ~ '.*-[0-9]{8}-[0-9]{8}-.*'"))
         .all()
     )

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -235,9 +235,9 @@ def find_duplicates(cert):
 
 def list_duplicate_certs_by_authority(authortiy_ids):
     """
-    Find duplicate certificates issued by given authorities that are still valid, have auto-rotation ON and have names
-    that are forced to be unique using serial number like 'some.name.prefix-YYYYMMDD-YYYYMMDD-serialnumber', thus the
-    pattern "%-[0-9]{8}-[0-9]{8}-%"
+    Find duplicate certificates issued by given authorities that are still valid, not replaced, have auto-rotation ON,
+    with names that are forced to be unique using serial number like 'some.name.prefix-YYYYMMDD-YYYYMMDD-serialnumber',
+    thus the pattern "%-[0-9]{8}-[0-9]{8}-%"
     :param authortiy_ids:
     :return: List of certificates matching criteria
     """
@@ -254,9 +254,18 @@ def list_duplicate_certs_by_authority(authortiy_ids):
 
 
 def get_certificates_with_same_prefix_with_rotate_on(prefix):
+    """
+    Find certificates with given prefix that are still valid, not replaced and marked for auto-rotate
+
+    :param prefix: prefix to match
+    :return:
+    """
+    now = arrow.now().format("YYYY-MM-DD")
     return (
         Certificate.query.filter(Certificate.name.like(prefix))
         .filter(Certificate.rotation == true())
+        .filter(Certificate.not_after >= now)
+        .filter(not_(Certificate.replaced.any()))
         .all()
     )
 

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -987,7 +987,7 @@ def disable_rotation_of_duplicate_certificates():
 
     current_app.logger.debug(log_data)
     try:
-        cli_certificate.disable_rotation_of_duplicate_certificates()
+        cli_certificate.disable_rotation_of_duplicate_certificates(True)
     except SoftTimeLimitExceeded:
         log_data["message"] = "Time limit exceeded."
         current_app.logger.error(log_data)

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -960,12 +960,12 @@ def deactivate_entrust_test_certificates():
 def disable_rotation_of_duplicate_certificates():
     """
     We occasionally get duplicate certificates with Let's encrypt. Figure out the set of duplicate certificates and
-    disable auto-rotate if no endpoint is attached to the certificate. This way only the certificated with endpoints
+    disable auto-rotate if no endpoint is attached to the certificate. This way only the certificate with endpoints
     will get auto-rotated. If none of the certs have endpoint attached, to be on the safe side, keep auto rotate ON
-    for one of the certs. This tasks considers all the certificates issued by authority listed in the config
+    for one of the certs. This task considers all the certificates issued by the authorities listed in the config
     AUTHORITY_TO_DISABLE_ROTATE_OF_DUPLICATE_CERTIFICATES
     Determining duplicate certificates: certificates sharing same name prefix (followed by serial number to make it
-    unique) that have same validity, owner, destination, SAN.
+    unique) which have same validity length (issuance and expiration), owner, destination, SANs.
     :return:
     """
 

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -954,3 +954,50 @@ def deactivate_entrust_test_certificates():
 
     metrics.send(f"{function}.success", "counter", 1)
     return log_data
+
+
+@celery.task(soft_time_limit=3600)
+def disable_rotation_of_duplicate_certificates():
+    """
+    We occasionally get duplicate certificates with Let's encrypt. Figure out the set of duplicate certificates and
+    disable auto-rotate if no endpoint is attached to the certificate. This way only the certificated with endpoints
+    will get auto-rotated. If none of the certs have endpoint attached, to be on the safe side, keep auto rotate ON
+    for one of the certs. This tasks considers all the certificates issued by authority listed in the config
+    AUTHORITY_TO_DISABLE_ROTATE_OF_DUPLICATE_CERTIFICATES
+    Determining duplicate certificates: certificates sharing same name prefix (followed by serial number to make it
+    unique) that have same validity, owner, destination, SAN.
+    :return:
+    """
+
+    function = f"{__name__}.{sys._getframe().f_code.co_name}"
+    task_id = None
+    if celery.current_task:
+        task_id = celery.current_task.request.id
+
+    log_data = {
+        "function": function,
+        "message": "Disable rotation of duplicate certs issued by Let's Encrypt",
+        "task_id": task_id,
+    }
+
+    if task_id and is_task_active(function, task_id, None):
+        log_data["message"] = "Skipping task: Task is already active"
+        current_app.logger.debug(log_data)
+        return
+
+    current_app.logger.debug(log_data)
+    try:
+        cli_certificate.disable_rotation_of_duplicate_certificates()
+    except SoftTimeLimitExceeded:
+        log_data["message"] = "Time limit exceeded."
+        current_app.logger.error(log_data)
+        sentry.captureException()
+        metrics.send("celery.timeout", "counter", 1, metric_tags={"function": function})
+        return
+    except Exception as e:
+        current_app.logger.info(log_data)
+        sentry.captureException()
+        current_app.logger.exception(e)
+        return
+
+    metrics.send(f"{function}.success", "counter", 1)


### PR DESCRIPTION
Async cert issuance sometimes results in duplicate certificate creation give the retry logic. These certificates keep gettin reissued. The task attempts to find duplicate certificates for configured authorities `AUTHORITY_TO_DISABLE_ROTATE_OF_DUPLICATE_CERTIFICATES ` and turns off auto-rotation for duplicates if no endpoint attached to the cert leaving at least one cert to be auto-rotated. To identify certs to process in this task, it uses the naming convention by Lemur which appends the serial number to keep cert names unique. The certs with same prefix followed by different serial numbers help to identify duplicate candidates to do further decision making.