### PR TITLE
Add revocation notification

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -331,6 +331,7 @@ Supported types:
 * Certificate rotation
 * Certificate reissued with no endpoints
 * Certificate reissue failed
+* Certificate revocation
 * Security certificate expiration summary
 
 **Default notifications**
@@ -440,6 +441,11 @@ to enable it, you must set the option ``--notify`` (when using cron) or the conf
 Whenever a cert is rotated, Lemur will send a notification via email to the certificate owner. This notification is
 disabled by default; to enable it, you must set the option ``--notify`` (when using cron) or the configuration parameter
 ``ENABLE_ROTATION_NOTIFICATION`` (when using celery).
+
+**Certificate revocation**
+
+Whenever a cert is revoked, Lemur will send a notification via email to the certificate owner. This notification will
+only be sent if the certificate's "notify" option is enabled.
 
 **Security certificate expiration summary**
 

--- a/lemur/notifications/cli.py
+++ b/lemur/notifications/cli.py
@@ -8,6 +8,7 @@
 from flask_script import Manager
 from sentry_sdk import capture_exception
 
+from lemur.certificates.service import get_expiring_deployed_certificates
 from lemur.constants import SUCCESS_METRIC_STATUS, FAILURE_METRIC_STATUS
 from lemur.extensions import metrics
 from lemur.notifications.messaging import send_expiration_notifications, \
@@ -111,13 +112,15 @@ def security_expiration_summary(exclude):
 
 def notify_expiring_deployed_certificates(exclude):
     """
-    Attempt to find any certificates that are expiring soon but are still deployed,
-    and notify the certificate owner.
+    Attempt to find any certificates that are expiring soon but are still deployed, and notify the certificate owner.
+    This information is retrieved from the database, and is based on the previous run of
+    identity_expiring_deployed_certificates.
     """
     status = FAILURE_METRIC_STATUS
     try:
         print("Starting to notify owners about certificates that are expiring but still deployed!")
-        success = send_expiring_deployed_certificate_notifications(exclude)
+        certificates = get_expiring_deployed_certificates(exclude).items()
+        success = send_expiring_deployed_certificate_notifications(certificates)
         print(
             f"Finished notifying owners about certificates that are expiring but still deployed! Success: {success}"
         )

--- a/lemur/notifications/messaging.py
+++ b/lemur/notifications/messaging.py
@@ -23,7 +23,6 @@ from lemur import database
 from lemur.certificates import service as certificates_service
 from lemur.certificates.models import Certificate
 from lemur.certificates.schemas import certificate_notification_output_schema
-from lemur.certificates.service import get_expiring_deployed_certificates
 from lemur.common.utils import windowed_query, is_selfsigned
 from lemur.constants import FAILURE_METRIC_STATUS, SUCCESS_METRIC_STATUS
 from lemur.extensions import metrics
@@ -505,17 +504,16 @@ def send_security_expiration_summary(exclude=None):
         return True
 
 
-def send_expiring_deployed_certificate_notifications(exclude):
+def send_expiring_deployed_certificate_notifications(certificates):
     """
-    This function will check for certs that are expiring soon and are still deployed. This information is retrieved
-    from the database, and is based on the previous run of identity_expiring_deployed_certificates.
-    It will send an email to the owner of any matching certificates.
+    Send an email to the owner of all provided certificates indicating that the certs are still deployed
+    but expiring soon.
     """
     success = failure = 0
     notification_type = "expiring_deployed_certificate"
     security_email = current_app.config.get("LEMUR_SECURITY_TEAM_EMAIL")
 
-    for owner, owner_certs in get_expiring_deployed_certificates(exclude).items():
+    for owner, owner_certs in certificates:
         notification_data = []
         # eventually we also want to use the options configured on the cert's notification(s) to notify the owner
         # for now, we'll just email the security team

