### PR TITLE
Consider duplicate certs issued in last n days

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -396,7 +396,34 @@ and security team (as specified by the ``LEMUR_SECURITY_TEAM_EMAIL`` configurati
 the pending certificate had notifications disabled.
 
 Lemur will attempt 3x times to resolve a pending certificate.
-This can at times result into 3 duplicate certificates, if all certificate attempts get resolved.
+This can at times result into 3 duplicate certificates, if all certificate attempts get resolved. There is a way to
+deduplicate these certificates periodically using a celery task ``disable_rotation_of_duplicate_certificates``.
+
+This needs 2 configurations
+
+.. data:: AUTHORITY_TO_DISABLE_ROTATE_OF_DUPLICATE_CERTIFICATES
+    :noindex:
+
+        List names of the authorities for which `disable_rotation_of_duplicate_certificates` should run. The task will
+        consider certificates issued by authorities configured here.
+
+    ::
+
+        AUTHORITY_TO_DISABLE_ROTATE_OF_DUPLICATE_CERTIFICATES = ["LetsEncrypt"]
+
+
+.. data:: DAYS_SINCE_ISSUANCE_DISABLE_ROTATE_OF_DUPLICATE_CERTIFICATES
+    :noindex:
+
+        Use this config (optional) to configure the number of days. The task `disable_rotation_of_duplicate_certificates`
+        will then consider valid certificates issued only in last those many number of days for deduplication. If not configured,
+        the task considers all the valid certificates. Ideally set this config to a value which is same as the number of
+        days between the two runs of `disable_rotation_of_duplicate_certificates`
+
+    ::
+
+        DAYS_SINCE_ISSUANCE_DISABLE_ROTATE_OF_DUPLICATE_CERTIFICATES = 7
+
 
 **Certificate rotation**
 

--- a/docs/production/index.rst
+++ b/docs/production/index.rst
@@ -329,19 +329,6 @@ The following commands that could/should be run on a periodic basis:
 - `check_revoked`
 - `sync`
 
-If you are using LetsEncrypt, you must also run the following:
-
-- `fetch_all_pending_acme_certs`
-- `remove_old_acme_certs`
-
-Rarely, lemur may see duplicate certificates issue with LetsEncrypt. This is because of the retry logic during
-resolution of pending certificates. To deduplicate these certificates, please consider running celery task
-`disable_rotation_of_duplicate_certificates`. This task will identify duplicate certificates and disable auto
-rotate if it's confident that the certificate is not being used. If certificate is in use, no change is done
-(operation status = skipped). If unused, auto-rotation will be disabled (operation status = success). If it's
-not able to confidently determine that certificates are duplicates, operation status will result in `failed` for
-that specific set of certificates. You may want to manually check these certs to determine if you want to keep them all.
-The task will always keep auto-rotate on for at least one certificate.
 
 How often you run these commands is largely up to the user. `notify` should be run once a day (more often will result in
 duplicate notifications). `check_revoked` is typically run at least once a day.
@@ -356,6 +343,22 @@ Example cron entries::
     */15 * * * * lemuruser export LEMUR_CONF=/Users/me/.lemur/lemur.conf.py; /www/lemur/bin/lemur source sync -s all
     0 22 * * * lemuruser export LEMUR_CONF=/Users/me/.lemur/lemur.conf.py; /www/lemur/bin/lemur certificate check_revoked
 
+
+If you are using LetsEncrypt, you must also run the following:
+
+- `fetch_all_pending_acme_certs`
+- `remove_old_acme_certs`
+
+Rarely, lemur may see duplicate certificates issue with LetsEncrypt. This is because of the retry logic during
+resolution of pending certificates. To deduplicate these certificates, please consider running the celery task
+`disable_rotation_of_duplicate_certificates`. This task will identify duplicate certificates and disable auto
+rotate if it's confident that the certificate is not being used. If  certificate is in use, no change is done
+(operation status = skipped). If unused, auto-rotation will be disabled (operation status = success). If it's
+not able to confidently determine that certificates are duplicates, operation status will result in `failed` for
+that specific set of certificates. You may want to manually check these certs to determine if you want to keep them all.
+The task will always keep auto-rotate on for at least one certificate.
+
+For better metrics around job completion, we recommend using celery to schedule recurring jobs in Lemur.
 
 Example Celery configuration (To be placed in your configuration file)::
 

--- a/docs/production/index.rst
+++ b/docs/production/index.rst
@@ -334,6 +334,15 @@ If you are using LetsEncrypt, you must also run the following:
 - `fetch_all_pending_acme_certs`
 - `remove_old_acme_certs`
 
+Rarely, lemur may see duplicate certificates issue with LetsEncrypt. This is because of the retry logic during
+resolution of pending certificates. To deduplicate these certificates, please consider running celery task
+`disable_rotation_of_duplicate_certificates`. This task will identify duplicate certificates and disable auto
+rotate if it's confident that the certificate is not being used. If certificate is in use, no change is done
+(operation status = skipped). If unused, auto-rotation will be disabled (operation status = success). If it's
+not able to confidently determine that certificates are duplicates, operation status will result in `failed` for
+that specific set of certificates. You may want to manually check these certs to determine if you want to keep them all.
+The task will always keep auto-rotate on for at least one certificate.
+
 How often you run these commands is largely up to the user. `notify` should be run once a day (more often will result in
 duplicate notifications). `check_revoked` is typically run at least once a day.
 `sync` is typically run every 15 minutes. `fetch_all_pending_acme_certs` should be ran frequently (Every minute is fine).

--- a/docs/production/index.rst
+++ b/docs/production/index.rst
@@ -418,6 +418,13 @@ Example Celery configuration (To be placed in your configuration file)::
                 'expires': 180
             },
             'schedule': crontab(hour=22, minute=0),
