### PR TITLE
Force source and destination delete to remove associations with certificate

### DIFF
--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -995,7 +995,7 @@ def remove_destination_association(certificate, destination):
         remove_from_destination(certificate, destination)
     except Exception as e:
         # This cleanup is the best-effort, it will capture the exception and log
-        sentry.captureException()
+        capture_exception()
         current_app.logger.warning(f"Failed to remove destination: {destination.label}. {str(e)}")
 
     metrics.send(

--- a/lemur/destinations/service.py
+++ b/lemur/destinations/service.py
@@ -12,6 +12,7 @@ from lemur import database
 from lemur.models import certificate_destination_associations
 from lemur.destinations.models import Destination
 from lemur.certificates.models import Certificate
+from lemur.certificates import service as certificate_service
 from lemur.logs import service as log_service
 from lemur.sources.service import add_aws_destination_to_sources
 
@@ -78,6 +79,14 @@ def delete(destination_id):
     """
     destination = get(destination_id)
     if destination:
+        # remove association of this source from all valid certificates
+        certificates = certificate_service.get_all_valid_certificates_with_destination(destination_id)
+        for certificate in certificates:
+            certificate_service.remove_source_and_destination_association(certificate, destination.label)
+            current_app.logger.warning(
+                f"Removed destination {destination.label} for {certificate.name} during destination delete")
+
+        # proceed with destination delete
         log_service.audit_log("delete_destination", destination.label, "Deleting destination")
         database.delete(destination)
 

--- a/lemur/destinations/service.py
+++ b/lemur/destinations/service.py
@@ -82,7 +82,7 @@ def delete(destination_id):
         # remove association of this source from all valid certificates
         certificates = certificate_service.get_all_valid_certificates_with_destination(destination_id)
         for certificate in certificates:
-            certificate_service.remove_source_and_destination_association(certificate, destination.label)
+            certificate_service.remove_destination_association(certificate, destination)
             current_app.logger.warning(
                 f"Removed destination {destination.label} for {certificate.name} during destination delete")
 

--- a/lemur/sources/service.py
+++ b/lemur/sources/service.py
@@ -299,7 +299,7 @@ def delete(source_id):
         # remove association of this source from all valid certificates
         certificates = certificate_service.get_all_valid_certificates_with_source(source_id)
         for certificate in certificates:
-            certificate_service.remove_source_and_destination_association(certificate, source.label)
+            certificate_service.remove_source_association(certificate, source)
             current_app.logger.warning(f"Removed source {source.label} for {certificate.name} during source delete")
 
         # proceed with source delete

--- a/lemur/sources/service.py
+++ b/lemur/sources/service.py
@@ -296,6 +296,13 @@ def delete(source_id):
     """
     source = get(source_id)
     if source:
+        # remove association of this source from all valid certificates
+        certificates = certificate_service.get_all_valid_certificates_with_source(source_id)
+        for certificate in certificates:
+            certificate_service.remove_source_and_destination_association(certificate, source.label)
+            current_app.logger.warning(f"Removed source {source.label} for {certificate.name} during source delete")
+
+        # proceed with source delete
         log_service.audit_log("delete_source", source.label, "Deleting source")
         database.delete(source)
 

--- a/lemur/static/app/angular/destinations/destination/destination.tpl.html
+++ b/lemur/static/app/angular/destinations/destination/destination.tpl.html
@@ -17,13 +17,16 @@
           destination label</p>
       </div>
     </div>
-    <div class="form-group">
+    <div class="form-group"
+         ng-class="{'has-error': createForm.comments.$invalid, 'has-success': !createForm.comments.$invalid&&createForm.comments.$dirty}">
       <label class="control-label col-sm-2">
         Description
       </label>
       <div class="col-sm-10">
         <textarea name="comments" ng-model="destination.description" placeholder="Something elegant"
-                  class="form-control"></textarea>
+                  class="form-control" required></textarea>
+        <p ng-show="createForm.comments.$invalid && !createForm.comments.$pristine" class="help-block">You must enter
+          description</p>
       </div>
     </div>
     <div class="form-group">

--- a/lemur/static/app/angular/destinations/view/view.tpl.html
+++ b/lemur/static/app/angular/destinations/view/view.tpl.html
@@ -36,7 +36,7 @@
                   Edit
                 </button>
                 <button uib-tooltip="Delete Destination" ng-click="remove(destination)"
-                        confirm-click="Proceed to remove the destination {{ destination.label }}?"
+                        confirm-click="Please note this will force delete existing association of this destination with valid certificates. Proceed to remove the destination {{ destination.label }}?"
                         type="button" class="btn btn-sm btn-danger pull-left">
                   Remove
                 </button>

--- a/lemur/static/app/angular/sources/source/source.tpl.html
+++ b/lemur/static/app/angular/sources/source/source.tpl.html
@@ -14,12 +14,14 @@
                 <p ng-show="createForm.label.$invalid && !createForm.label.$pristine" class="help-block">You must enter an source label</p>
             </div>
         </div>
-        <div class="form-group">
+        <div class="form-group"
+             ng-class="{'has-error': createForm.comments.$invalid, 'has-success': !createForm.comments.$invalid&&createForm.comments.$dirty}">
             <label class="control-label col-sm-2">
                 Description
             </label>
             <div class="col-sm-10">
-                <textarea name="comments" ng-model="source.description" placeholder="Something elegant" class="form-control" ></textarea>
+                <textarea name="comments" ng-model="source.description" placeholder="Something elegant" class="form-control" required></textarea>
+                <p ng-show="createForm.comments.$invalid && !createForm.comments.$pristine" class="help-block">You must enter description</p>
             </div>
         </div>
         <div class="form-group">

--- a/lemur/static/app/angular/sources/view/view.tpl.html
+++ b/lemur/static/app/angular/sources/view/view.tpl.html
@@ -36,7 +36,7 @@
                   Edit
                 </button>
                 <button uib-tooltip="Delete Source" ng-click="remove(source)"
-                        confirm-click="Proceed to remove the source {{ source.label }}?"
+                        confirm-click="Please note this will force delete existing association of this source with valid certificates. Proceed to remove the source {{ source.label }}?"
                         type="button" class="btn btn-sm btn-danger pull-left">
                   Remove
                 </button>


### PR DESCRIPTION
Source and destination delete is admin only operation. For situations like deleting account from AWS before doing necessary certificate cleanup from AWS and in Lemur, there does not exist a way to remove association of source or destination with a certificate. Modified the source and destination delete operation to remove such association of valid certificates (expired ones are already cleaned up via celery).
Modified the confirmation message for delete to reflect this change.
Also added missing form validation for source/destination create form.