### PR TITLE
[Draft] Fixing dependency for failing build python3.8-postgresql-12-focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ jobs:
             - postgresql-client-common
             - libgc1c2
             - libobjc4
+            - libc6-i386
             - lib32gcc-s1
             - lib32gcc-s1
             - lib32stdc++6

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
       python: "3.8"
       env: TOXENV=py38
       addons:
-        postgresql: '12'
+        postgresql: '10'
         chrome: stable
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
             - llvm-10
             - llvm-10-dev
             - clang-10
-            - libclang-10-dev
+            - libclang-common-10-dev
             - postgresql-12
             - postgresql-client-12
             - postgresql-server-dev-12

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,11 @@ jobs:
         postgresql: '12'
         chrome: stable
         apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-focal-10
           packages:
+            - clang-10
             - postgresql-12
             - postgresql-client-12
             - postgresql-server-dev-12

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,6 @@ jobs:
         postgresql: '12'
         chrome: stable
         apt:
-          sources:
-            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
-              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
-            - sourceline: 'ppa:ubuntu-toolchain-r/test'
           packages:
             - libclang-cpp10
             - libpq-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
         - postgresql
         - xvfb
     - name: "python3.8-postgresql-10-focal"
-      dist: focal
+      dist: bionic
       language: python
       python: "3.8"
       env: TOXENV=py38

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,9 @@ jobs:
         chrome: stable
         apt:
           sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-focal-10
+            - sourceline: 'deb http://apt.llvm.org/focal llvm-toolchain-focal-10 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
           packages:
             - lib32gcc-s1
             - lib32stdc++6

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,7 @@ jobs:
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
             - sourceline: 'ppa:ubuntu-toolchain-r/test'
           packages:
-            - llvm-10
-            - llvm-10-dev
             - clang-10
-            - libclang-common-10-dev
             - postgresql-12
             - postgresql-client-12
             - postgresql-server-dev-12

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,7 @@ before_install:
 before_script:
   - sudo systemctl stop postgresql
   - sudo apt-get install --allow-downgrades libpq5=12.6-0ubuntu0.20.04.1
+  - sudo apt-get install -yq --allow-downgrades libc6=2.31-0ubuntu9.2 libc6-dev=2.31-0ubuntu9.2
   # the port may have been auto-configured to use 5433 if it thought 5422 was already in use,
   # for some reason it happens very often
   # https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/bash/travis_setup_postgresql.bash#L52

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       services:
         - postgresql
         - xvfb
-    - name: "python3.8-postgresql-12-focal"
+    - name: "python3.8-postgresql-10-focal"
       dist: focal
       language: python
       python: "3.8"
@@ -39,27 +39,9 @@ jobs:
         chrome: stable
         apt:
           packages:
-            - libclang-cpp10
-            - libpq-dev
-            - pgdg-keyring
-            - postgresql-client-common
-            - libgc1c2
-            - libobjc4
-            - libc6-i386
-            - lib32gcc-s1
-            - lib32gcc-s1
-            - lib32stdc++6
-            - libclang-common-10-dev
-            - libclang1-10
-            - clang-10
-            - postgresql-common
-            - python3-pygments
-            - libz3-4
-            - libz3-dev
-            - ssl-cert
-            - postgresql-12
-            - postgresql-client-12
-            - postgresql-server-dev-12
+            - postgresql-10
+            - postgresql-client-10
+            - postgresql-server-dev-10
       services:
         - postgresql
         - xvfb
@@ -83,8 +65,6 @@ before_install:
 
 before_script:
   - sudo systemctl stop postgresql
-  - sudo apt-get install --allow-downgrades libpq5=12.6-0ubuntu0.20.04.1
-  - sudo apt-get install -yq --allow-downgrades libc6=2.31-0ubuntu9.2 libc6-dev=2.31-0ubuntu9.2
   # the port may have been auto-configured to use 5433 if it thought 5422 was already in use,
   # for some reason it happens very often
   # https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/bash/travis_setup_postgresql.bash#L52

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ jobs:
             - postgresql-client-common
             - libgc1c2
             - libobjc4
-            - libc6-i386
             - lib32gcc-s1
             - lib32gcc-s1
             - lib32stdc++6

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,24 @@ jobs:
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
             - sourceline: 'ppa:ubuntu-toolchain-r/test'
           packages:
+            - libclang-cpp10
+            - libpq-dev
+            - pgdg-keyring
+            - postgresql-client-common
+            - libgc1c2
+            - libobjc4
+            - libc6-i386
+            - lib32gcc-s1
+            - lib32gcc-s1
+            - lib32stdc++6
+            - libclang-common-10-dev
+            - libclang1-10
             - clang-10
+            - postgresql-common
+            - python3-pygments
+            - libz3-4
+            - libz3-dev
+            - ssl-cert
             - postgresql-12
             - postgresql-client-12
             - postgresql-server-dev-12
@@ -70,6 +87,7 @@ before_install:
 
 before_script:
   - sudo systemctl stop postgresql
+  - sudo apt-get install --allow-downgrades libpq5=12.6-0ubuntu0.20.04.1
   # the port may have been auto-configured to use 5433 if it thought 5422 was already in use,
   # for some reason it happens very often
   # https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/bash/travis_setup_postgresql.bash#L52

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,10 @@ jobs:
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
             - sourceline: 'ppa:ubuntu-toolchain-r/test'
           packages:
-            - lib32gcc-s1
-            - lib32stdc++6
-            - libc6-i386
+            - llvm-10
+            - llvm-10-dev
             - clang-10
-            - libclang-common-10-dev
+            - libclang-10-dev
             - postgresql-12
             - postgresql-client-12
             - postgresql-server-dev-12

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ jobs:
             - llvm-toolchain-focal-10
           packages:
             - clang-10
+            - libclang-common-10-dev
             - postgresql-12
             - postgresql-client-12
             - postgresql-server-dev-12

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
         chrome: stable
         apt:
           sources:
-            - sourceline: 'deb http://apt.llvm.org/focal llvm-toolchain-focal-10 main'
+            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
             - sourceline: 'ppa:ubuntu-toolchain-r/test'
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,9 @@ jobs:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-focal-10
           packages:
+            - lib32gcc-s1
+            - lib32stdc++6
+            - libc6-i386
             - clang-10
             - libclang-common-10-dev
             - postgresql-12


### PR DESCRIPTION
travis build is failing for python3.8-postgresql-12-focal with unmet dependency
`postgresql-server-dev-12 : Depends: clang-10 but it is not going to be installed`