### PR TITLE
Fix login bug during user creation

### DIFF
--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -275,6 +275,8 @@ def update_user(user, profile, roles):
             roles,
         )
 
+    return user
+
 
 class Login(Resource):
     """
@@ -440,7 +442,7 @@ class Ping(Resource):
             access_token
         )
         roles = create_user_roles(profile)
-        update_user(user, profile, roles)
+        user = update_user(user, profile, roles)
 
         if not user or not user.active:
             metrics.send(
@@ -499,7 +501,7 @@ class OAuth2(Resource):
 
         user, profile = retrieve_user(user_api_url, access_token)
         roles = create_user_roles(profile)
-        update_user(user, profile, roles)
+        user = update_user(user, profile, roles)
 
         if not user.active:
             metrics.send(


### PR DESCRIPTION
When an SSO login is done for the first time (i.e., when there is no `user` row in the database for the new user), roles are created properly with the role service, but the newly created user is never returned by `update_user()` in `lemur.auth.views`. This dooms the login until the second try, since the `user` variable is initially provided by `retrieve_user_*` and is used to complete the auth check.