### PR TITLE
generate and verify oauth state tokens

### DIFF
--- a/docker/src/lemur.conf.py
+++ b/docker/src/lemur.conf.py
@@ -34,6 +34,9 @@ LEMUR_TOKEN_SECRET = repr(os.environ.get('LEMUR_TOKEN_SECRET',
 LEMUR_ENCRYPTION_KEYS = repr(os.environ.get('LEMUR_ENCRYPTION_KEYS',
                                             base64.b64encode(get_random_secret(32).encode('utf8')).decode('utf8')))
 
+# this is the secret used to generate oauth state tokens
+OAUTH_STATE_TOKEN_SECRET = repr(os.environ.get('OAUTH_STATE_TOKEN_SECRET', base64.b64encode(get_random_secret(32).encode('utf8')).decode('utf8')))
+
 REDIS_HOST = 'redis'
 REDIS_PORT = 6379
 REDIS_DB = 0

--- a/docker/src/lemur.conf.py
+++ b/docker/src/lemur.conf.py
@@ -35,7 +35,7 @@ LEMUR_ENCRYPTION_KEYS = repr(os.environ.get('LEMUR_ENCRYPTION_KEYS',
                                             base64.b64encode(get_random_secret(32).encode('utf8')).decode('utf8')))
 
 # this is the secret used to generate oauth state tokens
-OAUTH_STATE_TOKEN_SECRET = repr(os.environ.get('OAUTH_STATE_TOKEN_SECRET', base64.b64encode(get_random_secret(32).encode('utf8')).decode('utf8')))
+OAUTH_STATE_TOKEN_SECRET = repr(os.environ.get('OAUTH_STATE_TOKEN_SECRET', base64.b64encode(get_random_secret(32).encode('utf8'))))
 
 REDIS_HOST = 'redis'
 REDIS_PORT = 6379

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -873,6 +873,36 @@ For more information about how to use social logins, see: `Satellizer <https://g
 
             OAUTH2_VERIFY_CERT = True
 
+.. data:: OAUTH_STATE_TOKEN_SECRET
+    :noindex:
+
+        The OAUTH_STATE_TOKEN_SECRET is used to sign state tokens to guard against CSRF attacks. Without a secret configured, Lemur will use
+        a fallback secret: ``b'0auth'``. The secret must be `bytes-like <https://cryptography.io/en/latest/glossary/#term-bytes-like>`;
+        it will be used to instantiate `HMAC <https://cryptography.io/en/latest/hazmat/primitives/mac/hmac/#cryptography.hazmat.primitives.hmac.HMAC>`.
+
+        For implementation details, see ``generate_state_token()`` and ``verify_state_token() in ``lemur/auth/views.py``.
+
+        Running lemur create_config will securely generate a key for your configuration file.
+        If you would like to generate your own, we recommend the following method:
+
+            >>> import os
+            >>> import base64
+            >>> KEY_LENGTH = 32  # tweak as needed
+            >>> base64.b64encode(os.urandom(KEY_LENGTH))
+
+    ::
+
+        OAUTH_STATE_TOKEN_SECRET = b'RVdUVEZFQU4oISFAK18oJGZka2lmZmFsMjI0NTkxMjg='
+
+.. data:: OAUTH_STATE_TOKEN_STALE_TOLERANCE_SECONDS
+    :noindex:
+
+        Defaults to 15 seconds if configuration is not discovered.
+
+        ::
+
+            OAUTH_STATE_TOKEN_STALE_TOLERANCE_SECONDS = 15
+
 .. data:: GOOGLE_CLIENT_ID
     :noindex:
 

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -931,9 +931,9 @@ For more information about how to use social logins, see: `Satellizer <https://g
 
         The OAUTH_STATE_TOKEN_SECRET is used to sign state tokens to guard against CSRF attacks. Without a secret configured, Lemur will use
         a fallback secret: ``b'0auth'``. The secret must be `bytes-like <https://cryptography.io/en/latest/glossary/#term-bytes-like>`;
-        it will be used to instantiate `HMAC <https://cryptography.io/en/latest/hazmat/primitives/mac/hmac/#cryptography.hazmat.primitives.hmac.HMAC>`.
+        it will be used to instantiate the key parameter of `HMAC <https://cryptography.io/en/latest/hazmat/primitives/mac/hmac/#cryptography.hazmat.primitives.hmac.HMAC>`.
 
-        For implementation details, see ``generate_state_token()`` and ``verify_state_token() in ``lemur/auth/views.py``.
+        For implementation details, see ``generate_state_token()`` and ``verify_state_token()`` in ``lemur/auth/views.py``.
 
         Running lemur create_config will securely generate a key for your configuration file.
         If you would like to generate your own, we recommend the following method:

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -945,7 +945,7 @@ For more information about how to use social logins, see: `Satellizer <https://g
 
     ::
 
-        OAUTH_STATE_TOKEN_SECRET = base64.b64encode(lemur.common.utils.get_random_secret(32).encode('utf8'))
+        OAUTH_STATE_TOKEN_SECRET = lemur.common.utils.get_state_token_secret()
 
 .. data:: OAUTH_STATE_TOKEN_STALE_TOLERANCE_SECONDS
     :noindex:

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -929,8 +929,8 @@ For more information about how to use social logins, see: `Satellizer <https://g
 .. data:: OAUTH_STATE_TOKEN_SECRET
     :noindex:
 
-        The OAUTH_STATE_TOKEN_SECRET is used to sign state tokens to guard against CSRF attacks. Without a secret configured, Lemur will use
-        a fallback secret: ``b'0auth'``. The secret must be `bytes-like <https://cryptography.io/en/latest/glossary/#term-bytes-like>`;
+        The OAUTH_STATE_TOKEN_SECRET is used to sign state tokens to guard against CSRF attacks. Without a secret configured, Lemur will create
+        a fallback secret on a per-server basis that would last for the length of the server's lifetime (e.g., between redeploys). The secret must be `bytes-like <https://cryptography.io/en/latest/glossary/#term-bytes-like>`;
         it will be used to instantiate the key parameter of `HMAC <https://cryptography.io/en/latest/hazmat/primitives/mac/hmac/#cryptography.hazmat.primitives.hmac.HMAC>`.
 
         For implementation details, see ``generate_state_token()`` and ``verify_state_token()`` in ``lemur/auth/views.py``.
@@ -945,7 +945,7 @@ For more information about how to use social logins, see: `Satellizer <https://g
 
     ::
 
-        OAUTH_STATE_TOKEN_SECRET = b'RVdUVEZFQU4oISFAK18oJGZka2lmZmFsMjI0NTkxMjg='
+        OAUTH_STATE_TOKEN_SECRET = base64.b64encode(lemur.common.utils.get_random_secret(32).encode('utf8'))
 
 .. data:: OAUTH_STATE_TOKEN_STALE_TOLERANCE_SECONDS
     :noindex:

--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -303,14 +303,14 @@ def verify_state_token(token):
     try:
         state = token.encode('utf-8')
         ts, digest = state.split(b':')
-        timestamp = int(ts, 16)  # todo: check freshness of timestamp vs. current time?
+        timestamp = int(ts, 16)
         if float(time.time() - timestamp) > stale_seconds:
             current_app.logger.warning('OAuth State token is too stale.')
             return False
         digest = base64.b64decode(digest)
         h = build_hmac()
         h.update(ts)
-        h.verify(digest)  # should verification fail for any reason, an exception is thrown
+        h.verify(digest)
         return True
     except InvalidSignature:
         current_app.logger.warning('OAuth State token is invalid.')

--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -305,7 +305,7 @@ def verify_state_token(token):
         ts, digest = state.split(b':')
         timestamp = int(ts, 16)  # todo: check freshness of timestamp vs. current time?
         if float(time.time() - timestamp) > stale_seconds:
-            current_app.logger.warning(f'OAuth State token is too stale.')
+            current_app.logger.warning('OAuth State token is too stale.')
             return False
         digest = base64.b64decode(digest)
         h = build_hmac()
@@ -313,7 +313,7 @@ def verify_state_token(token):
         h.verify(digest)  # should verification fail for any reason, an exception is thrown
         return True
     except InvalidSignature:
-        current_app.logger.warning(f'OAuth State token is invalid.')
+        current_app.logger.warning('OAuth State token is invalid.')
         return False
     except Exception as e:
         current_app.logger.warning(f'Error while parsing OAuth State token: {e}')

--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -10,6 +10,10 @@ import json
 import jwt
 import base64
 import requests
+import time
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, hmac
 
 from flask import Blueprint, current_app
 
@@ -277,6 +281,30 @@ def update_user(user, profile, roles):
 
     return user
 
+def generate_state_token():
+    key = current_app.config.get('OAUTH_STATE_TOKEN_SECRET', '0auth')
+    t = int(time.time())
+    ts = hex(t)[2:].encode('ascii')
+    h = hmac.HMAC(key, hashes.SHA256(), backend=default_backend())
+    h.update(ts)
+    digest = base64.b64encode(h.finalize())
+    state = ts + b':' + digest
+    return state.decode('utf-8')
+
+def verify_state_token(token):
+    try:
+        key = current_app.config.get('OAUTH_STATE_TOKEN_SECRET', '0auth')
+        state = token.encode('utf-8')
+        ts, digest = state.split(b':')
+        timestamp = int(ts, 16)  # todo: check timestamp vs current time?
+        digest = base64.b64decode(digest)
+        h = hmac.HMAC(key, hashes.SHA256(), backend=default_backend())
+        h.update(ts)
+        h.verify(digest)
+        return True
+    except Exception as e:
+        current_app.logger.info(f'Error while parsing OAuth State token: {e}')
+        return False
 
 class Login(Resource):
     """
@@ -417,6 +445,8 @@ class Ping(Resource):
         self.reqparse.add_argument("code", type=str, required=True, location="json")
 
         args = self.reqparse.parse_args()
+        if not verify_state_token(args["state"]):
+            return dict(message="The supplied credentials are invalid"), 403
 
         # you can either discover these dynamically or simply configure them
         access_token_url = current_app.config.get("PING_ACCESS_TOKEN_URL")
@@ -477,6 +507,8 @@ class OAuth2(Resource):
         self.reqparse.add_argument("code", type=str, required=True, location="json")
 
         args = self.reqparse.parse_args()
+        if not verify_state_token(args["state"]):
+            return dict(message="The supplied credentials are invalid"), 403
 
         # you can either discover these dynamically or simply configure them
         access_token_url = current_app.config.get("OAUTH2_ACCESS_TOKEN_URL")
@@ -623,7 +655,7 @@ class Providers(Resource):
                             "OAUTH2_AUTH_ENDPOINT"
                         ),
                         "requiredUrlParams": ["scope", "state", "nonce"],
-                        "state": "STATE",
+                        "state": generate_state_token(),
                         "nonce": get_psuedo_random_string(),
                         "type": "2.0",
                     }

--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -281,6 +281,7 @@ def update_user(user, profile, roles):
 
     return user
 
+
 def generate_state_token():
     key = current_app.config.get('OAUTH_STATE_TOKEN_SECRET', OAUTH_STATE_TOKEN_SECRET_FALLBACK)
     t = int(time.time())
@@ -290,6 +291,7 @@ def generate_state_token():
     digest = base64.b64encode(h.finalize())
     state = ts + b':' + digest
     return state.decode('utf-8')
+
 
 def verify_state_token(token):
     try:
@@ -305,6 +307,7 @@ def verify_state_token(token):
     except Exception as e:
         current_app.logger.info(f'Error while parsing OAuth State token: {e}')
         return False
+
 
 class Login(Resource):
     """

--- a/lemur/common/utils.py
+++ b/lemur/common/utils.py
@@ -9,7 +9,6 @@
 import base64
 import random
 import re
-import os
 import socket
 import ssl
 import string
@@ -55,6 +54,7 @@ def get_psuedo_random_string():
     challenge += "".join(random.choice(string.digits) for x in range(6))  # noqa
     return challenge
 
+
 def get_random_secret(length):
     """ Similar to get_pseudo_random_string, but accepts a length parameter. """
     secret_key = ''.join(random.choice(string.ascii_uppercase) for x in range(round(length / 4)))
@@ -62,8 +62,10 @@ def get_random_secret(length):
     secret_key = secret_key + ''.join(random.choice(string.ascii_lowercase) for x in range(round(length / 4)))
     return secret_key + ''.join(random.choice(string.digits) for x in range(round(length / 4)))
 
+
 def get_state_token_secret():
     return base64.b64encode(get_random_secret(32).encode('utf8'))
+
 
 def parse_certificate(body):
     """

--- a/lemur/common/utils.py
+++ b/lemur/common/utils.py
@@ -9,6 +9,7 @@
 import base64
 import random
 import re
+import os
 import socket
 import ssl
 import string
@@ -54,6 +55,15 @@ def get_psuedo_random_string():
     challenge += "".join(random.choice(string.digits) for x in range(6))  # noqa
     return challenge
 
+def get_random_secret(length):
+    """ Similar to get_pseudo_random_string, but accepts a length parameter. """
+    secret_key = ''.join(random.choice(string.ascii_uppercase) for x in range(round(length / 4)))
+    secret_key = secret_key + ''.join(random.choice("~!@#$%^&*()_+") for x in range(round(length / 4)))
+    secret_key = secret_key + ''.join(random.choice(string.ascii_lowercase) for x in range(round(length / 4)))
+    return secret_key + ''.join(random.choice(string.digits) for x in range(round(length / 4)))
+
+def get_state_token_secret():
+    return base64.b64encode(get_random_secret(32).encode('utf8'))
 
 def parse_certificate(body):
     """

--- a/lemur/constants.py
+++ b/lemur/constants.py
@@ -12,8 +12,6 @@ NONSTANDARD_NAMING_TEMPLATE = "{issuer}-{not_before}-{not_after}"
 SUCCESS_METRIC_STATUS = "success"
 FAILURE_METRIC_STATUS = "failure"
 
-# fallback if we don't have an oauth state token secret configured
-OAUTH_STATE_TOKEN_SECRET_FALLBACK = b'0auth'
 
 # when ACME attempts to resolve a certificate try in total 3 times
 ACME_ADDITIONAL_ATTEMPTS = 2

--- a/lemur/constants.py
+++ b/lemur/constants.py
@@ -13,7 +13,7 @@ SUCCESS_METRIC_STATUS = "success"
 FAILURE_METRIC_STATUS = "failure"
 
 # fallback if we don't have an oauth state token secret configured
-OAUTH_STATE_TOKEN_SECRET_FALLBACK = "0auth"
+OAUTH_STATE_TOKEN_SECRET_FALLBACK = b'0auth'
 
 # when ACME attempts to resolve a certificate try in total 3 times
 ACME_ADDITIONAL_ATTEMPTS = 2

--- a/lemur/constants.py
+++ b/lemur/constants.py
@@ -12,6 +12,9 @@ NONSTANDARD_NAMING_TEMPLATE = "{issuer}-{not_before}-{not_after}"
 SUCCESS_METRIC_STATUS = "success"
 FAILURE_METRIC_STATUS = "failure"
 
+# fallback if we don't have an oauth state token secret configured
+OAUTH_STATE_TOKEN_SECRET_FALLBACK = "0auth"
+
 # when ACME attempts to resolve a certificate try in total 3 times
 ACME_ADDITIONAL_ATTEMPTS = 2
 

--- a/lemur/manage.py
+++ b/lemur/manage.py
@@ -95,7 +95,7 @@ LEMUR_TOKEN_SECRET = '{secret_token}'
 LEMUR_ENCRYPTION_KEYS = '{encryption_key}'
 
 # this is the secret used to generate oauth state tokens
-OAUTH_STATE_TOKEN_SECRET = '{oauth_state_token_secret}'
+OAUTH_STATE_TOKEN_SECRET = {oauth_state_token_secret}
 
 # List of domain regular expressions that non-admin users can issue
 LEMUR_ALLOWED_DOMAINS = []
@@ -183,7 +183,7 @@ def generate_settings():
         encryption_key=Fernet.generate_key().decode("utf-8"),
         secret_token=base64.b64encode(os.urandom(KEY_LENGTH)).decode("utf-8"),
         flask_secret_key=base64.b64encode(os.urandom(KEY_LENGTH)).decode("utf-8"),
-        oauth_state_token_secret=base64.b64encode(os.urandom(KEY_LENGTH)).decode("utf-8"),
+        oauth_state_token_secret=base64.b64encode(os.urandom(KEY_LENGTH)),
     )
 
     return output

--- a/lemur/manage.py
+++ b/lemur/manage.py
@@ -94,6 +94,9 @@ SECRET_KEY = '{flask_secret_key}'
 LEMUR_TOKEN_SECRET = '{secret_token}'
 LEMUR_ENCRYPTION_KEYS = '{encryption_key}'
 
+# this is the secret used to generate oauth state tokens
+OAUTH_STATE_TOKEN_SECRET = '{oauth_state_token_secret}'
+
 # List of domain regular expressions that non-admin users can issue
 LEMUR_ALLOWED_DOMAINS = []
 
@@ -180,6 +183,7 @@ def generate_settings():
         encryption_key=Fernet.generate_key().decode("utf-8"),
         secret_token=base64.b64encode(os.urandom(KEY_LENGTH)).decode("utf-8"),
         flask_secret_key=base64.b64encode(os.urandom(KEY_LENGTH)).decode("utf-8"),
+        oauth_state_token_secret=base64.b64encode(os.urandom(KEY_LENGTH)).decode("utf-8"),
     )
 
     return output

--- a/lemur/tests/conf.py
+++ b/lemur/tests/conf.py
@@ -35,6 +35,10 @@ LEMUR_TOKEN_SECRET = "test"
 LEMUR_ENCRYPTION_KEYS = base64.urlsafe_b64encode(get_random_secret(length=32).encode('utf8'))
 
 
+# this is the secret used to generate oauth state tokens
+OAUTH_STATE_TOKEN_SECRET = base64.b64encode(get_random_secret(32).encode('utf8'))
+
+
 # List of domain regular expressions that non-admin users can issue
 LEMUR_ALLOWED_DOMAINS = [
     r"^[a-zA-Z0-9-]+\.example\.com$",

--- a/lemur/tests/conf.py
+++ b/lemur/tests/conf.py
@@ -38,6 +38,7 @@ LEMUR_ENCRYPTION_KEYS = base64.urlsafe_b64encode(get_random_secret(length=32).en
 # this is the secret used to generate oauth state tokens
 OAUTH_STATE_TOKEN_SECRET = base64.b64encode(get_random_secret(32).encode('utf8'))
 
+OAUTH_STATE_TOKEN_STALE_TOLERANCE_SECONDS = 15
 
 # List of domain regular expressions that non-admin users can issue
 LEMUR_ALLOWED_DOMAINS = [

--- a/lemur/tests/test_oauth.py
+++ b/lemur/tests/test_oauth.py
@@ -1,0 +1,24 @@
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, hmac
+
+from lemur.auth.views import *  # noqa
+
+def test_build_hmac(client):
+    from lemur.auth.views import build_hmac
+
+    assert isinstance(build_hmac(), hmac.HMAC)
+
+
+def test_generate_state_token(client):
+    from lemur.auth.views import generate_state_token
+
+    assert generate_state_token()
+
+
+def test_verify_state_token(client):
+    from lemur.auth.views import generate_state_token
+    from lemur.auth.views import verify_state_token
+
+    token = generate_state_token()
+    assert verify_state_token(token)
+    assert not verify_state_token('123456:f4k8')

--- a/lemur/tests/test_oauth.py
+++ b/lemur/tests/test_oauth.py
@@ -1,7 +1,5 @@
 from datetime import datetime, timedelta
 from freezegun import freeze_time
-import time
-from unittest.mock import patch
 
 from lemur.auth.views import *  # noqa
 from lemur.tests.conf import OAUTH_STATE_TOKEN_STALE_TOLERANCE_SECONDS
@@ -26,10 +24,10 @@ def test_verify_state_token(client):
     token = generate_state_token()
     assert verify_state_token(token)
 
-    # get stale faster
     with freeze_time(datetime.now() - timedelta(seconds=OAUTH_STATE_TOKEN_STALE_TOLERANCE_SECONDS), tick=True):
         stale_token = generate_state_token()
     assert not verify_state_token(stale_token)
+
     assert not verify_state_token('123456:f4k8')
     assert not verify_state_token('123456::f4k8')
     assert not verify_state_token('123456f4k8')

--- a/lemur/tests/test_oauth.py
+++ b/lemur/tests/test_oauth.py
@@ -1,4 +1,10 @@
+from datetime import datetime, timedelta
+from freezegun import freeze_time
+import time
+from unittest.mock import patch
+
 from lemur.auth.views import *  # noqa
+from lemur.tests.conf import OAUTH_STATE_TOKEN_STALE_TOLERANCE_SECONDS
 
 
 def test_build_hmac(client):
@@ -19,4 +25,12 @@ def test_verify_state_token(client):
 
     token = generate_state_token()
     assert verify_state_token(token)
+
+    # get stale faster
+    with freeze_time(datetime.now() - timedelta(seconds=OAUTH_STATE_TOKEN_STALE_TOLERANCE_SECONDS), tick=True):
+        stale_token = generate_state_token()
+    assert not verify_state_token(stale_token)
     assert not verify_state_token('123456:f4k8')
+    assert not verify_state_token('123456::f4k8')
+    assert not verify_state_token('123456f4k8')
+    assert not verify_state_token('')

--- a/lemur/tests/test_oauth.py
+++ b/lemur/tests/test_oauth.py
@@ -1,7 +1,5 @@
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import hashes, hmac
-
 from lemur.auth.views import *  # noqa
+
 
 def test_build_hmac(client):
     from lemur.auth.views import build_hmac


### PR DESCRIPTION
This PR adds support for generation and verification of oauth state token nonces during login. Rather than rely on storing state tokens in a database or flask session variable (good luck trying that with gunicorn threading lol), we instead go stateless 🎉  by leveraging hmac to sign all the tokens we hand out, and then verify every token that's passed to the Lemur API server. Timestamp is included in the state token, so we could do some kind of freshness check if we want.