### PR TITLE
Add notifications when reissue fails or a cert is reissued with no endpoints

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -329,6 +329,8 @@ Supported types:
 * CA certificate expiration
 * Pending ACME certificate failure
 * Certificate rotation
+* Certificate reissued with no endpoints
+* Certificate reissue failed
 * Security certificate expiration summary
 
 **Default notifications**
@@ -397,6 +399,14 @@ the pending certificate had notifications disabled.
 
 Lemur will attempt 3x times to resolve a pending certificate.
 This can at times result into 3 duplicate certificates, if all certificate attempts get resolved.
+
+**Certificate re-issuance**
+
+When a cert is reissued (i.e. a new certificate is minted to replace it), *and* the re-issuance either fails or
+succeeds but the certificate has no associated endpoints (meaning the subsequent rotation step will not occur),
+Lemur will send a notification via email to the certificate owner. This notification is disabled by default;
+to enable it, you must set the option ``--notify`` (when using cron) or the configuration parameter
+``ENABLE_REISSUE_NOTIFICATION`` (when using celery).
 
 **Certificate rotation**
 

--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -38,7 +38,8 @@ from lemur.deployment import service as deployment_service
 from lemur.domains.models import Domain
 from lemur.endpoints import service as endpoint_service
 from lemur.extensions import metrics
-from lemur.notifications.messaging import send_rotation_notification
+from lemur.notifications.messaging import send_rotation_notification, send_reissue_no_endpoints_notification, \
+    send_reissue_failed_notification
 from lemur.plugins.base import plugins
 
 manager = Manager(usage="Handles all certificate related tasks.")
@@ -139,14 +140,16 @@ def request_rotation(endpoint, certificate, message, commit):
                                                                  "endpoint": str(endpoint.dnsname)})
 
 
-def request_reissue(certificate, commit):
+def request_reissue(certificate, notify, commit):
     """
     Reissuing certificate and handles any exceptions.
     :param certificate:
+    :param notify:
     :param commit:
     :return:
     """
     status = FAILURE_METRIC_STATUS
+    notify = certificate.notify
     try:
         print("[+] {0} is eligible for re-issuance".format(certificate.name))
 
@@ -159,6 +162,8 @@ def request_reissue(certificate, commit):
         if commit:
             new_cert = reissue_certificate(certificate, replace=True)
             print("[+] New certificate named: {0}".format(new_cert.name))
+            if notify and not new_cert.endpoints:
+                send_reissue_no_endpoints_notification(new_cert)
 
         status = SUCCESS_METRIC_STATUS
 
@@ -168,6 +173,8 @@ def request_reissue(certificate, commit):
             f"Error reissuing certificate: {certificate.name}", exc_info=True
         )
         print(f"[!] Failed to reissue certificate: {certificate.name}. Reason: {e}")
