### PR TITLE
Add check to dns provider

### DIFF
--- a/lemur/dns_providers/service.py
+++ b/lemur/dns_providers/service.py
@@ -42,7 +42,7 @@ def get_friendly(dns_provider_id):
     """
     dns_provider = get(dns_provider_id)
     if not dns_provider:
-        raise ValueError(f'No DNS provider {dns_provider_id}')
+        return None
     dns_provider_friendly = {
         "name": dns_provider.name,
         "description": dns_provider.description,

--- a/lemur/dns_providers/service.py
+++ b/lemur/dns_providers/service.py
@@ -41,6 +41,8 @@ def get_friendly(dns_provider_id):
     :return:
     """
     dns_provider = get(dns_provider_id)
+    if not dns_provider:
+        raise ValueError(f'No DNS provider {dns_provider_id}')
     dns_provider_friendly = {
         "name": dns_provider.name,
         "description": dns_provider.description,


### PR DESCRIPTION
Adds a check that the dns provider object from the database is real before `get_friendly()` attempts to access its attributes. `get()` returns `None` if there's no data discovered from the db. I didn't want to add this check to `get()` directly since it wouldn't be fair to assume other callers want to use the return object's attributes (happy to bump it there, though, if it seems to be a better fit).

The only caller of `get_friendly()` looks to be [here](https://github.com/Netflix/lemur/blob/master/lemur/dns_providers/views.py#L169) - maybe we should gracefully return a `404` or `None` instead of raising `ValueError`?