### PR TITLE
ACME External Account Binding Support

### DIFF
--- a/docs/production/index.rst
+++ b/docs/production/index.rst
@@ -598,11 +598,12 @@ LetsEncrypt: Using a pre-existing ACME account
 -----------------------------------------------
 
 Let's Encrypt allows reusing an existing ACME account, to create and especially revoke certificates. The current
-implementation in the acme plugin, only allows for a single account for all ACME authorities, which might be an issue,
-when you try to use Let's Encrypt together with another certificate authority that uses the ACME protocol.
-
-To use an existing account, you need to configure the `ACME_PRIVATE_KEY` and `ACME_REGR` variables in the lemur
+implementation in the acme plugin, allows for a primary account for all ACME authorities.
+To use an existing account as the primary ACME account, you need to configure the `ACME_PRIVATE_KEY` and `ACME_REGR` variables in the lemur
 configuration.
+
+Alternatively, you can set `acme_regr` and `acme_private_key` as options during setup of a new issuer in Lemur.
+Lemur will use the `LEMUR_ENCRYPTION_KEYS` to encrypt the `acme_private_key` before storing it in the database.
 
 `ACME_PRIVATE_KEY` needs to be in the JWK format::
 
@@ -634,3 +635,21 @@ Using `python-jwt` converting an existing private key in PEM format is quite eas
     {"body": {}, "uri": "https://acme-staging-v02.api.letsencrypt.org/acme/acct/<ACCOUNT_NUMBER>"}
 
 The URI can be retrieved from the ACME create account endpoint when creating a new account, using the existing key.
+
+
+LetsEncrypt: Setting up a new ACME account
+------------------------------------------
+
+In case, you are not using the `ACME_PRIVATE_KEY` and `ACME_REGR` variables in the Lemur
+configuration to set up a pre-existing primary, Lemur will create a new account on the fly for you.
+Additionally, you can select the `store_account` while setting a new ACME-based issuer in Lemur,
+to avoid hitting rate limits for creating new accounts for each request.
+
+External Account Binding (EAB):
+-------------------------------
+
+The ACME protocol enables setting up a new ACME account linked to an existing external account.
+For this, your CA needs to issue you an hmac_key and kid, which you need while setting up a new ACME issuer in Lemur.
+hmac_key and kid are usually short-lived and are used to create a new account.
+When `store_account` is set in the options of a new issuer, Lemur will use the EAB credentials to set up a new account.
+

--- a/lemur/authorities/service.py
+++ b/lemur/authorities/service.py
@@ -12,7 +12,7 @@
 import json
 
 from lemur import database
-from lemur.common.utils import truthiness
+from lemur.common.utils import truthiness, data_encrypt
 from lemur.extensions import metrics
 from lemur.authorities.models import Authority
 from lemur.certificates.models import Certificate
@@ -143,6 +143,10 @@ def create(**kwargs):
     cert = upload(**kwargs)
     kwargs["authority_certificate"] = cert
     if kwargs.get("plugin", {}).get("plugin_options", []):
+        # encrypt the private key before persisting in DB
+        for option in kwargs.get("plugin").get("plugin_options"):
+            if option["name"] == "acme_private_key" and option["value"]:
+                option["value"] = data_encrypt(option["value"])
         kwargs["options"] = json.dumps(kwargs["plugin"]["plugin_options"])
 
     authority = Authority(**kwargs)

--- a/lemur/common/utils.py
+++ b/lemur/common/utils.py
@@ -45,6 +45,12 @@ def base64encode(string):
     return base64.b64encode(string.encode()).decode()
 
 
