### PR TITLE
put runtime oauth secret in flask session

### DIFF
--- a/lemur/tests/test_oauth.py
+++ b/lemur/tests/test_oauth.py
@@ -1,8 +1,10 @@
 from datetime import datetime, timedelta
 from freezegun import freeze_time
 
+from flask import current_app
+
 from lemur.auth.views import *  # noqa
-from lemur.tests.conf import OAUTH_STATE_TOKEN_STALE_TOLERANCE_SECONDS
+from lemur.tests.conf import OAUTH_STATE_TOKEN_STALE_TOLERANCE_SECONDS, OAUTH_STATE_TOKEN_SECRET
 
 
 def test_build_hmac(client):
@@ -10,6 +12,12 @@ def test_build_hmac(client):
 
     assert isinstance(build_hmac(), hmac.HMAC)
 
+    # make a bad key
+    current_app.config["OAUTH_STATE_TOKEN_SECRET"] = 'not-bytes-like'
+    assert not build_hmac()
+
+    # put back a good key, for remaining tests
+    current_app.config["OAUTH_STATE_TOKEN_SECRET"] = OAUTH_STATE_TOKEN_SECRET
 
 def test_generate_state_token(client):
     from lemur.auth.views import generate_state_token
@@ -32,3 +40,8 @@ def test_verify_state_token(client):
     assert not verify_state_token('123456::f4k8')
     assert not verify_state_token('123456f4k8')
     assert not verify_state_token('')
+
+    # force a new key to get generated and stored at runtime
+    current_app.config["OAUTH_STATE_TOKEN_SECRET"] = None
+    token_via_runtime_key = generate_state_token()
+    assert verify_state_token(token_via_runtime_key)

--- a/lemur/tests/test_oauth.py
+++ b/lemur/tests/test_oauth.py
@@ -19,6 +19,7 @@ def test_build_hmac(client):
     # put back a good key, for remaining tests
     current_app.config["OAUTH_STATE_TOKEN_SECRET"] = OAUTH_STATE_TOKEN_SECRET
 
+
 def test_generate_state_token(client):
     from lemur.auth.views import generate_state_token
 


### PR DESCRIPTION
I realized that in #3573, I inadvertently introduced a bug in the event that a state token secret must be generated at runtime: it's not stored in the Flask session, so subsequent use wouldn't work. 

In this PR, I write the runtime-made key into the Flask session explicitly, and add new tests for it. I also added an exception catch + test for `build_hmac()` in the case where the key set by the user isn't bytes-like, which is required.