### PR TITLE
Set default value for AcmeDnsChallenge.cleanup()'s unused validation_target parameter

### DIFF
--- a/lemur/plugins/lemur_acme/challenge_types.py
+++ b/lemur/plugins/lemur_acme/challenge_types.py
@@ -249,7 +249,7 @@ class AcmeDnsChallenge(AcmeChallenge):
     def deploy(self, challenge, acme_client, validation_target):
         pass
 
-    def cleanup(self, authorizations, acme_client, validation_target):
+    def cleanup(self, authorizations, acme_client, validation_target=None):
         """
         Best effort attempt to delete DNS challenges that may not have been deleted previously. This is usually called
         on an exception


### PR DESCRIPTION
The function is called from [lemur/plugins/lemur_acme/plugin.py#L229](https://github.com/Netflix/lemur/blob/ace7a1d52460e1e96f04327a59e576939636684c/lemur/plugins/lemur_acme/plugin.py#L229) with only two arguments, which results in a `TypeError` exception when the statement is executed.

Alternatively, the unused `validation_target` parameter could be removed altogether.