### PR TITLE
Surround reissue/revoke notifications with try

### DIFF
--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -165,12 +165,11 @@ def request_reissue(certificate, notify, commit):
             print("[+] New certificate named: {0}".format(new_cert.name))
             try:
                 # the notifications should not be able to cause this to fail, so surround with a try
-                if notify and not new_cert.endpoints:
+                if isinstance(new_cert, Certificate) and notify and not new_cert.endpoints:
                     send_reissue_no_endpoints_notification(new_cert)
             except Exception:
                 current_app.logger.warn(
-                    f"Error sending reissue notification for certificate: {certificate.name}. This is not a problem if"
-                    f"this is a PendingCertificate, as PendingCertificates have no endpoints.", exc_info=True
+                    f"Error sending reissue notification for certificate: {certificate.name}", exc_info=True
                 )
 
         status = SUCCESS_METRIC_STATUS

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -925,8 +925,14 @@ def cleanup_after_revoke(certificate):
     :param certificate: Certificate object to modify and update in DB
     :return: None
     """
-    if certificate.notify:
-        send_revocation_notification(certificate)
+    try:
+        if certificate.notify:
+            send_revocation_notification(certificate)
+    except Exception:
+        capture_exception()
+        current_app.logger.warn(
+            f"Error sending revocation notification for certificate: {certificate.name}", exc_info=True
+        )
 
     certificate.notify = False
     certificate.rotation = False


### PR DESCRIPTION
Fix possible errors caused by problems sending reissue and revoke notifications. Notifications should not cause the main reissue/revoke process to fail.