### PR TITLE
Add LEMUR_REISSUE_NOTIFICATION_EXCLUDED_DESTINATIONS

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -603,6 +603,16 @@ The following configuration options are supported:
           LEMUR_DEPLOYED_CERTIFICATE_CHECK_EXCLUDED_DOMAINS = ['excluded.com']
 
 
+.. data:: LEMUR_REISSUE_NOTIFICATION_EXCLUDED_DESTINATIONS
+    :noindex:
+
+       Specifies a set of destination labels to exclude from the reissued with endpoint notification checks. If a certificate is reissued without endpoints, but any of its destination labels are specified in this list, no "reissued without endpoints" notification will be sent.
+
+       ::
+
+          LEMUR_REISSUE_NOTIFICATION_EXCLUDED_DESTINATIONS = ['excluded-destination']
+
+
 Celery Options
 ---------------
 To make use of automated tasks within lemur (e.g. syncing source/destinations, or reissuing ACME certificates), you

--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -163,16 +163,8 @@ def request_reissue(certificate, notify, commit):
         if commit:
             new_cert = reissue_certificate(certificate, replace=True)
             print("[+] New certificate named: {0}".format(new_cert.name))
-            try:
-                # The notifications should not be able to cause this to fail, so surround with a try.
-                # Endpoints get moved from old to new cert during rotation, so the new cert won't have endpoints yet;
-                # instead, we have to check the old cert for endpoints.
-                if notify and not certificate.endpoints:
-                    send_reissue_no_endpoints_notification(new_cert)
-            except Exception:
-                current_app.logger.warn(
-                    f"Error sending reissue notification for certificate: {certificate.name}", exc_info=True
-                )
+            if notify:
+                send_reissue_no_endpoints_notification(certificate, new_cert)
 
         status = SUCCESS_METRIC_STATUS
 
@@ -183,12 +175,7 @@ def request_reissue(certificate, notify, commit):
         )
         print(f"[!] Failed to reissue certificate: {certificate.name}. Reason: {e}")
         if notify:
-            try:
-                send_reissue_failed_notification(certificate)
-            except Exception:
-                current_app.logger.warn(
-                    f"Error sending reissue failed notification for certificate: {certificate.name}", exc_info=True
-                )
+            send_reissue_failed_notification(certificate)
 
     metrics.send(
         "certificate_reissue",

--- a/lemur/notifications/messaging.py
+++ b/lemur/notifications/messaging.py
@@ -388,7 +388,7 @@ def send_reissue_no_endpoints_notification(old_cert, new_cert):
         if not old_cert.endpoints:
             excluded_destinations = current_app.config.get("LEMUR_REISSUE_NOTIFICATION_EXCLUDED_DESTINATIONS", [])
             has_excluded_destination = excluded_destinations and old_cert.destinations and \
-                                       [d for d in old_cert.destinations if d.label in excluded_destinations]
+                [d for d in old_cert.destinations if d.label in excluded_destinations]
             if not has_excluded_destination:
                 data = certificate_notification_output_schema.dump(new_cert).data
                 data["security_email"] = current_app.config.get("LEMUR_SECURITY_TEAM_EMAIL")

--- a/lemur/plugins/lemur_email/tests/test_email.py
+++ b/lemur/plugins/lemur_email/tests/test_email.py
@@ -182,7 +182,7 @@ def test_send_reissue_no_endpoints_notification(certificate):
     new_certificate = CertificateFactory()
     new_certificate.replaces.append(certificate)
     verify_sender_email()
-    assert send_reissue_no_endpoints_notification(new_certificate)
+    assert send_reissue_no_endpoints_notification(certificate, new_certificate)
 
 
 @mock_ses

--- a/lemur/tests/conf.py
+++ b/lemur/tests/conf.py
@@ -72,6 +72,9 @@ LEMUR_ALLOW_WEEKEND_EXPIRATION = False
 # needed for test_certificates
 LEMUR_PORTS_FOR_DEPLOYED_CERTIFICATE_CHECK = [443, 65521, 65522, 65523, 65524]
 
+# needed for test_messaging
+LEMUR_REISSUE_NOTIFICATION_EXCLUDED_DESTINATIONS = ['excluded-destination']
+
 # Database
 
 # modify this if you are not using a local database. Do not use any development or production DBs,

--- a/lemur/tests/test_messaging.py
+++ b/lemur/tests/test_messaging.py
@@ -202,13 +202,31 @@ def test_send_rotation_notification(notification_plugin, certificate):
 
 
 @mock_ses
-def test_send_reissue_no_endpoints_notification(notification_plugin, certificate):
+def test_send_reissue_no_endpoints_notification(notification_plugin, endpoint, certificate):
     from lemur.notifications.messaging import send_reissue_no_endpoints_notification
     verify_sender_email()
 
     new_cert = CertificateFactory()
     new_cert.replaces.append(certificate)
-    assert send_reissue_no_endpoints_notification(new_cert)
+    assert send_reissue_no_endpoints_notification(certificate, new_cert)
+    certificate.endpoints.append(endpoint)
+    assert not send_reissue_no_endpoints_notification(certificate, new_cert)
+
+
+@mock_ses
+def test_send_reissue_no_endpoints_notification_excluded_destination(destination_plugin, notification_plugin,
+                                                                     certificate, destination):
+    from lemur.notifications.messaging import send_reissue_no_endpoints_notification
+    verify_sender_email()
+
+    new_cert = CertificateFactory()
+    new_cert.replaces.append(certificate)
+    destination.label = 'not-excluded-destination'
+    certificate.destinations.append(destination)
+    assert send_reissue_no_endpoints_notification(certificate, new_cert)
+    # specified in tests/conf.py
+    destination.label = 'excluded-destination'
+    assert not send_reissue_no_endpoints_notification(certificate, new_cert)
 
 
 @mock_ses


### PR DESCRIPTION
Adds `LEMUR_REISSUE_NOTIFICATION_EXCLUDED_DESTINATIONS`, which allows configuration to specify a set of destinations for which we should _not_ notify about reissued certs with no endpoints. This is useful for cases where alternative (non-Lemur) automation handles certificate rotation on non-Lemur-managed endpoints.