+def base64decode(base64_input):
+    # Performs Base64 decoging of a b64 string to string using the base64.b64encode() function
+    # which encodes bytes to bytes.
+    return base64.b64decode(base64_input.encode()).decode()
+
+
 def get_psuedo_random_string():
     """
     Create a random and strongish challenge.

--- a/lemur/common/utils.py
+++ b/lemur/common/utils.py
@@ -455,3 +455,16 @@ def parse_serial(pem_certificate):
     x509_cert.get_notAfter()
     parsed_certificate = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, pem_certificate)
     return parsed_certificate.get_serial_number()
+
+
+def is_json(json_input):
+    """
+    Test if input is json
+    :param json_input:
+    :return: True or False
+    """
+    try:
+        json_object = json.loads(json_input)
+    except ValueError as e:
+        return False
+    return True

--- a/lemur/common/utils.py
+++ b/lemur/common/utils.py
@@ -7,6 +7,7 @@
 .. moduleauthor:: Kevin Glisson <kglisson@netflix.com>
 """
 import base64
+import json
 import random
 import re
 import socket

--- a/lemur/common/utils.py
+++ b/lemur/common/utils.py
@@ -28,6 +28,8 @@ from sqlalchemy import and_, func
 
 from lemur.constants import CERTIFICATE_KEY_TYPES
 from lemur.exceptions import InvalidConfiguration
+from lemur.utils import Vault
+from sqlalchemy.dialects.postgresql import TEXT
 
 paginated_parser = RequestParser()
 
@@ -457,6 +459,33 @@ def parse_serial(pem_certificate):
     return parsed_certificate.get_serial_number()
 
 
+def string_encrypt(data):
+    """
+    takes a string input and returns a base64 encoded encryption
+    reusing the Vault DB encryption module
+    :param data: string
+    :return: base64 ciphertext
+    """
+    if not isinstance(data, str):
+        data = str(data)
+    print(data)
+    ciphertext = base64encode(Vault().process_result_value(data, TEXT()))
+    print(ciphertext)
+    return ciphertext
+
+
+def string_decrypt(ciphertext):
+    """
+    takes a base64 encoded ciphertext and returns the respective string
+    reusing the Vault DB encryption module
+    :param ciphertext: base64 ciphertext
+    :return: plaintext string
+    """
+    print(ciphertext)
+    print(base64decode(ciphertext))
+    return Vault().process_result_value(base64decode(ciphertext), TEXT())
+
+
 def is_json(json_input):
     """
     Test if input is json
@@ -464,7 +493,7 @@ def is_json(json_input):
     :return: True or False
     """
     try:
-        json_object = json.loads(json_input)
-    except ValueError as e:
+        json.loads(json_input)
+    except ValueError:
         return False
     return True

--- a/lemur/common/utils.py
+++ b/lemur/common/utils.py
@@ -459,31 +459,27 @@ def parse_serial(pem_certificate):
     return parsed_certificate.get_serial_number()
 
 
-def string_encrypt(data):
+def data_encrypt(data):
     """
-    takes a string input and returns a base64 encoded encryption
+    takes an input and returns a base64 encoded encryption
     reusing the Vault DB encryption module
     :param data: string
     :return: base64 ciphertext
     """
     if not isinstance(data, str):
         data = str(data)
-    print(data)
-    ciphertext = base64encode(Vault().process_result_value(data, TEXT()))
-    print(ciphertext)
-    return ciphertext
+    ciphertext = Vault().process_bind_param(data, TEXT())
+    return ciphertext.decode("utf8")
 
 
-def string_decrypt(ciphertext):
+def data_decrypt(ciphertext):
     """
-    takes a base64 encoded ciphertext and returns the respective string
+    takes a ciphertext and returns the respective string
     reusing the Vault DB encryption module
     :param ciphertext: base64 ciphertext
     :return: plaintext string
     """
-    print(ciphertext)
-    print(base64decode(ciphertext))
-    return Vault().process_result_value(base64decode(ciphertext), TEXT())
+    return Vault().process_result_value(ciphertext.encode("utf8"), TEXT())
 
 
 def is_json(json_input):

