### PR TITLE
Autorotation for certs attached to destination(s)

### DIFF
--- a/docker/src/lemur.conf.py
+++ b/docker/src/lemur.conf.py
@@ -124,6 +124,13 @@ CELERYBEAT_SCHEDULE = {
     #     },
     #     'schedule': crontab(hour=10, minute=0),
     # }
+    # 'enable_autorotate_for_certs_attached_to_destination': {
+    #     'task': 'lemur.common.celery.enable_autorotate_for_certs_attached_to_destination',
+    #     'options': {
+    #         'expires': 180
+    #     },
+    #     'schedule': crontab(hour=10, minute=0),
+    # }
     # 'enable_autorotate_for_certs_attached_to_endpoint': {
     #     'task': 'lemur.common.celery.enable_autorotate_for_certs_attached_to_endpoint',
     #     'options': {

--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -28,6 +28,7 @@ from lemur.certificates.service import (
     get_all_valid_certs,
     get,
     get_all_certs_attached_to_endpoint_without_autorotate,
+    get_all_certs_attached_to_destination_without_autorotate,
     revoke as revoke_certificate,
     list_duplicate_certs_by_authority,
     get_certificates_with_same_prefix_with_rotate_on,
@@ -747,7 +748,7 @@ def check_revoked():
 
 
 @manager.command
-def automatically_enable_autorotate():
+def automatically_enable_autorotate_with_endpoint():
     """
     This function automatically enables auto-rotation for unexpired certificates that are
     attached to an endpoint but do not have autorotate enabled.
@@ -776,7 +777,49 @@ def automatically_enable_autorotate():
         else:
             log_data["destination_names"] = "NONE"
         current_app.logger.info(log_data)
-        metrics.send("automatically_enable_autorotate",
+        metrics.send("automatically_enable_autorotate_with_endpoints",
+                     "counter", 1,
+                     metric_tags={"certificate": log_data["certificate"],
+                                  "certificate_id": log_data["certificate_id"],
+                                  "authority_id": log_data["authority_id"],
+                                  "authority_name": log_data["authority_name"],
+                                  "destination_names": log_data["destination_names"]
+                                  })
+        cert.rotation = True
+        database.update(cert)
+
+
+@manager.command
+def automatically_enable_autorotate_with_destination():
+    """
+    This function automatically enables auto-rotation for unexpired certificates that are
+    attached to a destination but do not have autorotate enabled.
+
+    WARNING: This will overwrite the Auto-rotate toggle!
+    """
+    log_data = {
+        "function": f"{__name__}.{sys._getframe().f_code.co_name}",
+        "message": "Enabling auto-rotate for certificate"
+    }
+
+    permitted_authorities = current_app.config.get("ENABLE_AUTO_ROTATE_AUTHORITY", [])
+
+    eligible_certs = get_all_certs_attached_to_destination_without_autorotate()
+    for cert in eligible_certs:
+
+        if cert.authority_id not in permitted_authorities:
+            continue
+
+        log_data["certificate"] = cert.name
+        log_data["certificate_id"] = cert.id
+        log_data["authority_id"] = cert.authority_id
+        log_data["authority_name"] = authorities_get_by_id(cert.authority_id).name
+        if cert.destinations:
+            log_data["destination_names"] = ', '.join([d.label for d in cert.destinations])
+        else:
+            log_data["destination_names"] = "NONE"
+        current_app.logger.info(log_data)
+        metrics.send("automatically_enable_autorotate_with_destinations",
                      "counter", 1,
                      metric_tags={"certificate": log_data["certificate"],
                                   "certificate_id": log_data["certificate_id"],

--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -777,7 +777,7 @@ def automatically_enable_autorotate_with_endpoint():
         else:
             log_data["destination_names"] = "NONE"
         current_app.logger.info(log_data)
-        metrics.send("automatically_enable_autorotate_with_endpoints",
+        metrics.send("automatically_enable_autorotate_with_endpoint",
                      "counter", 1,
                      metric_tags={"certificate": log_data["certificate"],
                                   "certificate_id": log_data["certificate_id"],
@@ -803,8 +803,9 @@ def automatically_enable_autorotate_with_destination():
     }
 
     permitted_authorities = current_app.config.get("ENABLE_AUTO_ROTATE_AUTHORITY", [])
+    destination_plugin_name = current_app.config.get("ENABLE_AUTO_ROTATE_DESTINATION_TYPE", None)
 
-    eligible_certs = get_all_certs_attached_to_destination_without_autorotate()
+    eligible_certs = get_all_certs_attached_to_destination_without_autorotate(plugin_name=destination_plugin_name)
     for cert in eligible_certs:
 
         if cert.authority_id not in permitted_authorities:
@@ -819,7 +820,7 @@ def automatically_enable_autorotate_with_destination():
         else:
             log_data["destination_names"] = "NONE"
         current_app.logger.info(log_data)
-        metrics.send("automatically_enable_autorotate_with_destinations",
+        metrics.send("automatically_enable_autorotate_with_destination",
                      "counter", 1,
                      metric_tags={"certificate": log_data["certificate"],
                                   "certificate_id": log_data["certificate_id"],

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -176,6 +176,22 @@ def get_all_certs_attached_to_endpoint_without_autorotate():
     )
 
 
+def get_all_certs_attached_to_destination_without_autorotate():
+    """
+        Retrieves all certificates that are attached to a destination, but that do not have autorotate enabled.
+
+        :return: list of certificates attached to a destination without autorotate
+        """
+    return (
+        Certificate.query.filter(Certificate.destinations.any())
+        .filter(Certificate.rotation == false())
+        .filter(Certificate.revoked == false())
+        .filter(Certificate.not_after >= arrow.now())
+        .filter(not_(Certificate.replaced.any()))
+        .all()  # noqa
+    )
+
+
 def get_all_pending_cleaning_expiring_in_days(source, days_to_expire):
     """
     Retrieves all certificates that are available for cleaning, not attached to endpoint,

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -162,10 +162,10 @@ def get_all_pending_cleaning_expired(source):
 
 def get_all_certs_attached_to_endpoint_without_autorotate():
     """
-        Retrieves all certificates that are attached to an endpoint, but that do not have autorotate enabled.
+    Retrieves all certificates that are attached to an endpoint, but that do not have autorotate enabled.
 
-        :return: list of certificates attached to an endpoint without autorotate
-        """
+    :return: list of certificates attached to an endpoint without autorotate
+    """
     return (
         Certificate.query.filter(Certificate.endpoints.any())
         .filter(Certificate.rotation == false())
@@ -176,12 +176,24 @@ def get_all_certs_attached_to_endpoint_without_autorotate():
     )
 
 
-def get_all_certs_attached_to_destination_without_autorotate():
+def get_all_certs_attached_to_destination_without_autorotate(plugin_name=None):
     """
-        Retrieves all certificates that are attached to a destination, but that do not have autorotate enabled.
+    Retrieves all certificates that are attached to a destination, but that do not have autorotate enabled.
 
-        :return: list of certificates attached to a destination without autorotate
-        """
+    :param plugin_name: Optional destination plugin name to query. Queries certificates attached to any destination if not provided.
+    :return: list of certificates attached to a destination without autorotate
+    """
+    if plugin_name:
+        return (
+            Certificate.query.filter(Certificate.destinations.any(plugin_name=plugin_name))
+            .filter(Certificate.rotation == false())
+            .filter(Certificate.revoked == false())
+            .filter(Certificate.not_after >= arrow.now())
+            .filter(not_(Certificate.replaced.any()))
+            .all()  # noqa
+        )
+
+
     return (
         Certificate.query.filter(Certificate.destinations.any())
         .filter(Certificate.rotation == false())

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -193,7 +193,6 @@ def get_all_certs_attached_to_destination_without_autorotate(plugin_name=None):
             .all()  # noqa
         )
 
-
     return (
         Certificate.query.filter(Certificate.destinations.any())
         .filter(Certificate.rotation == false())

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -917,7 +917,31 @@ def enable_autorotate_for_certs_attached_to_endpoint():
     }
     current_app.logger.debug(log_data)
 
-    cli_certificate.automatically_enable_autorotate()
+    cli_certificate.automatically_enable_autorotate_with_endpoint()
+    metrics.send(f"{function}.success", "counter", 1)
+    return log_data
+
+
+@celery.task(soft_time_limit=3600)
+def enable_autorotate_for_certs_attached_to_destination():
+    """
+    This celery task automatically enables autorotation for unexpired certificates that are
+    attached to at least one destination but do not have autorotate enabled.
+    :return:
+    """
+    function = f"{__name__}.{sys._getframe().f_code.co_name}"
+    task_id = None
+    if celery.current_task:
+        task_id = celery.current_task.request.id
+
+    log_data = {
+        "function": function,
+        "task_id": task_id,
+        "message": "Enabling autorotate to eligible certificates",
+    }
+    current_app.logger.debug(log_data)
+
+    cli_certificate.automatically_enable_autorotate_with_destination()
     metrics.send(f"{function}.success", "counter", 1)
     return log_data
 


### PR DESCRIPTION
This PR allows config to specify the default rotation status that Angular picks up during the certificate creation screen. I've set it as `False` here to be conservative, but having it configurable can be helpful to users who want to make cert rotation opt-out instead of opt-in!