+        if notify:
+            send_reissue_failed_notification(certificate)
 
     metrics.send(
         "certificate_reissue",
@@ -474,6 +481,13 @@ def rotate_region(endpoint_name, new_certificate_name, old_certificate_name, mes
     help="Name of the certificate you wish to reissue.",
 )
 @manager.option(
+    "-a",
+    "--notify",
+    dest="message",
+    action="store_true",
+    help="Send a re-issue failed notification to the certificates owner (if re-isuance fails).",
+)
+@manager.option(
     "-c",
     "--commit",
     dest="commit",
@@ -481,7 +495,7 @@ def rotate_region(endpoint_name, new_certificate_name, old_certificate_name, mes
     default=False,
     help="Persist changes.",
 )
-def reissue(old_certificate_name, commit):
+def reissue(old_certificate_name, notify, commit):
     """
     Reissues certificate with the same parameters as it was originally issued with.
     If not time period is provided, reissues certificate as valid from today to
@@ -499,9 +513,9 @@ def reissue(old_certificate_name, commit):
 
         if not old_cert:
             for certificate in get_all_pending_reissue():
-                request_reissue(certificate, commit)
+                request_reissue(certificate, notify, commit)
         else:
-            request_reissue(old_cert, commit)
+            request_reissue(old_cert, notify, commit)
 
         status = SUCCESS_METRIC_STATUS
         print("[+] Done!")

--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -149,7 +149,7 @@ def request_reissue(certificate, notify, commit):
     :return:
     """
     status = FAILURE_METRIC_STATUS
-    notify = certificate.notify
+    notify = notify and certificate.notify
     try:
         print("[+] {0} is eligible for re-issuance".format(certificate.name))
 

--- a/lemur/certificates/schemas.py
+++ b/lemur/certificates/schemas.py
@@ -453,6 +453,9 @@ class CertificateNotificationOutputSchema(LemurOutputSchema):
     replaced_by = fields.Nested(
         CertificateNestedOutputSchema, many=True, attribute="replaced"
     )
+    replaces = fields.Nested(
+        CertificateNestedOutputSchema, many=True, attribute="replaces"
+    )
     endpoints = fields.Nested(EndpointNestedOutputSchema, many=True, missing=[])
 
 

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -619,7 +619,8 @@ def certificate_reissue():
 
     current_app.logger.debug(log_data)
     try:
-        cli_certificate.reissue(None, True)
+        notify = current_app.config.get("ENABLE_REISSUE_NOTIFICATION", None)
+        cli_certificate.reissue(None, notify, True)
     except SoftTimeLimitExceeded:
         log_data["message"] = "Certificate reissue: Time limit exceeded."
         current_app.logger.error(log_data)

--- a/lemur/notifications/messaging.py
+++ b/lemur/notifications/messaging.py
@@ -370,7 +370,20 @@ def send_default_notification(notification_type, data, targets, notification_opt
 
 def send_rotation_notification(certificate):
     data = certificate_notification_output_schema.dump(certificate).data
+    data["security_email"] = current_app.config.get("LEMUR_SECURITY_TEAM_EMAIL")
     return send_default_notification("rotation", data, [data["owner"]])
+
+
+def send_reissue_no_endpoints_notification(new_cert):
+    data = certificate_notification_output_schema.dump(new_cert).data
+    data["security_email"] = current_app.config.get("LEMUR_SECURITY_TEAM_EMAIL")
+    return send_default_notification("reissued_with_no_endpoints", data, [data["owner"]])
+
+
+def send_reissue_failed_notification(certificate):
+    data = certificate_notification_output_schema.dump(certificate).data
+    data["security_email"] = current_app.config.get("LEMUR_SECURITY_TEAM_EMAIL")
+    return send_default_notification("reissue_failed", data, [data["owner"]])
 
 
 def send_pending_failure_notification(

--- a/lemur/notifications/messaging.py
+++ b/lemur/notifications/messaging.py
@@ -377,13 +377,15 @@ def send_rotation_notification(certificate):
 def send_reissue_no_endpoints_notification(new_cert):
     data = certificate_notification_output_schema.dump(new_cert).data
     data["security_email"] = current_app.config.get("LEMUR_SECURITY_TEAM_EMAIL")
-    return send_default_notification("reissued_with_no_endpoints", data, [data["owner"]])
+    email_recipients = [data["owner"]] + data["security_email"]
+    return send_default_notification("reissued_with_no_endpoints", data, email_recipients)
 
 
 def send_reissue_failed_notification(certificate):
     data = certificate_notification_output_schema.dump(certificate).data
     data["security_email"] = current_app.config.get("LEMUR_SECURITY_TEAM_EMAIL")
-    return send_default_notification("reissue_failed", data, [data["owner"]])
+    email_recipients = [data["owner"]] + data["security_email"]
+    return send_default_notification("reissue_failed", data, email_recipients)
 
 
 def send_pending_failure_notification(

--- a/lemur/plugins/lemur_email/templates/reissue_failed.html
+++ b/lemur/plugins/lemur_email/templates/reissue_failed.html
@@ -34,7 +34,7 @@
                     <tr height="16"></tr>
                     <tr>
                         <td>
-                            <table bgcolor="#3681E4" width="100%" border="0" cellspacing="0" cellpadding="0"
+                            <table bgcolor="#F44336" width="100%" border="0" cellspacing="0" cellpadding="0"
                                    style="min-width:332px;max-width:600px;border:1px solid #e0e0e0;border-bottom:0;border-top-left-radius:3px;border-top-right-radius:3px">
                                 <tbody>
                                 <tr>
@@ -43,7 +43,7 @@
                                 <tr>
                                     <td width="32px"></td>
                                     <td style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:24px;color:#ffffff;line-height:1.25">
-                                       Your certificate has been rotated!
+                                        Your certificate has failed to be reissued!
                                     </td>
                                     <td width="32px"></td>
                                 </tr>
@@ -71,7 +71,10 @@
                                             <tr>
                                                 <td style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#202020;line-height:1.5">
                                                     Hi,
-                                                    <br>This is a Lemur certificate rotation notice. Your certificate has been re-issued and re-provisioned.
+                                                    <br>
+                                                    Your certificate has failed to be re-issued. If you still want to
+                                                    use this certificate, you must take manual action to reissue it
+                                                    via the Lemur UI.
                                                 </td>
                                             </tr>
                                             <tr>
@@ -87,6 +90,7 @@
                                                                     <br>
                                                                     <span style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#727272">
                                                                         <br>{{ message.certificates.owner }}
+                                                                        <br>{{ message.certificates.status }}
                                                                         <br>{{ message.certificates.validityEnd | time }}
                                                                         <a href="https://{{ hostname }}/#/certificates/{{ message.certificates.name }}" target="_blank">Details</a>
                                                                     </span>
@@ -97,81 +101,8 @@
                                                 </td>
                                             </tr>
                                             <tr>
-                                                <td style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:15px;color:#202020;line-height:1.5">
-                                                    Replaces:
-                                                </td>
-                                            </tr>
-                                            <tr>
                                                 <td style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#202020;line-height:1.5">
-                                                    <table border="0" cellspacing="0" cellpadding="0"
-                                                           style="margin-top:48px;margin-bottom:48px">
-                                                        <tbody>
-                                                        <tr valign="middle">
-                                                            <td width="32px"></td>
-                                                            <td width="16px"></td>
-                                                            <td style="line-height:1.2">
-                                                                <span style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:20px;color:#202020">{{ message.certificates.replaces[0].name }}</span>
-                                                                <br>
-                                                                <span style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#727272">
-                                                                        <br>{{ message.certificates.replaces[0].owner }}
-                                                                        <br>{{ message.certificates.replaces[0].validityEnd | time }}
-                                                                        <a href="https://{{ hostname }}/#/certificates/{{ message.certificates.replaces[0].name }}" target="_blank">Details</a>
-                                                                    </span>
-                                                            </td>
-                                                        </tr>
-                                                        </tbody>
-                                                    </table>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:15px;color:#202020;line-height:1.5">
-                                                    Endpoints Rotated:
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#202020;line-height:1.5">
-                                                    <table border="0" cellspacing="0" cellpadding="0"
-                                                           style="margin-top:48px;margin-bottom:48px">
-                                                        <tbody>
-                                                        {% if message.certificates.endpoints | length > 0 %}
-                                                            {% for endpoint in message.certificates.endpoints %}
-                                                                <tr valign="middle">
-                                                                    <td width="32px"></td>
-                                                                    <td width="16px"></td>
-                                                                    <td style="line-height:1.2">
-                                                                        <span style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:20px;color:#202020">{{ endpoint.name }}</span>
-                                                                        <br>
-                                                                        <span style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#727272">
-                                                                            <br>{{ endpoint.dnsname }} | {{ endpoint.port }}
-                                                                            <a href="https://{{ hostname }}/#/endpoints/{{ endpoint.name }}"
-                                                                               target="_blank">Details</a>
-                                                                        </span>
-                                                                    </td>
-                                                                </tr>
-                                                                {% if not loop.last %}
-                                                                    <tr valign="middle">
-                                                                        <td width="32px" height="24px"></td>
-                                                                    </tr>
-                                                                {% endif %}
-                                                            {% endfor %}
-                                                        {% else %}
-                                                            <tr valign="middle">
-                                                                <td width="32px"></td>
-                                                                <td width="16px"></td>
-                                                                <td style="line-height:1.2">
-                                                                        <span style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#727272">
-                                                                            No associated endpoints
-                                                                        </span>
-                                                                </td>
-                                                            </tr>
-                                                        {% endif %}
-                                                        </tbody>
-                                                    </table>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#202020;line-height:1.5">
-                                                    If any of the above information looks incorrect, or if the endpoints mentioned are no longer in use please reach out to {{ ", ".join(message.certificates.security_email) }}.</span>
+                                                    If you are having any trouble, please reach out to {{ ", ".join(message.certificates.security_email) }}.</span>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -217,7 +148,7 @@
                                 </tr>
                                 <tr>
                                     <td>
-                                        <div style="direction:ltr;text-align:left">© 2016 <span class="il">Lemur</span></div>
+                                        <div style="direction:ltr;text-align:left">© 2021 <span class="il">Lemur</span></div>
                                     </td>
                                 </tr>
                                 </tbody>

--- a/lemur/plugins/lemur_email/templates/reissued_with_no_endpoints.html
+++ b/lemur/plugins/lemur_email/templates/reissued_with_no_endpoints.html
@@ -34,7 +34,7 @@
                     <tr height="16"></tr>
                     <tr>
                         <td>
-                            <table bgcolor="#3681E4" width="100%" border="0" cellspacing="0" cellpadding="0"
+                            <table bgcolor="#F44336" width="100%" border="0" cellspacing="0" cellpadding="0"
                                    style="min-width:332px;max-width:600px;border:1px solid #e0e0e0;border-bottom:0;border-top-left-radius:3px;border-top-right-radius:3px">
                                 <tbody>
                                 <tr>
@@ -43,7 +43,7 @@
                                 <tr>
                                     <td width="32px"></td>
                                     <td style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:24px;color:#ffffff;line-height:1.25">
-                                       Your certificate has been rotated!
+                                        Your certificate requires manual action!
                                     </td>
                                     <td width="32px"></td>
                                 </tr>
@@ -71,7 +71,12 @@
                                             <tr>
                                                 <td style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#202020;line-height:1.5">
                                                     Hi,
-                                                    <br>This is a Lemur certificate rotation notice. Your certificate has been re-issued and re-provisioned.
+                                                    <br>
+                                                    Your certificate has been re-issued, but no endpoints are associated
+                                                    with it. If you'd like this newly re-issued certificate to be used,
+                                                    you must take manual action to update it. If you no longer need
+                                                    this certificate, please disable auto-rotation for it in the
+                                                    Lemur UI.
                                                 </td>
                                             </tr>
                                             <tr>
@@ -87,6 +92,7 @@
                                                                     <br>
                                                                     <span style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#727272">
                                                                         <br>{{ message.certificates.owner }}
+                                                                        <br>{{ message.certificates.status }}
                                                                         <br>{{ message.certificates.validityEnd | time }}
                                                                         <a href="https://{{ hostname }}/#/certificates/{{ message.certificates.name }}" target="_blank">Details</a>
                                                                     </span>
@@ -124,54 +130,8 @@
                                                 </td>
                                             </tr>
                                             <tr>
-                                                <td style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:15px;color:#202020;line-height:1.5">
-                                                    Endpoints Rotated:
-                                                </td>
-                                            </tr>
-                                            <tr>
                                                 <td style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#202020;line-height:1.5">
-                                                    <table border="0" cellspacing="0" cellpadding="0"
-                                                           style="margin-top:48px;margin-bottom:48px">
-                                                        <tbody>
-                                                        {% if message.certificates.endpoints | length > 0 %}
-                                                            {% for endpoint in message.certificates.endpoints %}
-                                                                <tr valign="middle">
-                                                                    <td width="32px"></td>
-                                                                    <td width="16px"></td>
-                                                                    <td style="line-height:1.2">
-                                                                        <span style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:20px;color:#202020">{{ endpoint.name }}</span>
-                                                                        <br>
-                                                                        <span style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#727272">
-                                                                            <br>{{ endpoint.dnsname }} | {{ endpoint.port }}
-                                                                            <a href="https://{{ hostname }}/#/endpoints/{{ endpoint.name }}"
-                                                                               target="_blank">Details</a>
-                                                                        </span>
-                                                                    </td>
-                                                                </tr>
-                                                                {% if not loop.last %}
-                                                                    <tr valign="middle">
-                                                                        <td width="32px" height="24px"></td>
-                                                                    </tr>
-                                                                {% endif %}
-                                                            {% endfor %}
-                                                        {% else %}
-                                                            <tr valign="middle">
-                                                                <td width="32px"></td>
-                                                                <td width="16px"></td>
-                                                                <td style="line-height:1.2">
-                                                                        <span style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#727272">
-                                                                            No associated endpoints
-                                                                        </span>
-                                                                </td>
-                                                            </tr>
-                                                        {% endif %}
-                                                        </tbody>
-                                                    </table>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#202020;line-height:1.5">
-                                                    If any of the above information looks incorrect, or if the endpoints mentioned are no longer in use please reach out to {{ ", ".join(message.certificates.security_email) }}.</span>
+                                                    If you are having any trouble, please reach out to {{ ", ".join(message.certificates.security_email) }}.</span>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -217,7 +177,7 @@
                                 </tr>
                                 <tr>
                                     <td>
-                                        <div style="direction:ltr;text-align:left">© 2016 <span class="il">Lemur</span></div>
+                                        <div style="direction:ltr;text-align:left">© 2021 <span class="il">Lemur</span></div>
                                     </td>
                                 </tr>
                                 </tbody>

--- a/lemur/plugins/lemur_email/tests/test_email.py
+++ b/lemur/plugins/lemur_email/tests/test_email.py
@@ -7,7 +7,7 @@ from moto import mock_ses
 
 from lemur.certificates.schemas import certificate_notification_output_schema
 from lemur.plugins.lemur_email.plugin import render_html
-from lemur.tests.factories import CertificateFactory
+from lemur.tests.factories import CertificateFactory, EndpointFactory
 from lemur.tests.test_messaging import verify_sender_email, create_cert_that_expires_in_days
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
@@ -29,9 +29,23 @@ def test_render_expiration(certificate, endpoint):
 
 
 def test_render_rotation(certificate, endpoint):
-    certificate.endpoints.append(endpoint)
+    new_cert = CertificateFactory()
+    new_cert.replaces.append(certificate)
+    new_cert.endpoints.append(endpoint)
 
-    assert render_html("rotation", get_options(), certificate_notification_output_schema.dump(certificate).data)
+    assert render_html("rotation", get_options(), certificate_notification_output_schema.dump(new_cert).data)
+
+
+def test_render_reissue_failed(certificate):
+    assert render_html("reissue_failed", get_options(), certificate_notification_output_schema.dump(certificate).data)
+
+
+def test_render_reissued_with_no_endpoints(certificate):
+    new_cert = CertificateFactory()
+    new_cert.replaces.append(certificate)
+
+    assert render_html("reissued_with_no_endpoints", get_options(),
+                       certificate_notification_output_schema.dump(new_cert).data)
 
 
 def test_render_rotation_failure(pending_certificate):
@@ -111,16 +125,39 @@ def test_send_expiration_notification_disabled():
 
 
 @mock_ses
-def test_send_rotation_notification(endpoint, source_plugin):
+def test_send_rotation_notification(certificate, endpoint, source_plugin):
     from lemur.notifications.messaging import send_rotation_notification
     from lemur.deployment.service import rotate_certificate
 
     new_certificate = CertificateFactory()
     rotate_certificate(endpoint, new_certificate)
+    new_certificate.replaces.append(certificate)
     assert endpoint.certificate == new_certificate
 
     verify_sender_email()
     assert send_rotation_notification(new_certificate)
+    new_certificate.endpoints = [EndpointFactory()]
+    assert send_rotation_notification(new_certificate)
+
+
+@mock_ses
+def test_send_reissue_failed_notification(certificate):
+    from lemur.notifications.messaging import send_reissue_failed_notification
+
+    verify_sender_email()
+    certificate.endpoints = [EndpointFactory()]
+    assert send_reissue_failed_notification(certificate)
+
+
+@mock_ses
+def test_send_reissue_no_endpoints_notification(certificate):
+    from lemur.notifications.messaging import send_reissue_no_endpoints_notification
+
+    verify_sender_email()
+    new_certificate = CertificateFactory()
+    new_certificate.replaces.append(certificate)
+    verify_sender_email()
+    assert send_reissue_no_endpoints_notification(new_certificate)
 
 
 @mock_ses

--- a/lemur/tests/test_messaging.py
+++ b/lemur/tests/test_messaging.py
@@ -183,7 +183,29 @@ def test_send_rotation_notification(notification_plugin, certificate):
     from lemur.notifications.messaging import send_rotation_notification
     verify_sender_email()
 
-    assert send_rotation_notification(certificate)
+    new_cert = CertificateFactory()
+    new_cert.replaces.append(certificate)
+    assert send_rotation_notification(new_cert)
+    new_cert.endpoints = [EndpointFactory()]
+    assert send_rotation_notification(new_cert)
+
+
+@mock_ses
+def test_send_reissue_no_endpoints_notification(notification_plugin, certificate):
+    from lemur.notifications.messaging import send_reissue_no_endpoints_notification
+    verify_sender_email()
+
+    new_cert = CertificateFactory()
+    new_cert.replaces.append(certificate)
+    assert send_reissue_no_endpoints_notification(new_cert)
+
+
+@mock_ses
+def test_send_reissue_failed_notification(notification_plugin, certificate):
+    from lemur.notifications.messaging import send_reissue_failed_notification
+    verify_sender_email()
+
+    assert send_reissue_failed_notification(certificate)
 
 
 @mock_ses

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -164,7 +164,7 @@ ecdsa==0.14.1
     #   sshpubkeys
 factory-boy==3.2.0
     # via -r requirements-tests.txt
-faker==8.1.3
+faker==8.1.4
     # via
     #   -r requirements-tests.txt
     #   factory-boy

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -72,7 +72,7 @@ ecdsa==0.14.1
     #   sshpubkeys
 factory-boy==3.2.0
     # via -r requirements-tests.in
-faker==8.1.3
+faker==8.1.4
     # via
     #   -r requirements-tests.in
     #   factory-boy


### PR DESCRIPTION
Adds two new notification types:
* When a certificate fails to be re-issued
* When a certificate is successfully re-issued, but has no associated endpoints

Both types are (currently) sent exclusively to the certificate owner and security team.