--- a/lemur/plugins/lemur_acme/acme_handlers.py
+++ b/lemur/plugins/lemur_acme/acme_handlers.py
@@ -198,14 +198,12 @@ class AcmeHandler(object):
             if eab_kid and eab_hmac_key:
                 # external account binding (eab_kid and eab_hmac_key could be potentially single use to establish
                 # long-term credentials)
-                external_account_binding = \
-                    messages.ExternalAccountBinding.from_data(account_public_key=key,
-                                                              kid=eab_kid,
-                                                              hmac_key=eab_hmac_key,
-                                                              directory={"newAccount": directory_url})
+                eab = messages.ExternalAccountBinding.from_data(account_public_key=key.public_key(),
+                                                                kid=eab_kid,
+                                                                hmac_key=eab_hmac_key,
+                                                                directory={'newAccount': directory_url})
                 registration = client.new_account_and_tos(
-                    messages.NewRegistration.from_data(email=email,
-                                                       external_account_binding=external_account_binding)
+                    messages.NewRegistration.from_data(email=email, external_account_binding=eab)
                 )
             else:
                 registration = client.new_account_and_tos(

--- a/lemur/plugins/lemur_acme/acme_handlers.py
+++ b/lemur/plugins/lemur_acme/acme_handlers.py
@@ -165,7 +165,7 @@ class AcmeHandler(object):
         existing_regr = options.get("acme_regr", current_app.config.get("ACME_REGR"))
 
         eab_kid = options.get("eab_kid", None)
-        eab_hmac_key = options.get("eab_kid", None)
+        eab_hmac_key = options.get("eab_hmac_key", None)
 
         if existing_key and existing_regr:
             current_app.logger.debug("Reusing existing ACME account")

--- a/lemur/plugins/lemur_acme/plugin.py
+++ b/lemur/plugins/lemur_acme/plugin.py
@@ -88,6 +88,20 @@ class ACMEIssuerPlugin(IssuerPlugin):
             "type": "str",
             "required": False,
             "helpMessage": "HMAC key for the external account.",
+        },
+        {
+            "name": "acme_private_key",
+            "type": "textarea",
+            "default": "",
+            "required": False,
+            "helpMessage": "Account Private Key. Will be encrypted.",
+        },
+        {
+            "name": "acme_regr",
+            "type": "textarea",
+            "default": "",
+            "required": False,
+            "helpMessage": "Account Registration",
         }
     ]
 
@@ -345,21 +359,37 @@ class ACMEHttpIssuerPlugin(IssuerPlugin):
         {
             "name": "eab_kid",
             "type": "str",
+            "default": "",
             "required": False,
             "helpMessage": "Key identifier for the external account.",
         },
         {
             "name": "eab_hmac_key",
             "type": "str",
+            "default": "",
             "required": False,
             "helpMessage": "HMAC key for the external account.",
+        },
+        {
+            "name": "acme_private_key",
+            "type": "textarea",
+            "default": "",
+            "required": False,
+            "helpMessage": "Account Private Key. Will be encrypted.",
+        },
+        {
+            "name": "acme_regr",
+            "type": "textarea",
+            "default": "",
+            "required": False,
+            "helpMessage": "Account Registration",
         },
         {
             "name": "tokenDestination",
             "type": "destinationSelect",
             "required": True,
             "helpMessage": "The destination to use to deploy the token.",
-        },
+        }
     ]
 
     def __init__(self, *args, **kwargs):

--- a/lemur/plugins/lemur_acme/plugin.py
+++ b/lemur/plugins/lemur_acme/plugin.py
@@ -48,7 +48,7 @@ class ACMEIssuerPlugin(IssuerPlugin):
             "type": "str",
             "required": True,
             "validation": check_validation(r"^http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$"),