+        },
+        'disable_rotation_of_duplicate_certificates': {
+            'task': 'lemur.common.celery.disable_rotation_of_duplicate_certificates',
+            'options': {
+                'expires': 180
+            },
+            'schedule': crontab(hour=22, minute=0, day_of_week=2),
         }
     }
 

--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -798,6 +798,8 @@ def disable_rotation_of_duplicate_certificates(commit):
         return
 
     log_data["authorities"] = authority_names
+    days_since_issuance = current_app.config.get("DAYS_SINCE_ISSUANCE_DISABLE_ROTATE_OF_DUPLICATE_CERTIFICATES", -1)
+    log_data["days_since_issuance"] = f"{days_since_issuance} (Ignored if -1)"
 
     authority_ids = []
     invalid_authorities = []
@@ -815,7 +817,7 @@ def disable_rotation_of_duplicate_certificates(commit):
         current_app.logger.error(log_data)
         return
 
-    duplicate_candidate_certs = list_duplicate_certs_by_authority(authority_ids)
+    duplicate_candidate_certs = list_duplicate_certs_by_authority(authority_ids, days_since_issuance)
 
     log_data["certs_with_serial_number_count"] = len(duplicate_candidate_certs)
     current_app.logger.info(log_data)

--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -929,6 +929,7 @@ def is_duplicate(matching_cert, compare_to):
     if (
         matching_cert.owner != compare_to.owner
         or matching_cert.san != compare_to.san
+        or matching_cert.key_type != compare_to.key_type
         or matching_cert.not_before.date() != compare_to.not_before.date()
         or matching_cert.not_after.date() != compare_to.not_after.date()
     ):

--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -798,8 +798,8 @@ def disable_rotation_of_duplicate_certificates(commit):
         return
 
     log_data["authorities"] = authority_names
-    days_since_issuance = current_app.config.get("DAYS_SINCE_ISSUANCE_DISABLE_ROTATE_OF_DUPLICATE_CERTIFICATES", -1)
-    log_data["days_since_issuance"] = f"{days_since_issuance} (Ignored if -1)"
+    days_since_issuance = current_app.config.get("DAYS_SINCE_ISSUANCE_DISABLE_ROTATE_OF_DUPLICATE_CERTIFICATES", None)
+    log_data["days_since_issuance"] = f"{days_since_issuance} (Ignored if none)"
 
     authority_ids = []
     invalid_authorities = []

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -240,8 +240,7 @@ def list_duplicate_certs_by_authority(authority_ids, days_since_issuance):
     with names that are forced to be unique using serial number like 'some.name.prefix-YYYYMMDD-YYYYMMDD-serialnumber',
     thus the pattern "%-[0-9]{8}-[0-9]{8}-%"
     :param authority_ids:
