### PR TITLE
Improving robustness of Check revoke 

### DIFF
--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -699,8 +699,13 @@ def check_revoked():
             # this must be tha last page
             there_are_still_certs = False
         else:
-            page = page + 1
-
+            metrics.send(
+                "certificate_revoked_progress",
+                "counter",
+                1,
+                metric_tags={"page":page}
+            )
+            page += 1
 
         for cert in certs:
             try:

--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -755,7 +755,7 @@ def check_revoked():
     metrics.send(
         "certificate_revoked_checked",
         "gauge",
-        page * count + len(certs),
+        (page - 1) * count + len(certs),
     )
 
 

--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -697,7 +697,7 @@ def check_revoked():
             # this must be tha last page
             there_are_still_certs = False
         else:
-            page =+ 1
+            page = page + 1
 
 
         for cert in certs:

--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -687,37 +687,48 @@ def check_revoked():
         "function": f"{__name__}.{sys._getframe().f_code.co_name}",
         "message": "Checking for revoked Certificates"
     }
+    there_are_still_certs = True
+    page=1
+    count=1000
+    while there_are_still_certs:
+        certs = get_all_valid_certs(current_app.config.get("SUPPORTED_REVOCATION_AUTHORITY_PLUGINS", []),
+                                    paginate=True, page=page, count=count)
+        if len(certs) < count:
+            # this must be tha last page
+            there_are_still_certs = False
+        else:
+            page =+ 1
 
-    certs = get_all_valid_certs(current_app.config.get("SUPPORTED_REVOCATION_AUTHORITY_PLUGINS", []))
-    for cert in certs:
-        try:
-            if cert.chain:
-                status = verify_string(cert.body, cert.chain)
-            else:
-                status = verify_string(cert.body, "")
 
-            cert.status = "valid" if status else "revoked"
+        for cert in certs:
+            try:
+                if cert.chain:
+                    status = verify_string(cert.body, cert.chain)
+                else:
+                    status = verify_string(cert.body, "")
 
-            if cert.status == "revoked":
-                log_data["valid"] = cert.status
-                log_data["certificate_name"] = cert.name
-                log_data["certificate_id"] = cert.id
-                metrics.send(
-                    "certificate_revoked",
-                    "counter",
-                    1,
-                    metric_tags={"status": log_data["valid"],
+                cert.status = "valid" if status else "revoked"
+
+                if cert.status == "revoked":
+                    log_data["valid"] = cert.status
+                    log_data["certificate_name"] = cert.name
+                    log_data["certificate_id"] = cert.id
+                    metrics.send(
+                        "certificate_revoked",
+                        "counter",
+                        1,
+                        metric_tags={"status": log_data["valid"],
                                  "certificate_name": log_data["certificate_name"],
                                  "certificate_id": log_data["certificate_id"]},
-                )
-                current_app.logger.info(log_data)
+                    )
+                    current_app.logger.info(log_data)
 
-        except Exception as e:
-            capture_exception()
-            current_app.logger.exception(e)
-            cert.status = "unknown"
+            except Exception as e:
+                capture_exception()
+                current_app.logger.exception(e)
+                cert.status = "unknown"
 
-        database.update(cert)
+            database.update(cert)
 
 
 @manager.command

--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -688,8 +688,8 @@ def check_revoked():
         "message": "Checking for revoked Certificates"
     }
     there_are_still_certs = True
-    page=1
-    count=1000
+    page = 1
+    count = 1000
     ocsp_err_count = 0
     crl_err_count = 0
     while there_are_still_certs:
@@ -703,7 +703,7 @@ def check_revoked():
                 "certificate_revoked_progress",
                 "counter",
                 1,
-                metric_tags={"page":page}
+                metric_tags={"page": page}
             )
             page += 1
 

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -112,26 +112,35 @@ def get_all_certs():
     return Certificate.query.all()
 
 
-def get_all_valid_certs(authority_plugin_name):
+def get_all_valid_certs(authority_plugin_name, paginate=False, page=1, count=1000):
     """
     Retrieves all valid (not expired & not revoked) certificates within Lemur, for the given authority plugin names
     ignored if no authority_plugin_name provided.
 
     Note that depending on the DB size retrieving all certificates might an expensive operation
+    :param paginate: option to use pagination, for large number of certicicates. default to false
+    :param page: the page to turn. default to 1
+    :param count: number of return certificates per page. default 1000
 
-    :return:
+    :return: list of certificates to check for revocation
     """
+    assert (page > 0)
+    query = database.session_query(Certificate) if paginate else Certificate.query
+
     if authority_plugin_name:
-        return (
-            Certificate.query.outerjoin(Authority, Authority.id == Certificate.authority_id).filter(
-                Certificate.not_after > arrow.now().format("YYYY-MM-DD")).filter(
-                Authority.plugin_name.in_(authority_plugin_name)).filter(Certificate.revoked.is_(False)).all()
-        )
+        query = query.outerjoin(Authority, Authority.id == Certificate.authority_id).filter(
+            Certificate.not_after > arrow.now().format("YYYY-MM-DD")).filter(
+            Authority.plugin_name.in_(authority_plugin_name)).filter(Certificate.revoked.is_(False))
+
     else:
