### PR TITLE
update postgres instance auth during builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,10 @@ before_script:
   # the port may have been auto-configured to use 5433 if it thought 5422 was already in use,
   # for some reason it happens very often
   # https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/bash/travis_setup_postgresql.bash#L52
+  # Addressing (psql: error: FATAL:  Peer authentication failed for user "postgres") with trusted auth mode
+  # https://github.com/travis-ci/travis-ci/issues/9624#issuecomment-389537036
   - sudo sed -i -e 's/5433/5432/' /etc/postgresql/*/main/postgresql.conf
+  - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/*/main/pg_hba.conf
   - sudo systemctl restart postgresql
   - psql -c "create database lemur;" -U postgres
   - psql -c "create user lemur with password 'lemur;'" -U postgres


### PR DESCRIPTION
Confession: I haven't used Travis at all in my deployment of Lemur, but I've noticed that we frequently get errors [like this](https://travis-ci.com/github/Netflix/lemur/jobs/507811498) for the `python3.7-postgresql-12-bionic` builds:

```
psql: error: FATAL:  Peer authentication failed for user "postgres"
The command "psql -c "create database lemur;" -U postgres" failed and exited with 2 during .
```

It seems to only affect Postgres 12?

I have no idea if [this suggested fix](https://github.com/travis-ci/travis-ci/issues/9624#issuecomment-389537036) will work or not, but I figured I could make a PR to see what happens when we try changing local Postgres auth to `trusted` mode 🤷 