-            "helpMessage": "Must be a valid web url starting with http[s]://",
+            "helpMessage": "ACME resource URI. Must be a valid web url starting with http[s]://",
         },
         {
             "name": "telephone",
@@ -68,7 +68,7 @@ class ACMEIssuerPlugin(IssuerPlugin):
             "type": "textarea",
             "default": "",
             "validation": check_validation("^-----BEGIN CERTIFICATE-----"),
-            "helpMessage": "Certificate to use",
+            "helpMessage": "ACME root certificate",
         },
         {
             "name": "store_account",
@@ -76,6 +76,18 @@ class ACMEIssuerPlugin(IssuerPlugin):
             "required": False,
             "helpMessage": "Disable to create a new account for each ACME request",
             "default": False,
+        },
+        {
+            "name": "eab_kid",
+            "type": "str",
+            "required": False,
+            "helpMessage": "Key identifier for the external account.",
+        },
+        {
+            "name": "eab_hmac_key",
+            "type": "str",
+            "required": False,
+            "helpMessage": "HMAC key for the external account.",
         }
     ]
 

--- a/lemur/plugins/lemur_acme/plugin.py
+++ b/lemur/plugins/lemur_acme/plugin.py
@@ -47,7 +47,7 @@ class ACMEIssuerPlugin(IssuerPlugin):
             "name": "acme_url",
             "type": "str",
             "required": True,