-        return (
-            Certificate.query.filter(Certificate.not_after > arrow.now().format("YYYY-MM-DD")).filter(
-                Certificate.revoked.is_(False)).all()
-        )
+        query = query.filter(Certificate.not_after > arrow.now().format("YYYY-MM-DD")).filter(
+            Certificate.revoked.is_(False))
+
+    if paginate:
+        items = database.paginate(query, page, count)
+        return items['items']
+
+    return query.all()
 
 
 def get_all_pending_cleaning_expired(source):

--- a/lemur/certificates/verify.py
+++ b/lemur/certificates/verify.py
@@ -79,7 +79,7 @@ def ocsp_verify(cert, cert_path, issuer_chain_path):
         return False
 
     elif "unauthorized" in p_message:
-        # indicates the OCSP server does no longer no this certificate
+        # indicates the OCSP server does not know this certificate
         metrics.send("check_revocation_ocsp_verify", "counter", 1, metric_tags={"status": "unauthorized", "url": url})
         current_app.logger.warning(f"OCSP unauthorized error:{url}")
         raise Exception(f"OCSP unauthorized error: {url}")

--- a/lemur/certificates/verify.py
+++ b/lemur/certificates/verify.py
@@ -58,7 +58,7 @@ def ocsp_verify(cert, cert_path, issuer_chain_path):
     )
 
     try:
-        message, err = p2.communicate(timeout=15)
+        message, err = p2.communicate(timeout=6)
     except TimeoutExpired:
         try:
             p2.kill()
@@ -115,7 +115,7 @@ def crl_verify(cert, cert_path):
         if point not in crl_cache:
             current_app.logger.debug("Retrieving CRL: {}".format(point))
             try:
-                response = requests.get(point, timeout=(3.05, 15))
+                response = requests.get(point, timeout=(3.05, 6))
 
                 if response.status_code != 200:
                     raise Exception("Unable to retrieve CRL: {0}".format(point))

--- a/lemur/certificates/verify.py
+++ b/lemur/certificates/verify.py
@@ -61,16 +61,14 @@ def ocsp_verify(cert, cert_path, issuer_chain_path):
         message, err = p2.communicate(timeout=15)
     except TimeoutExpired:
         p2.kill()
-        outs, errs = proc.communicate()
+        p2.communicate()
         return False
-
-
 
     p_message = message.decode("utf-8")
 
     if "error" in p_message or "Error" in p_message:
         metrics.send("check_revocation_ocsp_verify", "counter", 1, metric_tags={"status": "error", "url": url})
-        raise Exception(f"Got error when parsing OCSP url:{url}")
+        raise Exception(f"Got error when parsing OCSP url: {url}")
 
     elif "revoked" in p_message:
         current_app.logger.debug(
@@ -80,12 +78,12 @@ def ocsp_verify(cert, cert_path, issuer_chain_path):
 
     elif "unauthorized" in p_message:
         # indicates the OCSP server does no longer no this certificate
-        metrics.send("check_revocation_ocsp_verify", "counter", 1, metric_tags={"status":"unauthorized", "url": url})
+        metrics.send("check_revocation_ocsp_verify", "counter", 1, metric_tags={"status": "unauthorized", "url": url})
         current_app.logger.warning(f"OCSP unauthorized error:{url}")
-        raise Exception(f"OCSP unauthorized error:{url}")
+        raise Exception(f"OCSP unauthorized error: {url}")
 
     elif "good" not in p_message:
-        raise Exception(f"Did not receive a valid OCSP response from url:{url}")
+        raise Exception(f"Did not receive a valid OCSP response from url: {url}")
 
     return True
 

--- a/lemur/certificates/verify.py
+++ b/lemur/certificates/verify.py
@@ -174,14 +174,14 @@ def verify(cert_path, issuer_chain_path):
         verify_result = ocsp_verify(cert, cert_path, issuer_chain_path)
     except Exception as e:
         capture_exception()
-        current_app.logger.exception(e)
+        current_app.logger.warning(e)
 
     if verify_result is None:
         try:
             verify_result = crl_verify(cert, cert_path)
         except Exception as e:
             capture_exception()
-            current_app.logger.exception(e)
+            current_app.logger.warning(e)
 
     if verify_result is None:
         current_app.logger.debug("Failed to verify {}".format(cert.serial_number))

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -751,7 +751,7 @@ def get_all_zones():
     return log_data
 
 
-@celery.task(soft_time_limit=3600)
+@celery.task(soft_time_limit=7200)
 def check_revoked():
     """
     This celery task attempts to check if any certs are expired

--- a/lemur/tests/test_verify.py
+++ b/lemur/tests/test_verify.py
@@ -13,7 +13,8 @@ from .vectors import INTERMEDIATE_CERT_STR
 def test_verify_simple_cert():
     """Simple certificate without CRL or OCSP."""
     # Verification returns None if there are no means to verify a cert
-    assert verify_string(INTERMEDIATE_CERT_STR, "") is None
+    res, ocsp_err, crl_err = verify_string(INTERMEDIATE_CERT_STR, "")
+    assert res is None
 
 
 def test_verify_crl_unknown_scheme(cert_builder, private_key):


### PR DESCRIPTION
- adding timeouts to prevent the OCSP and curl lookups from hanging
- adding pagination for the query, to improve DB query performance
- adding metric to monitor OCSP failures (`unauthorized`)
- adding better logging about the progress of job
- adding a final report on OCSP/CRL failures