### PR TITLE
Fix timeout for deployed cert check

### DIFF
--- a/lemur/common/utils.py
+++ b/lemur/common/utils.py
@@ -428,7 +428,9 @@ def get_certificate_via_tls(host, port, timeout=10):
     context = ssl.create_default_context()
     context.check_hostname = False  # we don't care about validating the cert
     context.verify_mode = ssl.CERT_NONE  # we don't care about validating the cert; it may be self-signed
-    conn = socket.create_connection((host, port), timeout=timeout)
+    conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    conn.settimeout(timeout)
+    conn.connect((host, port))
     sock = context.wrap_socket(conn, server_hostname=host)
     sock.settimeout(timeout)
     try:


### PR DESCRIPTION
Fixes timeout. A portion of the `create_connection` call doesn't actually seem to honor the timeout passed in; doing it this way does actually seem to enforce the timeout as intended.

I haven't found any good documentation on why this is the case. I have a test running locally that indicates the behavior was wrong and is now correct, but I can't run it with the embedded localhost server as the timeout doesn't seem to be an issue on localhost.