### PR TITLE
Raven to sentry sdk migration

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -232,6 +232,13 @@ Basic Configuration
         using the legacy `SENTRY_CONFIG`, which Lemur attempts to respect, in case `SENTRY_DSN` is missing,
         with environment set to empty.
 
+        Example for using Senty to capture exceptions:
+
+            >>>  from sentry_sdk import capture_exception
+            >>>  ..
+            >>>  capture_exception()
+            >>>  # supplying extra information
+            >>>  capture_exception(extra={"certificate_name": str(certificate.name)})
 
 
 Certificate Default Options

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -221,6 +221,19 @@ Basic Configuration
         This is an optional config applicable for settings where Lemur is deployed in AWS. For accessing regionalized
         STS endpoints, LEMUR_AWS_REGION defines the region where Lemur is deployed.
 
+.. data:: SENTRY_DSN
+    :noindex:
+
+        To initialize the Sentry integration to capture errors and exceptions, the `SENTRY_DSN` is required to be set to
+        the respective URL. `LEMUR_ENV` is also a related variable to define the environment for sentry events, e.g.,
+        'test' or 'prod'.
+
+        Note that previously Lemur relied on Raven[flask] before migrating to `sentry_sdk`. In this case, you might be
+        using the legacy `SENTRY_CONFIG`, which Lemur attempts to respect, in case `SENTRY_DSN` is missing,
+        with environment set to empty.
+
+
+
 Certificate Default Options
 ---------------------------
 

--- a/lemur/acme_providers/cli.py
+++ b/lemur/acme_providers/cli.py
@@ -5,7 +5,7 @@ import arrow
 from flask_script import Manager
 from flask import current_app
 
-from lemur.extensions import sentry
+from sentry_sdk import capture_exception
 from lemur.constants import SUCCESS_METRIC_STATUS
 from lemur.plugins import plugins
 from lemur.plugins.lemur_acme.plugin import AcmeHandler
@@ -65,7 +65,7 @@ def dnstest(domain, token):
             dns_provider_plugin.wait_for_dns_change(change_id, account_number)
             print(f"[+] Verified TXT Record in `{dns_provider.name}` provider")
         except Exception:
-            sentry.captureException()
+            capture_exception()
             current_app.logger.debug(
                 f"Unable to resolve DNS challenge for change_id: {change_id}, account_id: "
                 f"{account_number}",

--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -124,7 +124,7 @@ def request_rotation(endpoint, certificate, message, commit):
 
         except Exception as e:
             capture_exception(extra={"certificate_name": str(certificate.name),
-                                           "endpoint": str(endpoint.dnsname)})
+                                     "endpoint": str(endpoint.dnsname)})
             current_app.logger.exception(
                 f"Error rotating certificate: {certificate.name}", exc_info=True
             )

--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -12,6 +12,7 @@ from flask_script import Manager
 from sqlalchemy import or_
 from tabulate import tabulate
 from time import sleep
+from sentry_sdk import capture_exception
 
 from lemur import database
 from lemur.authorities.models import Authority
@@ -36,7 +37,7 @@ from lemur.constants import SUCCESS_METRIC_STATUS, FAILURE_METRIC_STATUS, CRLRea
 from lemur.deployment import service as deployment_service
 from lemur.domains.models import Domain
 from lemur.endpoints import service as endpoint_service
-from lemur.extensions import sentry, metrics
+from lemur.extensions import metrics
 from lemur.notifications.messaging import send_rotation_notification
 from lemur.plugins.base import plugins
 
@@ -122,7 +123,7 @@ def request_rotation(endpoint, certificate, message, commit):
             status = SUCCESS_METRIC_STATUS
 
         except Exception as e:
-            sentry.captureException(extra={"certificate_name": str(certificate.name),
+            capture_exception(extra={"certificate_name": str(certificate.name),
                                            "endpoint": str(endpoint.dnsname)})
             current_app.logger.exception(
                 f"Error rotating certificate: {certificate.name}", exc_info=True
@@ -162,7 +163,7 @@ def request_reissue(certificate, commit):
         status = SUCCESS_METRIC_STATUS
 
     except Exception as e:
-        sentry.captureException(extra={"certificate_name": str(certificate.name)})
+        capture_exception(extra={"certificate_name": str(certificate.name)})
         current_app.logger.exception(
             f"Error reissuing certificate: {certificate.name}", exc_info=True
         )
@@ -274,7 +275,7 @@ def rotate(endpoint_name, new_certificate_name, old_certificate_name, message, c
         print("[+] Done!")
 
     except Exception as e:
-        sentry.captureException(
+        capture_exception(
             extra={
                 "old_certificate_name": str(old_certificate_name),
                 "new_certificate_name": str(new_certificate_name),
@@ -440,7 +441,7 @@ def rotate_region(endpoint_name, new_certificate_name, old_certificate_name, mes
         print("[+] Done!")
 
     except Exception as e:
-        sentry.captureException(
+        capture_exception(
             extra={
                 "old_certificate_name": str(old_certificate_name),
                 "new_certificate_name": str(new_certificate_name),
@@ -505,7 +506,7 @@ def reissue(old_certificate_name, commit):
         status = SUCCESS_METRIC_STATUS
         print("[+] Done!")
     except Exception as e:
-        sentry.captureException()
+        capture_exception()
         current_app.logger.exception("Error reissuing certificate.", exc_info=True)
         print("[!] Failed to reissue certificates. Reason: {}".format(e))
 
@@ -586,7 +587,7 @@ def worker(data, commit, reason):
         )
 
     except Exception as e:
-        sentry.captureException()
+        capture_exception()
         metrics.send(
             "certificate_revoke",
             "counter",
@@ -686,7 +687,7 @@ def check_revoked():
                 current_app.logger.info(log_data)
 
         except Exception as e:
-            sentry.captureException()
+            capture_exception()
             current_app.logger.exception(e)
             cert.status = "unknown"
 
@@ -776,7 +777,7 @@ def deactivate_entrust_certificates():
 
         except Exception as e:
             current_app.logger.info(log_data)
-            sentry.captureException()
+            capture_exception()
             current_app.logger.exception(e)
 
 

--- a/lemur/certificates/verify.py
+++ b/lemur/certificates/verify.py
@@ -8,10 +8,10 @@
 import requests
 import subprocess
 from flask import current_app
-from lemur.extensions import sentry
 from requests.exceptions import ConnectionError, InvalidSchema
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
+from sentry_sdk import capture_exception
 
 from lemur.utils import mktempfile
 from lemur.common.utils import parse_certificate
@@ -157,14 +157,14 @@ def verify(cert_path, issuer_chain_path):
     try:
         verify_result = ocsp_verify(cert, cert_path, issuer_chain_path)
     except Exception as e:
-        sentry.captureException()
+        capture_exception()
         current_app.logger.exception(e)
 
     if verify_result is None:
         try:
             verify_result = crl_verify(cert, cert_path)
         except Exception as e:
-            sentry.captureException()
+            capture_exception()
             current_app.logger.exception(e)
 
     if verify_result is None:

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -16,6 +16,7 @@ from celery.exceptions import SoftTimeLimitExceeded
 from celery.signals import task_failure, task_received, task_revoked, task_success
 from datetime import datetime, timezone, timedelta
 from flask import current_app
+from sentry_sdk import capture_exception
 
 from lemur.authorities.service import get as get_authority
 from lemur.certificates import cli as cli_certificate
@@ -24,7 +25,7 @@ from lemur.constants import ACME_ADDITIONAL_ATTEMPTS
 from lemur.destinations import service as destinations_service
 from lemur.dns_providers import cli as cli_dns_providers
 from lemur.endpoints import cli as cli_endpoints
-from lemur.extensions import metrics, sentry
+from lemur.extensions import metrics
 from lemur.factory import create_app
 from lemur.notifications import cli as cli_notification
 from lemur.notifications.messaging import send_pending_failure_notification
@@ -472,7 +473,7 @@ def clean_source(source):
     except SoftTimeLimitExceeded:
         log_data["message"] = "Clean source: Time limit exceeded."
         current_app.logger.error(log_data)
-        sentry.captureException()
+        capture_exception()
         metrics.send("celery.timeout", "counter", 1, metric_tags={"function": function})
     return log_data
 
@@ -543,7 +544,7 @@ def sync_source(source):
     except SoftTimeLimitExceeded:
         log_data["message"] = "Error syncing source: Time limit exceeded."
         current_app.logger.error(log_data)
-        sentry.captureException()
+        capture_exception()
         metrics.send(
             "sync_source_timeout", "counter", 1, metric_tags={"source": source}
         )
@@ -622,7 +623,7 @@ def certificate_reissue():
     except SoftTimeLimitExceeded:
         log_data["message"] = "Certificate reissue: Time limit exceeded."
         current_app.logger.error(log_data)
-        sentry.captureException()
+        capture_exception()
         metrics.send("celery.timeout", "counter", 1, metric_tags={"function": function})
         return
 
@@ -667,7 +668,7 @@ def certificate_rotate(**kwargs):
     except SoftTimeLimitExceeded:
         log_data["message"] = "Certificate rotate: Time limit exceeded."
         current_app.logger.error(log_data)
-        sentry.captureException()
+        capture_exception()
         metrics.send("celery.timeout", "counter", 1, metric_tags={"function": function})
         return
 
@@ -705,7 +706,7 @@ def endpoints_expire():
     except SoftTimeLimitExceeded:
         log_data["message"] = "endpoint expire: Time limit exceeded."
         current_app.logger.error(log_data)
-        sentry.captureException()
+        capture_exception()
         metrics.send("celery.timeout", "counter", 1, metric_tags={"function": function})
         return
 
@@ -741,7 +742,7 @@ def get_all_zones():
     except SoftTimeLimitExceeded:
         log_data["message"] = "get all zones: Time limit exceeded."
         current_app.logger.error(log_data)
-        sentry.captureException()
+        capture_exception()
         metrics.send("celery.timeout", "counter", 1, metric_tags={"function": function})
         return
 
@@ -777,7 +778,7 @@ def check_revoked():
     except SoftTimeLimitExceeded:
         log_data["message"] = "Checking revoked: Time limit exceeded."
         current_app.logger.error(log_data)
-        sentry.captureException()
+        capture_exception()
         metrics.send("celery.timeout", "counter", 1, metric_tags={"function": function})
         return
 
@@ -816,7 +817,7 @@ def notify_expirations():
     except SoftTimeLimitExceeded:
         log_data["message"] = "Notify expiring Time limit exceeded."
         current_app.logger.error(log_data)
-        sentry.captureException()
+        capture_exception()
         metrics.send("celery.timeout", "counter", 1, metric_tags={"function": function})
         return
 
@@ -852,7 +853,7 @@ def notify_authority_expirations():
     except SoftTimeLimitExceeded:
         log_data["message"] = "Notify expiring CA Time limit exceeded."
         current_app.logger.error(log_data)
-        sentry.captureException()
+        capture_exception()
         metrics.send("celery.timeout", "counter", 1, metric_tags={"function": function})
         return
 
@@ -888,7 +889,7 @@ def send_security_expiration_summary():
     except SoftTimeLimitExceeded:
         log_data["message"] = "Send summary for expiring certs Time limit exceeded."
         current_app.logger.error(log_data)
-        sentry.captureException()
+        capture_exception()
         metrics.send("celery.timeout", "counter", 1, metric_tags={"function": function})
         return
 
@@ -948,7 +949,7 @@ def deactivate_entrust_test_certificates():
     except SoftTimeLimitExceeded:
         log_data["message"] = "Time limit exceeded."
         current_app.logger.error(log_data)
-        sentry.captureException()
+        capture_exception()
         metrics.send("celery.timeout", "counter", 1, metric_tags={"function": function})
         return
 
@@ -991,12 +992,12 @@ def disable_rotation_of_duplicate_certificates():
     except SoftTimeLimitExceeded:
         log_data["message"] = "Time limit exceeded."
         current_app.logger.error(log_data)
-        sentry.captureException()
+        capture_exception()
         metrics.send("celery.timeout", "counter", 1, metric_tags={"function": function})
         return
     except Exception as e:
         current_app.logger.info(log_data)
-        sentry.captureException()
+        capture_exception()
         current_app.logger.exception(e)
         return
 

--- a/lemur/common/defaults.py
+++ b/lemur/common/defaults.py
@@ -4,9 +4,9 @@ import unicodedata
 from cryptography import x509
 from cryptography.hazmat.primitives.serialization import Encoding
 from flask import current_app
+from sentry_sdk import capture_exception
 
 from lemur.common.utils import is_selfsigned
-from lemur.extensions import sentry
 from lemur.constants import SAN_NAMING_TEMPLATE, DEFAULT_NAMING_TEMPLATE
 
 
@@ -77,7 +77,7 @@ def common_name(cert):
             return subject_oid[0].value.strip()
         return None
     except Exception as e:
-        sentry.captureException()
+        capture_exception()
         current_app.logger.error(
             {
                 "message": "Unable to get common name",
@@ -101,7 +101,7 @@ def organization(cert):
 
         return o[0].value.strip()
     except Exception as e:
-        sentry.captureException()
+        capture_exception()
         current_app.logger.error("Unable to get organization! {0}".format(e))
 
 
@@ -118,7 +118,7 @@ def organizational_unit(cert):
 
         return ou[0].value.strip()
     except Exception as e:
-        sentry.captureException()
+        capture_exception()
         current_app.logger.error("Unable to get organizational unit! {0}".format(e))
 
 
@@ -135,7 +135,7 @@ def country(cert):
 
         return c[0].value.strip()
     except Exception as e:
-        sentry.captureException()
+        capture_exception()
         current_app.logger.error("Unable to get country! {0}".format(e))
 
 
@@ -152,7 +152,7 @@ def state(cert):
 
         return s[0].value.strip()
     except Exception as e:
-        sentry.captureException()
+        capture_exception()
         current_app.logger.error("Unable to get state! {0}".format(e))
 
 
@@ -169,7 +169,7 @@ def location(cert):
 
         return loc[0].value.strip()
     except Exception as e:
-        sentry.captureException()
+        capture_exception()
         current_app.logger.error("Unable to get location! {0}".format(e))
 
 
@@ -190,9 +190,9 @@ def domains(cert):
             domains.append(entry)
     except x509.ExtensionNotFound:
         if current_app.config.get("LOG_SSL_SUBJ_ALT_NAME_ERRORS", True):
-            sentry.captureException()
+            capture_exception()
     except Exception as e:
-        sentry.captureException()
+        capture_exception()
 
     return domains
 
@@ -244,7 +244,7 @@ def bitstrength(cert):
     try:
         return cert.public_key().key_size
     except AttributeError:
-        sentry.captureException()
+        capture_exception()
         current_app.logger.debug("Unable to get bitstrength.")
 
 

--- a/lemur/common/health.py
+++ b/lemur/common/health.py
@@ -7,8 +7,10 @@
 .. moduleauthor:: Kevin Glisson <kglisson@netflix.com>
 """
 from flask import Blueprint
+from sentry_sdk import capture_exception
+
 from lemur.database import db
-from lemur.extensions import sentry
+
 
 mod = Blueprint("healthCheck", __name__)
 
@@ -19,7 +21,7 @@ def health():
         if healthcheck(db):
             return "ok"
     except Exception:
-        sentry.captureException()
+        capture_exception()
         return "db check failed"
 
 

--- a/lemur/common/redis.py
+++ b/lemur/common/redis.py
@@ -5,7 +5,8 @@ Helper Class for Redis
 import redis
 import sys
 from flask import current_app
-from lemur.extensions import sentry
+from sentry_sdk import capture_exception
+
 from lemur.factory import create_app
 
 if current_app:
@@ -37,7 +38,7 @@ class RedisHandler:
                 "port": self.port
             }
             current_app.logger.error(log_data)
-            sentry.captureException()
+            capture_exception()
         return red
 
 

--- a/lemur/common/schema.py
+++ b/lemur/common/schema.py
@@ -9,13 +9,11 @@
 """
 from functools import wraps
 from flask import request, current_app
-
+from sentry_sdk import capture_exception
 from sqlalchemy.orm.collections import InstrumentedList
 
 from inflection import camelize, underscore
 from marshmallow import Schema, post_dump, pre_load
-
-from lemur.extensions import sentry
 
 
 class LemurSchema(Schema):
@@ -159,7 +157,7 @@ def validate_schema(input_schema, output_schema):
             try:
                 resp = f(*args, **kwargs)
             except Exception as e:
-                sentry.captureException()
+                capture_exception()
                 current_app.logger.exception(e)
                 return dict(message=str(e)), 500
 

--- a/lemur/dns_providers/cli.py
+++ b/lemur/dns_providers/cli.py
@@ -1,11 +1,12 @@
 from flask_script import Manager
 
 import sys
+from sentry_sdk import capture_exception
 
 from lemur.constants import SUCCESS_METRIC_STATUS
 from lemur.plugins.lemur_acme.acme_handlers import AcmeDnsHandler
 from lemur.dns_providers.service import get_all_dns_providers, set_domains
-from lemur.extensions import metrics, sentry
+from lemur.extensions import metrics
 
 manager = Manager(
     usage="Iterates through all DNS providers and sets DNS zones in the database."
@@ -34,7 +35,7 @@ def get_all_zones():
         except Exception as e:
             print("[+] Error with DNS Provider {}: {}".format(dns_provider.name, e))
             log_data["message"] = f"get all zones failed for {dns_provider} {e}."
-            sentry.captureException(extra=log_data)
+            capture_exception(extra=log_data)
 
     status = SUCCESS_METRIC_STATUS
 

--- a/lemur/dns_providers/util.py
+++ b/lemur/dns_providers/util.py
@@ -5,8 +5,8 @@ import dns.name
 import dns.query
 import dns.resolver
 import re
+from sentry_sdk import capture_exception
 
-from lemur.extensions import sentry
 from lemur.extensions import metrics
 
 
@@ -95,7 +95,7 @@ def get_dns_records(domain, rdtype, nameserver):
             for record in rdata.strings:
                 records.append(record.decode("utf-8"))
     except dns.exception.DNSException:
-        sentry.captureException()
+        capture_exception()
         function = sys._getframe().f_code.co_name
         metrics.send(f"{function}.fail", "counter", 1)
     return records

--- a/lemur/endpoints/cli.py
+++ b/lemur/endpoints/cli.py
@@ -12,9 +12,10 @@ from datetime import timedelta
 
 from sqlalchemy import cast
 from sqlalchemy_utils import ArrowType
+from sentry_sdk import capture_exception
 
 from lemur import database
-from lemur.extensions import metrics, sentry
+from lemur.extensions import metrics
 from lemur.endpoints.models import Endpoint
 
 
@@ -53,4 +54,4 @@ def expire(ttl):
 
         print("[+] Finished expiration.")
     except Exception as e:
-        sentry.captureException()
+        capture_exception()

--- a/lemur/extensions.py
+++ b/lemur/extensions.py
@@ -38,10 +38,6 @@ from lemur.metrics import Metrics
 
 metrics = Metrics()
 
-from raven.contrib.flask import Sentry
-
-sentry = Sentry()
-
 from blinker import Namespace
 
 signals = Namespace()

--- a/lemur/factory.py
+++ b/lemur/factory.py
@@ -156,7 +156,7 @@ def configure_extensions(app):
             # associating users to errors
             send_default_pii=True,
             shutdown_timeout=60,
-            environment=app.config.get("LEMUR_ENV", 'test'),
+            environment=app.config.get("LEMUR_ENV", ''),
         )
 
     if app.config["CORS"]:

--- a/lemur/factory.py
+++ b/lemur/factory.py
@@ -11,6 +11,7 @@
 """
 import os
 import importlib
+import logmatic
 import errno
 import pkg_resources
 import socket
@@ -20,11 +21,16 @@ from logging.handlers import RotatingFileHandler
 
 from flask import Flask
 from flask_replicated import FlaskReplicated
-import logmatic
+
+import sentry_sdk
+from sentry_sdk.integrations.celery import CeleryIntegration
+from sentry_sdk.integrations.redis import RedisIntegration
+from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+from sentry_sdk.integrations.flask import FlaskIntegration
 
 from lemur.certificates.hooks import activate_debug_dump
 from lemur.common.health import mod as health
-from lemur.extensions import db, migrate, principal, smtp_mail, metrics, sentry, cors
+from lemur.extensions import db, migrate, principal, smtp_mail, metrics, cors
 
 
 DEFAULT_BLUEPRINTS = (health,)
@@ -136,7 +142,19 @@ def configure_extensions(app):
     principal.init_app(app)
     smtp_mail.init_app(app)
     metrics.init_app(app)
-    sentry.init_app(app)
+
+    if app.config["SENTRY_DSN"]:
+        sentrdy_dns = app.config["SENTRY_DSN"]
+        sentry_sdk.init(
+            dsn=sentrdy_dns,
+            integrations = [
+                SqlalchemyIntegration(),
+                CeleryIntegration(),
+                RedisIntegration(),
+                FlaskIntegration()],
+            # associating users to errors
+            send_default_pii=True,
+    )
 
     if app.config["CORS"]:
         app.config["CORS_HEADERS"] = "Content-Type"

--- a/lemur/factory.py
+++ b/lemur/factory.py
@@ -146,9 +146,9 @@ def configure_extensions(app):
     # the legacy Raven[flask] relied on SENTRY_CONFIG
     if app.config.get("SENTRY_DSN", None) or app.config.get("SENTRY_CONFIG", None):
         # priority given to SENTRY_DSN
-        sentry_dns = app.config.get("SENTRY_DSN", None) or app.config["SENTRY_CONFIG"]['dsn']
+        sentry_dsn = app.config.get("SENTRY_DSN", None) or app.config["SENTRY_CONFIG"]['dsn']
         sentry_sdk.init(
-            dsn=sentry_dns,
+            dsn=sentry_dsn,
             integrations=[SqlalchemyIntegration(),
                           CeleryIntegration(),
                           RedisIntegration(),

--- a/lemur/notifications/cli.py
+++ b/lemur/notifications/cli.py
@@ -6,9 +6,10 @@
 .. moduleauthor:: Kevin Glisson <kglisson@netflix.com>
 """
 from flask_script import Manager
+from sentry_sdk import capture_exception
 
 from lemur.constants import SUCCESS_METRIC_STATUS, FAILURE_METRIC_STATUS
-from lemur.extensions import sentry, metrics
+from lemur.extensions import metrics
 from lemur.notifications.messaging import send_expiration_notifications
 from lemur.notifications.messaging import send_authority_expiration_notifications
 from lemur.notifications.messaging import send_security_expiration_summary
@@ -53,7 +54,7 @@ def expirations(exclude, disabled_notification_plugins):
         )
         status = SUCCESS_METRIC_STATUS
     except Exception as e:
-        sentry.captureException()
+        capture_exception()
 
     metrics.send(
         "expiration_notification_job", "counter", 1, metric_tags={"status": status}
@@ -77,7 +78,7 @@ def authority_expirations():
         )
         status = SUCCESS_METRIC_STATUS
     except Exception as e:
-        sentry.captureException()
+        capture_exception()
 
     metrics.send(
         "authority_expiration_notification_job", "counter", 1, metric_tags={"status": status}
@@ -100,7 +101,7 @@ def security_expiration_summary(exclude):
         if success:
             status = SUCCESS_METRIC_STATUS
     except Exception:
-        sentry.captureException()
+        capture_exception()
 
     metrics.send(
         "security_expiration_notification_job", "counter", 1, metric_tags={"status": status}

--- a/lemur/notifications/messaging.py
+++ b/lemur/notifications/messaging.py
@@ -15,6 +15,7 @@ from itertools import groupby
 
 import arrow
 from flask import current_app
+from sentry_sdk import capture_exception
 from sqlalchemy import and_
 from sqlalchemy.sql.expression import false, true
 
@@ -24,7 +25,7 @@ from lemur.certificates.models import Certificate
 from lemur.certificates.schemas import certificate_notification_output_schema
 from lemur.common.utils import windowed_query, is_selfsigned
 from lemur.constants import FAILURE_METRIC_STATUS, SUCCESS_METRIC_STATUS
-from lemur.extensions import metrics, sentry
+from lemur.extensions import metrics
 from lemur.pending_certificates.schemas import pending_certificate_output_schema
 from lemur.plugins import plugins
 from lemur.plugins.utils import get_plugin_option
@@ -217,7 +218,7 @@ def send_plugin_notification(event_type, data, recipients, notification):
     except Exception as e:
         log_data["message"] = f"Unable to send {event_type} notification to recipients {recipients}"
         current_app.logger.error(log_data, exc_info=True)
-        sentry.captureException()
+        capture_exception()
 
     metrics.send(
         "notification",
@@ -354,7 +355,7 @@ def send_default_notification(notification_type, data, targets, notification_opt
         log_data["message"] = f"Unable to send {notification_type} notification for certificate data {data} " \
                               f"to targets {targets}"
         current_app.logger.error(log_data, exc_info=True)
-        sentry.captureException()
+        capture_exception()
 
     metrics.send(
         "notification",
@@ -469,7 +470,7 @@ def send_security_expiration_summary(exclude=None):
         log_data["message"] = f"Unable to send {notification_type} notification for certificates " \
                               f"{message_data} to targets {security_email}"
         current_app.logger.error(log_data, exc_info=True)
-        sentry.captureException()
+        capture_exception()
 
     metrics.send(
         "notification",

--- a/lemur/plugins/lemur_acme/powerdns.py
+++ b/lemur/plugins/lemur_acme/powerdns.py
@@ -6,7 +6,9 @@ import lemur.common.utils as utils
 import lemur.dns_providers.util as dnsutil
 import requests
 from flask import current_app
-from lemur.extensions import metrics, sentry
+from sentry_sdk import capture_exception
+
+from lemur.extensions import metrics
 
 REQUIRED_VARIABLES = [
     "ACME_POWERDNS_APIKEYNAME",
@@ -90,7 +92,7 @@ def get_zones(account_number):
         current_app.logger.debug(log_data)
 
     except Exception as e:
-        sentry.captureException()
+        capture_exception()
         log_data["message"] = "Failed to Retrieve Zone Data"
         current_app.logger.debug(log_data)
         raise
@@ -135,7 +137,7 @@ def create_txt_record(domain, token, account_number):
         log_data["message"] = "TXT record(s) successfully created"
         current_app.logger.debug(log_data)
     except Exception as e:
-        sentry.captureException()
+        capture_exception()
         log_data["Exception"] = e
         log_data["message"] = "Unable to create TXT record(s)"
         current_app.logger.debug(log_data)
@@ -231,7 +233,7 @@ def delete_txt_record(change_id, account_number, domain, token):
             log_data["message"] = "TXT record successfully deleted"
             current_app.logger.debug(log_data)
         except Exception as e:
-            sentry.captureException()
+            capture_exception()
             log_data["Exception"] = e
             log_data["message"] = "Unable to delete TXT record: patching exception"
             current_app.logger.debug(log_data)
@@ -272,7 +274,7 @@ def delete_txt_record(change_id, account_number, domain, token):
             log_data["message"] = "TXT record successfully deleted"
             current_app.logger.debug(log_data)
         except Exception as e:
-            sentry.captureException()
+            capture_exception()
             log_data["Exception"] = e
             log_data["message"] = "Unable to delete TXT record"
             current_app.logger.debug(log_data)
@@ -344,7 +346,7 @@ def _get_txt_records(domain):
         current_app.logger.debug(log_data)
 
     except Exception as e:
-        sentry.captureException()
+        capture_exception()
         log_data["Exception"] = e
         log_data["message"] = "Failed to Retrieve TXT Records"
         current_app.logger.debug(log_data)

--- a/lemur/plugins/lemur_acme/ultradns.py
+++ b/lemur/plugins/lemur_acme/ultradns.py
@@ -10,7 +10,9 @@ import dns.query
 import dns.resolver
 
 from flask import current_app
-from lemur.extensions import metrics, sentry
+from sentry_sdk import capture_exception
+
+from lemur.extensions import metrics
 
 
 class Record:
@@ -221,7 +223,7 @@ def wait_for_dns_change(change_id, account_number=None):
             time.sleep(10)
     if not status:
         metrics.send(f"{function}.fail", "counter", 1, metric_tags={"fqdn": fqdn, "txt_record": token})
-        sentry.captureException(extra={"fqdn": str(fqdn), "txt_record": str(token)})
+        capture_exception(extra={"fqdn": str(fqdn), "txt_record": str(token)})
     return
 
 

--- a/lemur/plugins/lemur_aws/iam.py
+++ b/lemur/plugins/lemur_aws/iam.py
@@ -9,8 +9,9 @@
 import botocore
 
 from retrying import retry
+from sentry_sdk import capture_exception
 
-from lemur.extensions import metrics, sentry
+from lemur.extensions import metrics
 from lemur.plugins.lemur_aws.sts import sts_client
 
 
@@ -131,7 +132,7 @@ def get_certificate(name, **kwargs):
     try:
         return client.get_server_certificate(ServerCertificateName=name)["ServerCertificate"]
     except client.exceptions.NoSuchEntityException:
-        sentry.captureException()
+        capture_exception()
         return None
 
 

--- a/lemur/plugins/lemur_aws/s3.py
+++ b/lemur/plugins/lemur_aws/s3.py
@@ -8,7 +8,7 @@
 """
 from botocore.exceptions import ClientError
 from flask import current_app
-from lemur.extensions import sentry
+from sentry_sdk import capture_exception
 
 from .sts import sts_client
 
@@ -39,7 +39,7 @@ def put(bucket_name, region_name, prefix, data, encrypt, **kwargs):
             bucket.put_object(Key=prefix, Body=data, ACL="bucket-owner-full-control")
             return True
         except ClientError:
-            sentry.captureException()
+            capture_exception()
             return False
 
 
@@ -56,7 +56,7 @@ def delete(bucket_name, prefixed_object_name, **kwargs):
                                  f"Status_code: {response}")
         return response['ResponseMetadata']['HTTPStatusCode'] < 300
     except ClientError:
-        sentry.captureException()
+        capture_exception()
         return False
 
 
@@ -71,5 +71,5 @@ def get(bucket_name, prefixed_object_name, **kwargs):
                                  f"object_name: {prefixed_object_name}")
         return response['Body'].read().decode("utf-8")
     except ClientError:
-        sentry.captureException()
+        capture_exception()
         return None

--- a/lemur/plugins/lemur_verisign/plugin.py
+++ b/lemur/plugins/lemur_verisign/plugin.py
@@ -12,9 +12,10 @@ import requests
 import xmltodict
 from cryptography import x509
 from flask import current_app
+from sentry_sdk import capture_exception
 
 from lemur.common.utils import get_psuedo_random_string
-from lemur.extensions import metrics, sentry
+from lemur.extensions import metrics
 from lemur.plugins import lemur_verisign as verisign
 from lemur.plugins.bases import IssuerPlugin, SourcePlugin
 
@@ -217,7 +218,7 @@ class VerisignIssuerPlugin(IssuerPlugin):
                 1,
                 metric_tags={"common_name": issuer_options.get("common_name", "")},
             )
-            sentry.captureException(
+            capture_exception(
                 extra={"common_name": issuer_options.get("common_name", "")}
             )
             raise Exception(f"Error with Verisign: {response.content}")

--- a/lemur/sources/cli.py
+++ b/lemur/sources/cli.py
@@ -9,14 +9,13 @@ import sys
 import time
 
 from tabulate import tabulate
-
 from flask_script import Manager
-
 from flask import current_app
+from sentry_sdk import capture_exception
 
 from lemur.constants import SUCCESS_METRIC_STATUS, FAILURE_METRIC_STATUS
 
-from lemur.extensions import metrics, sentry
+from lemur.extensions import metrics
 from lemur.plugins.base import plugins
 
 from lemur.sources import service as source_service
@@ -69,7 +68,7 @@ def execute_clean(plugin, certificate, source):
         return SUCCESS_METRIC_STATUS
     except Exception as e:
         current_app.logger.exception(e)
-        sentry.captureException()
+        capture_exception()
 
 
 @manager.option(
@@ -113,7 +112,7 @@ def sync(source_strings):
 
             print("[X] Failed syncing source {label}!\n".format(label=source.label))
 
-            sentry.captureException()
+            capture_exception()
             metrics.send(
                 "source_sync_fail",
                 "counter",

--- a/lemur/sources/service.py
+++ b/lemur/sources/service.py
@@ -9,13 +9,14 @@ import arrow
 import copy
 
 from flask import current_app
+from sentry_sdk import capture_exception
 
 from lemur import database
 from lemur.sources.models import Source
 from lemur.certificates.models import Certificate
 from lemur.certificates import service as certificate_service
 from lemur.endpoints import service as endpoint_service
-from lemur.extensions import metrics, sentry
+from lemur.extensions import metrics
 from lemur.destinations import service as destination_service
 
 from lemur.certificates.schemas import CertificateUploadInputSchema
@@ -102,7 +103,7 @@ def sync_endpoints(source):
                         source.label
                     )
                 )
-                sentry.captureException()
+                capture_exception()
 
             if certificate_attached_to_endpoint:
                 lemur_matching_cert, updated_by_hash_tmp = find_cert(certificate_attached_to_endpoint)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,38 +10,33 @@ bleach==3.3.0
     # via readme-renderer
 certifi==2020.12.5
     # via requests
-cffi==1.14.5
-    # via cryptography
 cfgv==3.2.0
     # via pre-commit
 chardet==4.0.0
     # via requests
 colorama==0.4.4
     # via twine
-cryptography==3.4.7
-    # via secretstorage
 distlib==0.3.1
     # via virtualenv
-docutils==0.17
+docutils==0.17.1
     # via readme-renderer
 filelock==3.0.12
     # via virtualenv
 flake8==3.8.4
     # via -r requirements-dev.in
-identify==2.2.3
+identify==2.2.4
     # via pre-commit
 idna==2.10
     # via requests
-importlib-metadata==3.10.0
+importlib-metadata==4.0.1
     # via
+    #   flake8
     #   keyring
+    #   pre-commit
     #   twine
+    #   virtualenv
 invoke==1.5.0
     # via -r requirements-dev.in
-jeepney==0.6.0
-    # via
-    #   keyring
-    #   secretstorage
 keyring==23.0.1
     # via twine
 mccabe==0.6.1
@@ -58,11 +53,9 @@ pre-commit==2.12.1
     # via -r requirements-dev.in
 pycodestyle==2.6.0
     # via flake8
-pycparser==2.20
-    # via cffi
 pyflakes==2.2.0
     # via flake8
-pygments==2.8.1
+pygments==2.9.0
     # via readme-renderer
 pyparsing==2.4.7
     # via packaging
@@ -80,8 +73,6 @@ requests==2.25.1
     #   twine
 rfc3986==1.4.0
     # via twine
-secretstorage==3.3.1
-    # via keyring
 six==1.15.0
     # via
     #   bleach
@@ -93,9 +84,11 @@ tqdm==4.60.0
     # via twine
 twine==3.4.1
     # via -r requirements-dev.in
+typing-extensions==3.10.0.0
+    # via importlib-metadata
 urllib3==1.26.4
     # via requests
-virtualenv==20.4.3
+virtualenv==20.4.4
     # via pre-commit
 webencodings==0.5.1
     # via bleach

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -73,7 +73,7 @@ requests==2.25.1
     #   twine
 rfc3986==1.4.0
     # via twine
-six==1.15.0
+six==1.16.0
     # via
     #   bleach
     #   readme-renderer
@@ -88,7 +88,7 @@ typing-extensions==3.10.0.0
     # via importlib-metadata
 urllib3==1.26.4
     # via requests
-virtualenv==20.4.4
+virtualenv==20.4.6
     # via pre-commit
 webencodings==0.5.1
     # via bleach

--- a/requirements-docs.in
+++ b/requirements-docs.in
@@ -36,9 +36,9 @@ pem
 pyjks >= 19 # pyjks < 19 depends on pycryptodome, which conflicts with dyn's usage of pycrypto
 pyjwt
 pyOpenSSL
-raven[flask]
 redis
 retrying
+sentry-sdk
 SQLAlchemy-Utils
 tabulate
 vine

--- a/requirements-docs.in
+++ b/requirements-docs.in
@@ -7,6 +7,7 @@ acme
 arrow
 boto3
 botocore
+celery
 certbot
 certsrv
 CloudFlare

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -13,6 +13,8 @@ alabaster==0.7.12
     # via sphinx
 alembic==1.6.0
     # via flask-migrate
+amqp==5.0.6
+    # via kombu
 aniso8601==9.0.1
     # via flask-restful
 appdirs==1.4.4
@@ -30,7 +32,7 @@ aws-sam-translator==1.35.0
     # via
     #   -r requirements-tests.txt
     #   cfn-lint
-aws-xray-sdk==2.7.0
+aws-xray-sdk==2.8.0
     # via
     #   -r requirements-tests.txt
     #   moto
@@ -44,18 +46,21 @@ bcrypt==3.2.0
     #   paramiko
 beautifulsoup4==4.9.3
     # via cloudflare
-black==21.4b2
+billiard==3.6.4.0
+    # via celery
+black==21.5b0
     # via -r requirements-tests.txt
 blinker==1.4
     # via
     #   flask-mail
     #   flask-principal
+boto3==1.17.65
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
     #   aws-sam-translator
     #   moto
-botocore==1.20.62
+botocore==1.20.65
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
@@ -63,6 +68,8 @@ botocore==1.20.62
     #   boto3
     #   moto
     #   s3transfer
+celery==5.0.5
+    # via -r requirements-docs.in
 certbot==1.14.0
     # via
     #   -r requirements-docs.in
@@ -80,7 +87,7 @@ cffi==1.14.5
     #   bcrypt
     #   cryptography
     #   pynacl
-cfn-lint==0.48.2
+cfn-lint==0.49.0
     # via
     #   -r requirements-tests.txt
     #   moto
@@ -88,10 +95,20 @@ chardet==4.0.0
     # via
     #   -r requirements-tests.txt
     #   requests
+click-didyoumean==0.0.3
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.1.6
+    # via celery
 click==7.1.2
     # via
     #   -r requirements-tests.txt
     #   black
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
     #   flask
 cloudflare==2.8.15
     # via -r requirements-docs.in
@@ -213,7 +230,9 @@ imagesize==1.2.0
     # via sphinx
 importlib-metadata==4.0.1
     # via
+    #   -r requirements-tests.txt
     #   jsonschema
+    #   kombu
     #   pluggy
     #   pytest
     #   stevedore
@@ -246,7 +265,7 @@ josepy==1.8.0
     #   -r requirements-tests.txt
     #   acme
     #   certbot
-jsondiff==1.2.0
+jsondiff==1.3.0
     # via
     #   -r requirements-tests.txt
     #   moto
@@ -269,6 +288,8 @@ junit-xml==1.9
     # via
     #   -r requirements-tests.txt
     #   cfn-lint
+kombu==5.0.2
+    # via celery
 logmatic-python==0.1.7
     # via -r requirements-docs.in
 mako==1.1.4
@@ -285,15 +306,11 @@ marshmallow==2.20.4
     # via
     #   -r requirements-docs.in
     #   marshmallow-sqlalchemy
-mock==4.0.3
-    # via
-    #   -r requirements-tests.txt
-    #   moto
 more-itertools==8.7.0
     # via
     #   -r requirements-tests.txt
     #   moto
-moto[all]==2.0.4
+moto[all]==2.0.6
     # via -r requirements-tests.txt
 mypy-extensions==0.4.3
     # via
@@ -320,7 +337,7 @@ pathspec==0.8.1
     # via
     #   -r requirements-tests.txt
     #   black
-pbr==5.5.1
+pbr==5.6.0
     # via
     #   -r requirements-tests.txt
     #   stevedore
@@ -330,6 +347,8 @@ pluggy==0.13.1
     # via
     #   -r requirements-tests.txt
     #   pytest
+prompt-toolkit==3.0.18
+    # via click-repl
 py==1.10.0
     # via
     #   -r requirements-tests.txt
@@ -382,7 +401,7 @@ pytest-flask==1.2.0
     # via -r requirements-tests.txt
 pytest-mock==3.6.0
     # via -r requirements-tests.txt
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements-tests.txt
     #   pytest-flask
@@ -409,6 +428,7 @@ pytz==2021.1
     #   -r requirements-tests.txt
     #   acme
     #   babel
+    #   celery
     #   certbot
     #   flask-restful
     #   moto
@@ -448,7 +468,7 @@ requests==2.25.1
     #   requests-toolbelt
     #   responses
     #   sphinx
-responses==0.13.2
+responses==0.13.3
     # via
     #   -r requirements-tests.txt
     #   moto
@@ -471,6 +491,7 @@ six==1.15.0
     #   bandit
     #   bcrypt
     #   cfn-lint
+    #   click-repl
     #   configobj
     #   ecdsa
     #   fakeredis
@@ -523,7 +544,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.4
     # via sphinx
-sqlalchemy-utils==0.37.1
+sqlalchemy-utils==0.37.2
     # via -r requirements-docs.in
 sqlalchemy==1.3.24
     # via
@@ -554,9 +575,12 @@ toml==0.10.2
 twofish==0.3.0
     # via pyjks
 typed-ast==1.4.3
-    # via black
+    # via
+    #   -r requirements-tests.txt
+    #   black
 typing-extensions==3.10.0.0
     # via
+    #   -r requirements-tests.txt
     #   arrow
     #   black
     #   importlib-metadata
@@ -568,8 +592,13 @@ urllib3==1.26.4
     #   responses
     #   sentry-sdk
 vine==5.0.0
-    # via -r requirements-docs.in
-websocket-client==0.58.0
+    # via
+    #   -r requirements-docs.in
+    #   amqp
+    #   celery
+wcwidth==0.2.5
+    # via prompt-toolkit
+websocket-client==0.59.0
     # via
     #   -r requirements-tests.txt
     #   docker
@@ -605,7 +634,7 @@ zope.hookable==5.0.1
     # via
     #   -r requirements-tests.txt
     #   zope.component
-zope.interface==5.3.0
+zope.interface==5.4.0
     # via
     #   -r requirements-tests.txt
     #   certbot

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -11,7 +11,7 @@ acme==1.14.0
     #   certbot
 alabaster==0.7.12
     # via sphinx
-alembic==1.5.8
+alembic==1.6.0
     # via flask-migrate
 aniso8601==9.0.1
     # via flask-restful
@@ -19,7 +19,7 @@ appdirs==1.4.4
     # via
     #   -r requirements-tests.txt
     #   black
-arrow==1.0.3
+arrow==1.1.0
     # via -r requirements-docs.in
 attrs==20.3.0
     # via
@@ -34,7 +34,7 @@ aws-xray-sdk==2.7.0
     # via
     #   -r requirements-tests.txt
     #   moto
-babel==2.9.0
+babel==2.9.1
     # via sphinx
 bandit==1.7.0
     # via -r requirements-tests.txt
@@ -203,7 +203,7 @@ gitpython==3.1.14
     #   bandit
 gunicorn==20.1.0
     # via -r requirements-docs.in
-hvac==0.10.9
+hvac==0.10.10
     # via -r requirements-docs.in
 idna==2.10
     # via
@@ -212,6 +212,12 @@ idna==2.10
     #   requests
 imagesize==1.2.0
     # via sphinx
+importlib-metadata==4.0.1
+    # via
+    #   jsonschema
+    #   pluggy
+    #   pytest
+    #   stevedore
 inflection==0.5.1
     # via -r requirements-docs.in
 iniconfig==1.1.1
@@ -346,11 +352,11 @@ pycryptodomex==3.10.1
     # via pyjks
 pyflakes==2.3.1
     # via -r requirements-tests.txt
-pygments==2.8.1
+pygments==2.9.0
     # via sphinx
 pyjks==20.0.0
     # via -r requirements-docs.in
-pyjwt==2.0.1
+pyjwt==2.1.0
     # via -r requirements-docs.in
 pynacl==1.4.0
     # via paramiko
@@ -518,7 +524,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.4
     # via sphinx
-sqlalchemy-utils==0.37.0
+sqlalchemy-utils==0.37.1
     # via -r requirements-docs.in
 sqlalchemy==1.3.24
     # via
@@ -548,6 +554,13 @@ toml==0.10.2
     #   pytest
 twofish==0.3.0
     # via pyjks
+typed-ast==1.4.3
+    # via black
+typing-extensions==3.10.0.0
+    # via
+    #   arrow
+    #   black
+    #   importlib-metadata
 urllib3==1.26.4
     # via
     #   -r requirements-tests.txt
@@ -579,6 +592,7 @@ xmltodict==0.12.0
 zipp==3.4.1
     # via
     #   -r requirements-tests.txt
+    #   importlib-metadata
     #   moto
 zope.component==5.0.0
     # via

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -50,7 +50,6 @@ blinker==1.4
     # via
     #   flask-mail
     #   flask-principal
-    #   raven
 boto3==1.17.57
     # via
     #   -r requirements-docs.in
@@ -73,6 +72,7 @@ certifi==2020.12.5
     # via
     #   -r requirements-tests.txt
     #   requests
+    #   sentry-sdk
 certsrv==2.1.1
     # via -r requirements-docs.in
 cffi==1.14.5
@@ -187,7 +187,6 @@ flask==1.1.2
     #   flask-script
     #   flask-sqlalchemy
     #   pytest-flask
-    #   raven
 freezegun==1.1.0
     # via -r requirements-tests.txt
 future==0.18.2
@@ -416,8 +415,6 @@ pyyaml==5.4.1
     #   cfn-lint
     #   cloudflare
     #   moto
-raven[flask]==6.10.0
-    # via -r requirements-docs.in
 redis==3.5.3
     # via
     #   -r requirements-docs.in
@@ -460,6 +457,8 @@ s3transfer==0.4.2
     # via
     #   -r requirements-tests.txt
     #   boto3
+sentry-sdk==1.0.0
+    # via -r requirements-docs.in
 six==1.15.0
     # via
     #   -r requirements-tests.txt
@@ -555,6 +554,7 @@ urllib3==1.26.4
     #   botocore
     #   requests
     #   responses
+    #   sentry-sdk
 vine==5.0.0
     # via -r requirements-docs.in
 websocket-client==0.58.0

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -14,17 +14,17 @@ attrs==20.3.0
     #   pytest
 aws-sam-translator==1.35.0
     # via cfn-lint
-aws-xray-sdk==2.7.0
+aws-xray-sdk==2.8.0
     # via moto
 bandit==1.7.0
     # via -r requirements-tests.in
-black==21.4b0
+black==21.5b0
     # via -r requirements-tests.in
-boto3==1.17.57
+boto3==1.17.65
     # via
     #   aws-sam-translator
     #   moto
-botocore==1.20.57
+botocore==1.20.65
     # via
     #   aws-xray-sdk
     #   boto3
@@ -36,7 +36,7 @@ certifi==2020.12.5
     # via requests
 cffi==1.14.5
     # via cryptography
-cfn-lint==0.48.2
+cfn-lint==0.49.0
     # via moto
 chardet==4.0.0
     # via requests
@@ -72,7 +72,7 @@ ecdsa==0.14.1
     #   sshpubkeys
 factory-boy==3.2.0
     # via -r requirements-tests.in
-faker==8.1.1
+faker==8.1.2
     # via
     #   -r requirements-tests.in
     #   factory-boy
@@ -92,6 +92,12 @@ idna==2.10
     # via
     #   moto
     #   requests
+importlib-metadata==4.0.1
+    # via
+    #   jsonschema
+    #   pluggy
+    #   pytest
+    #   stevedore
 iniconfig==1.1.1
     # via pytest
 itsdangerous==1.1.0
@@ -108,7 +114,7 @@ josepy==1.8.0
     # via
     #   acme
     #   certbot
-jsondiff==1.2.0
+jsondiff==1.3.0
     # via moto
 jsonpatch==1.32
     # via cfn-lint
@@ -124,11 +130,9 @@ markupsafe==1.1.1
     # via
     #   jinja2
     #   moto
-mock==4.0.3
-    # via moto
 more-itertools==8.7.0
     # via moto
-moto[all]==2.0.4
+moto[all]==2.0.6
     # via -r requirements-tests.in
 mypy-extensions==0.4.3
     # via black
@@ -142,7 +146,7 @@ parsedatetime==2.6
     # via certbot
 pathspec==0.8.1
     # via black
-pbr==5.5.1
+pbr==5.6.0
     # via stevedore
 pluggy==0.13.1
     # via pytest
@@ -172,7 +176,7 @@ pytest-flask==1.2.0
     # via -r requirements-tests.in
 pytest-mock==3.6.0
     # via -r requirements-tests.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements-tests.in
     #   pytest-flask
@@ -201,7 +205,7 @@ redis==3.5.3
     # via fakeredis
 regex==2021.4.4
     # via black
-requests-mock==1.8.0
+requests-mock==1.9.2
     # via -r requirements-tests.in
 requests-toolbelt==0.9.1
     # via acme
@@ -213,7 +217,7 @@ requests==2.25.1
     #   requests-mock
     #   requests-toolbelt
     #   responses
-responses==0.13.2
+responses==0.13.3
     # via moto
 rsa==4.7.2
     # via python-jose
@@ -250,12 +254,18 @@ toml==0.10.2
     # via
     #   black
     #   pytest
+typed-ast==1.4.3
+    # via black
+typing-extensions==3.10.0.0
+    # via
+    #   black
+    #   importlib-metadata
 urllib3==1.26.4
     # via
     #   botocore
     #   requests
     #   responses
-websocket-client==0.58.0
+websocket-client==0.59.0
     # via docker
 werkzeug==1.0.1
     # via
@@ -267,14 +277,16 @@ wrapt==1.12.1
 xmltodict==0.12.0
     # via moto
 zipp==3.4.1
-    # via moto
+    # via
+    #   importlib-metadata
+    #   moto
 zope.component==5.0.0
     # via certbot
 zope.event==4.5.0
     # via zope.component
 zope.hookable==5.0.1
     # via zope.component
-zope.interface==5.3.0
+zope.interface==5.4.0
     # via
     #   certbot
     #   zope.component

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --no-emit-index-url --output-file=requirements-tests.txt requirements-tests.in
 #
-acme==1.14.0
+acme==1.15.0
     # via certbot
 appdirs==1.4.4
     # via black
@@ -20,17 +20,17 @@ bandit==1.7.0
     # via -r requirements-tests.in
 black==21.5b0
     # via -r requirements-tests.in
-boto3==1.17.65
+boto3==1.17.67
     # via
     #   aws-sam-translator
     #   moto
-botocore==1.20.65
+botocore==1.20.67
     # via
     #   aws-xray-sdk
     #   boto3
     #   moto
     #   s3transfer
-certbot==1.14.0
+certbot==1.15.0
     # via -r requirements-tests.in
 certifi==2020.12.5
     # via requests
@@ -223,7 +223,7 @@ rsa==4.7.2
     # via python-jose
 s3transfer==0.4.2
     # via boto3
-six==1.15.0
+six==1.16.0
     # via
     #   aws-sam-translator
     #   bandit

--- a/requirements.in
+++ b/requirements.in
@@ -42,10 +42,10 @@ pyjwt
 pyOpenSSL
 pyyaml>=4.2b1 #high severity alert
 python_ldap
-raven[flask]
 redis
 requests
 retrying
+sentry-sdk
 six
 SQLAlchemy-Utils
 sqlalchemy < 1.4.0 # ImportError: cannot import name '_ColumnEntity' https://github.com/sqlalchemy/sqlalchemy/issues/6226

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --no-emit-index-url --output-file=requirements.txt requirements.in
 #
-acme==1.14.0
+acme==1.15.0
     # via
     #   -r requirements.in
     #   certbot
@@ -32,16 +32,16 @@ blinker==1.4
     # via
     #   flask-mail
     #   flask-principal
-boto3==1.17.65
+boto3==1.17.67
     # via -r requirements.in
-botocore==1.20.65
+botocore==1.20.67
     # via
     #   -r requirements.in
     #   boto3
     #   s3transfer
 celery[redis]==4.4.2
     # via -r requirements.in
-certbot==1.14.0
+certbot==1.15.0
     # via -r requirements.in
 certifi==2020.12.5
     # via
@@ -242,7 +242,7 @@ s3transfer==0.4.2
     # via boto3
 sentry-sdk==1.0.0
     # via -r requirements.in
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements.in
     #   bcrypt
@@ -257,7 +257,7 @@ six==1.15.0
     #   sqlalchemy-utils
 soupsieve==2.2.1
     # via beautifulsoup4
-sqlalchemy-utils==0.37.1
+sqlalchemy-utils==0.37.2
     # via -r requirements.in
 sqlalchemy==1.3.24
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,13 +10,13 @@ acme==1.14.0
     #   certbot
 alembic-autogenerate-enums==0.0.2
     # via -r requirements.in
-alembic==1.5.8
+alembic==1.6.0
     # via flask-migrate
 amqp==2.6.1
     # via kombu
 aniso8601==9.0.1
     # via flask-restful
-arrow==1.0.3
+arrow==1.1.0
     # via -r requirements.in
 asyncpool==1.0
     # via -r requirements.in
@@ -32,9 +32,9 @@ blinker==1.4
     # via
     #   flask-mail
     #   flask-principal
-boto3==1.17.57
+boto3==1.17.65
     # via -r requirements.in
-botocore==1.20.57
+botocore==1.20.65
     # via
     #   -r requirements.in
     #   boto3
@@ -116,10 +116,12 @@ future==0.18.2
     # via -r requirements.in
 gunicorn==20.1.0
     # via -r requirements.in
-hvac==0.10.9
+hvac==0.10.10
     # via -r requirements.in
 idna==2.10
     # via requests
+importlib-metadata==4.0.1
+    # via kombu
 inflection==0.5.1
     # via -r requirements.in
 itsdangerous==1.1.0
@@ -184,7 +186,7 @@ pycryptodomex==3.10.1
     # via pyjks
 pyjks==20.0.0
     # via -r requirements.in
-pyjwt==2.0.1
+pyjwt==2.1.0
     # via -r requirements.in
 pynacl==1.4.0
     # via paramiko
@@ -255,7 +257,7 @@ six==1.15.0
     #   sqlalchemy-utils
 soupsieve==2.2.1
     # via beautifulsoup4
-sqlalchemy-utils==0.37.0
+sqlalchemy-utils==0.37.1
     # via -r requirements.in
 sqlalchemy==1.3.24
     # via
@@ -268,6 +270,10 @@ tabulate==0.8.9
     # via -r requirements.in
 twofish==0.3.0
     # via pyjks
+typing-extensions==3.10.0.0
+    # via
+    #   arrow
+    #   importlib-metadata
 urllib3==1.26.4
     # via
     #   botocore
@@ -281,13 +287,15 @@ werkzeug==1.0.1
     # via flask
 xmltodict==0.12.0
     # via -r requirements.in
+zipp==3.4.1
+    # via importlib-metadata
 zope.component==5.0.0
     # via certbot
 zope.event==4.5.0
     # via zope.component
 zope.hookable==5.0.1
     # via zope.component
-zope.interface==5.3.0
+zope.interface==5.4.0
     # via
     #   certbot
     #   zope.component

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,6 @@ blinker==1.4
     # via
     #   flask-mail
     #   flask-principal
-    #   raven
 boto3==1.17.57
     # via -r requirements.in
 botocore==1.20.57
@@ -48,6 +47,7 @@ certifi==2020.12.5
     # via
     #   -r requirements.in
     #   requests
+    #   sentry-sdk
 certsrv==2.1.1
     # via -r requirements.in
 cffi==1.14.5
@@ -112,7 +112,6 @@ flask==1.1.2
     #   flask-restful
     #   flask-script
     #   flask-sqlalchemy
-    #   raven
 future==0.18.2
     # via -r requirements.in
 gunicorn==20.1.0
@@ -221,8 +220,6 @@ pyyaml==5.4.1
     # via
     #   -r requirements.in
     #   cloudflare
-raven[flask]==6.10.0
-    # via -r requirements.in
 redis==3.5.3
     # via
     #   -r requirements.in
@@ -241,6 +238,8 @@ retrying==1.3.3
     # via -r requirements.in
 s3transfer==0.4.2
     # via boto3
+sentry-sdk==1.0.0
+    # via -r requirements.in
 six==1.15.0
     # via
     #   -r requirements.in
@@ -273,6 +272,7 @@ urllib3==1.26.4
     # via
     #   botocore
     #   requests
+    #   sentry-sdk
 vine==1.3.0
     # via
     #   amqp


### PR DESCRIPTION
Since beginning of 2021,  [Raven](https://github.com/getsentry/raven-python) has been deprecated in favor of [Sentry-Python](https://github.com/getsentry/sentry-python).

This PR migrates our sentry integration:

current dependency:

```
raven[flask]
```
Initialization in `extensions.py `

```
from raven.contrib.flask import Sentry

sentry = Sentry()
```

The DSN is usually controlled via `SENTRY_CONFIG`
```
SENTRY_CONFIG = {
   'dsn': 'https:...',
    'include_paths': ['lemur']
}
```
usage:

```
from lemur.extensions import sentry
..


except Exception as e:
    sentry.captureException(extra={"certificate_name": str(certificate.name)})
```

 

New usage: 
dependency:
```
pip install --upgrade sentry-sdk
```

setup: (Sentry comes with some default integrations)

```
import sentry_sdk

from sentry_sdk.integrations.celery import CeleryIntegration
from sentry_sdk.integrations.redis import RedisIntegration
from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
from sentry_sdk.integrations.flask import FlaskIntegration

sentry_sdk.init(
    dsn="https://examplePublicKey@o0.ingest.sentry.io/0",
    integrations[
        SqlalchemyIntegration(),
        CeleryIntegration(),
        RedisIntegration(),
        FlaskIntegration()],
    # associating users to errors
    send_default_pii=True,
)
``` 

usage:
```
from sentry_sdk import capture_exception

..

except Exception as e: 
    capture_exception(extra={"certificate_name": str(certificate.name)})
 ```