### PR TITLE
Add ports column to certificate_associations - alembic migration only

### DIFF
--- a/lemur/migrations/versions/4fe230f7a26e_.py
+++ b/lemur/migrations/versions/4fe230f7a26e_.py
@@ -1,0 +1,39 @@
+"""Add 'ports' column to certificate_associations table
+
+Revision ID: 4fe230f7a26e
+Revises: c301c59688d2
+Create Date: 2021-05-07 10:57:16.964743
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4fe230f7a26e'
+down_revision = 'c301c59688d2'
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+def upgrade():
+    # Add the "ports" column
+    op.add_column('certificate_associations', sa.Column('ports', postgresql.ARRAY(sa.Integer()), nullable=True))
+    # Make the existing foreign key columns non-nullable
+    op.alter_column('certificate_associations', 'domain_id',
+                    existing_type=sa.INTEGER(),
+                    nullable=False)
+    op.alter_column('certificate_associations', 'certificate_id',
+                    existing_type=sa.INTEGER(),
+                    nullable=False)
+
+
+def downgrade():
+    # Make the existing foreign key columns nullable
+    op.alter_column('certificate_associations', 'certificate_id',
+                    existing_type=sa.INTEGER(),
+                    nullable=True)
+    op.alter_column('certificate_associations', 'domain_id',
+                    existing_type=sa.INTEGER(),
+                    nullable=True)
+    # Drop the "ports" column
+    op.drop_column('certificate_associations', 'ports')


### PR DESCRIPTION
Unfortunately, it's necessary to put in/execute the DB migration before the schema change in code can be added. Here's the exception thrown if I combine the code change and schema change (the main error is `sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedColumn) column certificate_associations.ports does not exist`):

```
[2021-05-07 14:41:41,749] ERROR in app: Exception on /api/1/certificates/80916 [GET]
Traceback (most recent call last):
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/marshmallow/utils.py", line 349, in _get_value_for_key
    return obj[key]
TypeError: 'Certificate' object is not subscriptable
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1277, in _execute_context
    cursor, statement, parameters, context
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/engine/default.py", line 608, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.UndefinedColumn: column certificate_associations.ports does not exist
LINE 1: ...te_id AS certificate_associations_certificate_id, certificat...
                                                             ^
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/flask_restful/__init__.py", line 468, in wrapper
    resp = resource(*args, **kwargs)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/flask/views.py", line 89, in view
    return self.dispatch_request(*args, **kwargs)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/flask_restful/__init__.py", line 583, in dispatch_request
    resp = meth(*args, **kwargs)
  File "/Users/jschladen/repos/lemur-dev/lemur/lemur/auth/service.py", line 139, in decorated_function
    return f(*args, **kwargs)
  File "/Users/jschladen/repos/lemur-dev/lemur/lemur/common/schema.py", line 175, in decorated_function
    return unwrap_pagination(resp, output_schema_to_use), 200
  File "/Users/jschladen/repos/lemur-dev/lemur/lemur/common/schema.py", line 137, in unwrap_pagination
    return output_schema.dump(data).data
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/marshmallow/schema.py", line 521, in dump
    **kwargs
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/marshmallow/marshalling.py", line 140, in serialize
    index=(index if index_errors else None)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/marshmallow/marshalling.py", line 63, in call_and_store
    value = getter_func(data)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/marshmallow/marshalling.py", line 134, in <lambda>
    getter = lambda d: field_obj.serialize(attr_name, d, accessor=accessor)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/marshmallow/fields.py", line 243, in serialize
    value = self.get_value(attr, obj, accessor=accessor)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/marshmallow/fields.py", line 186, in get_value
    return accessor_func(check_key, obj, default)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/marshmallow/schema.py", line 415, in get_attribute
    return utils.get_value(attr, obj, default)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/marshmallow/utils.py", line 336, in get_value
    return _get_value_for_keys(key.split('.'), obj, default)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/marshmallow/utils.py", line 341, in _get_value_for_keys
    return _get_value_for_key(keys[0], obj, default)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/marshmallow/utils.py", line 352, in _get_value_for_key
    attr = getattr(obj, key)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/ext/associationproxy.py", line 193, in __get__
    return inst.get(obj)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/ext/associationproxy.py", line 561, in get
    _lazy_collection(obj, self.target_collection)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/ext/associationproxy.py", line 602, in _new
    collection_class = util.duck_type_collection(lazy_collection())
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/ext/associationproxy.py", line 932, in __call__
    return getattr(self.parent, self.target)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/orm/attributes.py", line 294, in __get__
    return self.impl.get(instance_state(instance), dict_)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/orm/attributes.py", line 730, in get
    value = self.callable_(state, passive)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/orm/strategies.py", line 760, in _load_for_state
    session, state, primary_key_identity, passive
  File "<string>", line 1, in <lambda>
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/orm/strategies.py", line 902, in _emit_lazyload
    .with_post_criteria(set_default_params)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/ext/baked.py", line 544, in all
    return list(self)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/ext/baked.py", line 444, in __iter__
    return q._execute_and_instances(context)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/orm/query.py", line 3560, in _execute_and_instances
    result = conn.execute(querycontext.statement, self._params)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1011, in execute
    return meth(self, multiparams, params)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/sql/elements.py", line 298, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1130, in _execute_clauseelement
    distilled_params,
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1317, in _execute_context
    e, statement, parameters, cursor, context
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1511, in _handle_dbapi_exception
    sqlalchemy_exception, with_traceback=exc_info[2], from_=e
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 182, in raise_
    raise exception
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1277, in _execute_context
    cursor, statement, parameters, context
  File "/Users/jschladen/repos/lemur-dev/lib/python3.7/site-packages/sqlalchemy/engine/default.py", line 608, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedColumn) column certificate_associations.ports does not exist
LINE 1: ...te_id AS certificate_associations_certificate_id, certificat...
                                                             ^
[SQL: SELECT certificate_associations.domain_id AS certificate_associations_domain_id, certificate_associations.certificate_id AS certificate_associations_certificate_id, certificate_associations.ports AS certificate_associations_ports 
FROM certificate_associations 
WHERE %(param_1)s = certificate_associations.certificate_id]
[parameters: {'param_1': 80916}]
(Background on this error at: http://sqlalche.me/e/13/f405)
```