-            "validation": check_validation(r"^http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$"),
+            "validation": check_validation(r"http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+"),
             "helpMessage": "ACME resource URI. Must be a valid web url starting with http[s]://",
         },
         {
@@ -312,7 +312,7 @@ class ACMEHttpIssuerPlugin(IssuerPlugin):
             "name": "acme_url",
             "type": "str",
             "required": True,
-            "validation": check_validation(r"/^http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$/"),
+            "validation": check_validation(r"http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+"),
             "helpMessage": "Must be a valid web url starting with http[s]://",
         },
         {
@@ -333,7 +333,7 @@ class ACMEHttpIssuerPlugin(IssuerPlugin):
             "type": "textarea",
             "default": "",
             "validation": check_validation("^-----BEGIN CERTIFICATE-----"),
-            "helpMessage": "Certificate to use",
+            "helpMessage": "ACME root Certificate",
         },
         {
             "name": "store_account",
@@ -341,6 +341,18 @@ class ACMEHttpIssuerPlugin(IssuerPlugin):
             "required": False,
             "helpMessage": "Disable to create a new account for each ACME request",
             "default": False,
+        },
+        {
+            "name": "eab_kid",
+            "type": "str",
+            "required": False,
+            "helpMessage": "Key identifier for the external account.",
+        },
+        {
+            "name": "eab_hmac_key",
+            "type": "str",
+            "required": False,
+            "helpMessage": "HMAC key for the external account.",
         },
         {
             "name": "tokenDestination",

--- a/lemur/plugins/lemur_acme/plugin.py
+++ b/lemur/plugins/lemur_acme/plugin.py
@@ -265,7 +265,11 @@ class ACMEIssuerPlugin(IssuerPlugin):
         :param options:
         :return:
         """
-        role = {"username": "", "password": "", "name": "acme"}
+        name = "acme"
+        if options.get("authority"):
+            name += "_" + '_'.join(options['name'].split(" "))
+        role = {"username": "", "password": "", "name": name}
+
         plugin_options = options.get("plugin", {}).get("plugin_options")
         if not plugin_options:
             error = "Invalid options for lemur_acme plugin: {}".format(options)
@@ -370,7 +374,12 @@ class ACMEHttpIssuerPlugin(IssuerPlugin):
         :param options:
         :return:
         """
-        role = {"username": "", "password": "", "name": "acme"}
+        name = "acme"
+        print(options)
+        if options['name']:
+            name += "_" + '_'.join(options['name'].split(" "))
+        role = {"username": "", "password": "", "name": name}
+
         plugin_options = options.get("plugin", {}).get("plugin_options")
         if not plugin_options:
             error = "Invalid options for lemur_acme plugin: {}".format(options)

--- a/lemur/plugins/lemur_acme/plugin.py
+++ b/lemur/plugins/lemur_acme/plugin.py
@@ -417,7 +417,6 @@ class ACMEHttpIssuerPlugin(IssuerPlugin):
         :return:
         """
         name = "acme"
-        print(options)
         if options['name']:
             name += "_" + '_'.join(options['name'].split(" "))
         role = {"username": "", "password": "", "name": name}

--- a/lemur/plugins/lemur_acme/tests/test_acme_dns.py
+++ b/lemur/plugins/lemur_acme/tests/test_acme_dns.py
@@ -3,10 +3,11 @@ from unittest.mock import patch, Mock
 
 import josepy as jose
 from cryptography.x509 import DNSName
-from flask import Flask
+from flask import Flask, current_app
 from lemur.plugins.lemur_acme import plugin
 from lemur.plugins.lemur_acme.acme_handlers import AuthorizationRecord
 from lemur.common.utils import generate_private_key
+from lemur.tests.conf import LEMUR_ENCRYPTION_KEYS
 from unittest.mock import MagicMock
 
 
@@ -184,6 +185,7 @@ class TestAcmeDns(unittest.TestCase):
     @patch("lemur.plugins.lemur_acme.acme_handlers.BackwardsCompatibleClientV2")
     def test_setup_acme_client_success_store_new_account(self, mock_acme, mock_authorities_service,
                                                          mock_key_generation):
+        current_app.config["LEMUR_ENCRYPTION_KEYS"] = LEMUR_ENCRYPTION_KEYS
         mock_authority = Mock()
         mock_authority.id = 2
         mock_authority.options = '[{"name": "mock_name", "value": "mock_value"}, ' \
@@ -202,10 +204,8 @@ class TestAcmeDns(unittest.TestCase):
 
         self.acme.setup_acme_client(mock_authority)
 
-        mock_authorities_service.update_options.assert_called_with(2, options='[{"name": "mock_name", "value": "mock_value"}, '
-        '{"name": "store_account", "value": true}, '
-        '{"name": "acme_private_key", "value": "{\\"n\\": \\"PwIOkViO\\", \\"kty\\": \\"RSA\\"}"}, '
-        '{"name": "acme_regr", "value": "{\\"body\\": {}, \\"uri\\": \\"http://test.com\\"}"}]')
+        mock_authorities_service.update_options.assert_called_once()
+        assert "acme_private_key" in mock_authorities_service.update_options.call_args[1]['options']
 
     @patch("lemur.plugins.lemur_acme.acme_handlers.authorities_service")
     @patch("lemur.plugins.lemur_acme.acme_handlers.BackwardsCompatibleClientV2")

--- a/lemur/plugins/lemur_acme/tests/test_acme_dns.py
+++ b/lemur/plugins/lemur_acme/tests/test_acme_dns.py
@@ -7,7 +7,7 @@ from flask import Flask
 from lemur.plugins.lemur_acme import plugin
 from lemur.plugins.lemur_acme.acme_handlers import AuthorizationRecord
 from lemur.common.utils import generate_private_key
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 
 class TestAcmeDns(unittest.TestCase):

--- a/lemur/plugins/lemur_acme/tests/test_acme_http.py
+++ b/lemur/plugins/lemur_acme/tests/test_acme_http.py
@@ -24,12 +24,13 @@ class TestAcmeHttp(unittest.TestCase):
 
     def test_create_authority(self):
         options = {
-            "plugin": {"plugin_options": [{"name": "certificate", "value": "123"}]}
+            "plugin": {"plugin_options": [{"name": "certificate", "value": "123"}]},
+            "name": "mock_authority"
         }
         acme_root, b, role = self.ACMEHttpIssuerPlugin.create_authority(options)
         self.assertEqual(acme_root, "123")
         self.assertEqual(b, "")
-        self.assertEqual(role, [{"username": "", "password": "", "name": "acme"}])
+        self.assertEqual(role, [{"username": "", "password": "", "name": "acme_mock_authority"}])
 
     @patch("lemur.plugins.lemur_acme.plugin.AcmeHandler.setup_acme_client")
     @patch("lemur.plugins.base.manager.PluginManager.get")

--- a/lemur/tests/test_ldap.py
+++ b/lemur/tests/test_ldap.py
@@ -1,6 +1,6 @@
 import pytest
 from lemur.auth.ldap import *  # noqa
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 class LdapPrincipalTester(LdapPrincipal):

--- a/lemur/tests/test_utils.py
+++ b/lemur/tests/test_utils.py
@@ -130,6 +130,15 @@ def test_convert_pkcs7_bytes_to_pem():
     assert (parse_certificate("\n".join(str(leaf).splitlines())) == INTERMEDIATE_CERT)
 
 
+def test_encryption():
+    from lemur.common.utils import string_encrypt, string_decrypt
+    plaintext = "encrypt this string"
+    assert (string_decrypt(string_encrypt(plaintext)) == plaintext)
+
+    plaintext = 123
+    assert (string_decrypt(string_encrypt(plaintext)) == int(plaintext))
+
+
 def test_is_json():
     from lemur.common.utils import is_json
     assert is_json("{}") is True
@@ -138,4 +147,3 @@ def test_is_json():
     assert is_json('{ "value":100}') is True
     assert is_json("{\"value\":100 }") is True
     assert is_json('{"range":[5,6.8],"name":"something"}') is True
-

--- a/lemur/tests/test_utils.py
+++ b/lemur/tests/test_utils.py
@@ -128,3 +128,14 @@ def test_convert_pkcs7_bytes_to_pem():
 
     assert(parse_certificate("\n".join(str(root).splitlines())) == ROOTCA_CERT)
     assert (parse_certificate("\n".join(str(leaf).splitlines())) == INTERMEDIATE_CERT)
+
+
+def test_is_json():
+    from lemur.common.utils import is_json
+    assert is_json("{}") is True
+    assert is_json("{some text}") is False
+    assert is_json("{'value':100 }") is False
+    assert is_json('{ "value":100}') is True
+    assert is_json("{\"value\":100 }") is True
+    assert is_json('{"range":[5,6.8],"name":"something"}') is True
+

--- a/lemur/tests/test_utils.py
+++ b/lemur/tests/test_utils.py
@@ -130,13 +130,16 @@ def test_convert_pkcs7_bytes_to_pem():
     assert (parse_certificate("\n".join(str(leaf).splitlines())) == INTERMEDIATE_CERT)
 
 
-def test_encryption():
-    from lemur.common.utils import string_encrypt, string_decrypt
+def test_encryption(client):
+    from lemur.common.utils import data_encrypt, data_decrypt
     plaintext = "encrypt this string"
-    assert (string_decrypt(string_encrypt(plaintext)) == plaintext)
+    assert (data_decrypt(data_encrypt(plaintext)) == plaintext)
 
     plaintext = 123
-    assert (string_decrypt(string_encrypt(plaintext)) == int(plaintext))
+    assert (data_decrypt(data_encrypt(plaintext)) == str(plaintext))
+
+    plaintext = {"this": "is a test"}
+    assert (data_decrypt(data_encrypt(plaintext)) == str(plaintext))
 
 
 def test_is_json():


### PR DESCRIPTION
historically, the ACME plugin like other plugins has been sourcing the API credentials via the config file. The ACME plugin, however, could be used with multiple CAs. Hence, with this PR, we support adding the API credentials in the CA options. We encrypt the credentials before storage in Lemur. 

More specifically, when adding a new ACME issuer, one can now set `acme_regr` and `acme_private_key` (encrypted by Lemur).

**External Account Binding (EAB):**
Lemur now supports EAB, and can create a new account based on provisioned EAB credentials (`kid`, and `hmac_key`).