### PR TITLE
Travis build fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,19 +29,19 @@ jobs:
       services:
         - postgresql
         - xvfb
-    - name: "python3.8-postgresql-12-focal"
-      dist: focal
+    - name: "python3.8-postgresql-10-bionic"
+      dist: bionic
       language: python
       python: "3.8"
       env: TOXENV=py38
       addons:
-        postgresql: '12'
+        postgresql: '10'
         chrome: stable
         apt:
           packages:
-            - postgresql-12
-            - postgresql-client-12
-            - postgresql-server-dev-12
+            - postgresql-10
+            - postgresql-client-10
+            - postgresql-server-dev-10
       services:
         - postgresql
         - xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,22 @@ jobs:
       services:
         - postgresql
         - xvfb
+    - name: "python3.7-postgresql-12-bionic"
+      dist: bionic
+      language: python
+      python: "3.7"
+      env: TOXENV=py37
+      addons:
+        postgresql: '12'
+        chrome: stable
+        apt:
+          packages:
+            - postgresql-12
+            - postgresql-client-12
+            - postgresql-server-dev-12
+      services:
+        - postgresql
+        - xvfb
     - name: "python3.8-postgresql-10-bionic"
       dist: bionic
       language: python


### PR DESCRIPTION
travis build is failing for python3.8-postgresql-12-focal with unmet dependency
`postgresql-server-dev-12 : Depends: clang-10 but it is not going to be installed`

Thus running travis build with `python3.8 + postgresql-10 + bionic` and `python3.7 + postgresql-12 + bionic`

Closed PR with attempts to fix travis build using focal with python 3.8 + postgres 12 https://github.com/Netflix/lemur/pull/3543