--- a/lemur/notifications/messaging.py
+++ b/lemur/notifications/messaging.py
@@ -368,6 +368,12 @@ def send_default_notification(notification_type, data, targets, notification_opt
         return True
 
 
+def send_revocation_notification(certificate):
+    data = certificate_notification_output_schema.dump(certificate).data
+    data["security_email"] = current_app.config.get("LEMUR_SECURITY_TEAM_EMAIL")
+    return send_default_notification("revocation", data, [data["owner"]])
+
+
 def send_rotation_notification(certificate):
     data = certificate_notification_output_schema.dump(certificate).data
     data["security_email"] = current_app.config.get("LEMUR_SECURITY_TEAM_EMAIL")

--- a/lemur/plugins/lemur_email/templates/revocation.html
+++ b/lemur/plugins/lemur_email/templates/revocation.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+        "http://www.w3.org/TR/html4/loose.dtd">
+<html lang="en">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="initial-scale=1.0">    <!-- So that mobile webkit will display zoomed in -->
+    <meta name="format-detection" content="telephone=no"> <!-- disable auto telephone linking in iOS -->
+
+    <title>Lemur</title>
+</head>
+
+<div style="margin:0;padding:0" bgcolor="#FFFFFF">
+    <table width="100%" height="100%" style="min-width:348px" border="0" cellspacing="0" cellpadding="0">
+        <tbody>
+        <tr height="32px"></tr>
+        <tr align="center">
+            <td width="32px"></td>
+            <td>
+                <table border="0" cellspacing="0" cellpadding="0" style="max-width:600px">
+                    <tbody>
+                    <tr>
+                        <td>
+                            <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                                <tbody>
+                                <tr>
+                                    <td align="left" style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:35px;color:#727272; line-height:1.5">
+                                        Lemur
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </td>
+                    </tr>
+                    <tr height="16"></tr>
+                    <tr>
+                        <td>
+                            <table bgcolor="#F44336" width="100%" border="0" cellspacing="0" cellpadding="0"
+                                   style="min-width:332px;max-width:600px;border:1px solid #e0e0e0;border-bottom:0;border-top-left-radius:3px;border-top-right-radius:3px">
+                                <tbody>
+                                <tr>
+                                    <td height="72px" colspan="3"></td>
+                                </tr>
+                                <tr>
+                                    <td width="32px"></td>
+                                    <td style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:24px;color:#ffffff;line-height:1.25">
+                                       Your certificate has been revoked!
+                                    </td>
+                                    <td width="32px"></td>
+                                </tr>
+                                <tr>
+                                    <td height="18px" colspan="3"></td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <table width="100%" border="0" cellspacing="0" cellpadding="0"
+                                   style="min-width:332px;max-width:600px;border:1px solid #f0f0f0;border-bottom:1px solid #c0c0c0;border-top:0;border-bottom-left-radius:3px;border-bottom-right-radius:3px">
+                                <tbody>
+                                <tr height="16px">
+                                    <td width="32px" rowspan="3"></td>
+                                    <td></td>
+                                    <td width="32px" rowspan="3"></td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <table style="min-width:300px" border="0" cellspacing="0" cellpadding="0">
+                                            <tbody>
+                                            <tr>
+                                                <td style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#202020;line-height:1.5">
+                                                    Hi,
+                                                    <br>The following Lemur certificate has been revoked.
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#202020;line-height:1.5">
+                                                    <table border="0" cellspacing="0" cellpadding="0"
+                                                           style="margin-top:48px;margin-bottom:48px">
+                                                        <tbody>
+                                                            <tr valign="middle">
+                                                                <td width="32px"></td>
+                                                                <td width="16px"></td>
+                                                                <td style="line-height:1.2">
+                                                                    <span style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:20px;color:#202020">{{ message.certificates.name }}</span>
+                                                                    <span style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#727272">
+                                                                        <br>{{ message.certificates.endpoints | length }} Endpoints
+                                                                        <br>{{ message.certificates.owner }}
+                                                                        <br>{{ message.certificates.validityEnd | time }}
+                                                                        <br>{{ message.certificates.status }}
+                                                                        <br><a href="https://{{ hostname }}/#/certificates/{{ message.certificates.name }}" target="_blank">Details</a>
+                                                                    </span>
+                                                                </td>
+                                                            </tr>
+                                                        </tbody>
+                                                    </table>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#202020;line-height:1.5">
+                                                    If this revocation was unexpected, please reach out to {{ ", ".join(message.certificates.security_email) }}.
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                            </tr>
+                                            <tr>
+                                                <td style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:13px;color:#202020;line-height:1.5">
+                                                    <br>Best,<br><span class="il">Lemur</span>
+                                                </td>
+                                            </tr>
+                                            <tr height="16px"></tr>
+                                            <tr>
+                                                <td>
+                                                    <table style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:12px;color:#b9b9b9;line-height:1.5">
+                                                        <tbody>
+                                                        <tr>
+                                                            <td>*All times are in UTC<br></td>
+                                                        </tr>
+                                                        </tbody>
+                                                    </table>
+                                                </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                                <tr height="32px"></tr>
+                                </tbody>
+                            </table>
+                        </td>
+                    </tr>
+                    <tr height="16"></tr>
+                    <tr>
+                        <td style="max-width:600px;font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:10px;color:#bcbcbc;line-height:1.5"></td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <table style="font-family:Roboto-Regular,Helvetica,Arial,sans-serif;font-size:10px;color:#666666;line-height:18px;padding-bottom:10px">
+                                <tbody>
+                                <tr>
+                                    <td>You received this mandatory email announcement to update you about
+                                        important changes to your <span class="il">TLS certificate</span>.
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <div style="direction:ltr;text-align:left">© 2016 <span class="il">Lemur</span></div>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </td>
+            <td width="32px"></td>
+        </tr>
+        <tr height="32px"></tr>
+        </tbody>
+    </table>
+</div>

--- a/lemur/plugins/lemur_email/tests/test_email.py
+++ b/lemur/plugins/lemur_email/tests/test_email.py
@@ -28,6 +28,12 @@ def test_render_expiration(certificate, endpoint):
     assert render_html("expiration", get_options(), [certificate_notification_output_schema.dump(certificate).data])
 
 
+def test_render_revocation(certificate, endpoint):
+    certificate.endpoints.append(endpoint)
+
+    assert render_html("revocation", get_options(), certificate_notification_output_schema.dump(certificate).data)
+
+
 def test_render_rotation(certificate, endpoint):
     new_cert = CertificateFactory()
     new_cert.replaces.append(certificate)
@@ -122,6 +128,15 @@ def test_send_expiration_notification_disabled():
 
     verify_sender_email()
     assert send_expiration_notifications([], ['email-notification']) == (0, 0)
+
+
+@mock_ses
+def test_send_revocation_notification(certificate, endpoint):
+    from lemur.notifications.messaging import send_revocation_notification
+
+    verify_sender_email()
+    certificate.endpoints = [endpoint]
+    assert send_revocation_notification(certificate)
 
 
 @mock_ses

--- a/lemur/tests/test_messaging.py
+++ b/lemur/tests/test_messaging.py
@@ -6,6 +6,7 @@ import pytest
 from freezegun import freeze_time
 from moto import mock_ses
 
+from lemur.certificates.service import get_expiring_deployed_certificates
 from lemur.tests.factories import AuthorityFactory, CertificateFactory, EndpointFactory
 
 
@@ -273,7 +274,8 @@ def test_send_expiring_deployed_certificate_notifications():
     cert_4 = create_cert_that_expires_in_days(10, domains=[Domain(name='domain1.com')], owner='testowner3@example.com')
     cert_4.certificate_associations[0].ports = []
 
-    assert send_expiring_deployed_certificate_notifications(None) == (3, 0)  # 3 certs with ports
+    certificates = get_expiring_deployed_certificates([]).items()
+    assert send_expiring_deployed_certificate_notifications(certificates) == (3, 0)  # 3 certs with ports
 
 
 def create_ca_cert_that_expires_in_days(days):

--- a/lemur/tests/test_messaging.py
+++ b/lemur/tests/test_messaging.py
@@ -179,6 +179,15 @@ def test_send_expiration_summary_notification(certificate, notification, notific
 
 
 @mock_ses
+def test_send_evocation_notification(notification_plugin, certificate):
+    from lemur.notifications.messaging import send_revocation_notification
+    verify_sender_email()
+
+    certificate.endpoints = [EndpointFactory()]
+    assert send_revocation_notification(certificate)
+
+
+@mock_ses
 def test_send_rotation_notification(notification_plugin, certificate):
     from lemur.notifications.messaging import send_rotation_notification
     verify_sender_email()


### PR DESCRIPTION
I was originally planning to wait to add this until more of the notification refactoring I'm planning was done, but at this point it makes sense to add this type alongside the other two re-issue notifications I just added. As with the last ones, these will only be sent to the certificate owner and security team.