-    :param days_since_issuance: If days_since_issuance != -1, include certificates issued in only last
-                                days_since_issuance days
+    :param days_since_issuance: If not -1, include certificates issued in only last days_since_issuance days
     :return: List of certificates matching criteria
     """
 

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -240,7 +240,7 @@ def list_duplicate_certs_by_authority(authority_ids, days_since_issuance):
     with names that are forced to be unique using serial number like 'some.name.prefix-YYYYMMDD-YYYYMMDD-serialnumber',
     thus the pattern "%-[0-9]{8}-[0-9]{8}-%"
     :param authority_ids:
-    :param days_since_issuance: If not -1, include certificates issued in only last days_since_issuance days
+    :param days_since_issuance: If not none, include certificates issued in only last days_since_issuance days
     :return: List of certificates matching criteria
     """
 
@@ -252,7 +252,7 @@ def list_duplicate_certs_by_authority(authority_ids, days_since_issuance):
         .filter(not_(Certificate.replaced.any()))\
         .filter(text("name ~ '.*-[0-9]{8}-[0-9]{8}-.*'"))
 
-    if days_since_issuance != -1:
+    if days_since_issuance:
         issuance_window = (
             arrow.now().shift(days=-days_since_issuance).format("YYYY-MM-DD")
         )

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -234,24 +234,32 @@ def find_duplicates(cert):
         return Certificate.query.filter_by(body=cert["body"].strip(), chain=None).all()
 
 
-def list_duplicate_certs_by_authority(authortiy_ids):
+def list_duplicate_certs_by_authority(authority_ids, days_since_issuance):
     """
     Find duplicate certificates issued by given authorities that are still valid, not replaced, have auto-rotation ON,
     with names that are forced to be unique using serial number like 'some.name.prefix-YYYYMMDD-YYYYMMDD-serialnumber',
     thus the pattern "%-[0-9]{8}-[0-9]{8}-%"
-    :param authortiy_ids:
+    :param authority_ids:
+    :param days_since_issuance: If days_since_issuance != -1, include certificates issued in only last
+                                days_since_issuance days
     :return: List of certificates matching criteria
     """
 
     now = arrow.now().format("YYYY-MM-DD")
-    return (
-        Certificate.query.filter(Certificate.authority_id.in_(authortiy_ids))
-        .filter(Certificate.not_after >= now)
-        .filter(Certificate.rotation == true())
-        .filter(not_(Certificate.replaced.any()))
+    query = database.session_query(Certificate)\
+        .filter(Certificate.authority_id.in_(authority_ids))\
+        .filter(Certificate.not_after >= now)\
+        .filter(Certificate.rotation == true())\
+        .filter(not_(Certificate.replaced.any()))\
         .filter(text("name ~ '.*-[0-9]{8}-[0-9]{8}-.*'"))
-        .all()
-    )
+
+    if days_since_issuance != -1:
+        issuance_window = (
+            arrow.now().shift(days=-days_since_issuance).format("YYYY-MM-DD")
+        )
+        query = query.filter(Certificate.date_created >= issuance_window)
+
+    return query.all()
 
 
 def get_certificates_with_same_prefix_with_rotate_on(prefix):


### PR DESCRIPTION
Extending https://github.com/Netflix/lemur/pull/3542 to consider certificates issued in last N days, where N is configured using config `DAYS_SINCE_ISSUANCE_DISABLE_ROTATE_OF_DUPLICATE_CERTIFICATES`. If not configured, this value results in -1 and gets ignored. In that case, the job will run on all valid certificates that satisfy the duplicate check.

Not setting this parameters doesn't cause a harm and thus is optional. By setting this param value to same as the window after which deduplication job runs, one can avoid same cert from going under duplicate checks (this happens only if the cert with serial number is actively used).