### PR TITLE
Fix immediate (synchronous) acme creation

### DIFF
--- a/docs/production/index.rst
+++ b/docs/production/index.rst
@@ -495,9 +495,11 @@ before requesting that LetsEncrypt finalize the certificate request and send us 
 
 .. figure:: letsencrypt_flow.png
 
-To start issuing certificates through LetsEncrypt, you must enable Celery support within Lemur first. After doing so,
+To start issuing certificates through LetsEncrypt, you must enable Celery support within Lemur first[*]_. After doing so,
 you need to create a LetsEncrypt authority. To do this, visit
 Authorities -> Create. Set the applicable attributes and click "More Options".
+
+.. [*] It is possible to use synchronous certificate creation by supplying the ``create_immediately`` parameter in your certificate creation requests.
 
 .. figure:: letsencrypt_authority_1.png
 

--- a/docs/production/index.rst
+++ b/docs/production/index.rst
@@ -499,7 +499,7 @@ To start issuing certificates through LetsEncrypt, you must enable Celery suppor
 you need to create a LetsEncrypt authority. To do this, visit
 Authorities -> Create. Set the applicable attributes and click "More Options".
 
-.. [*] It is possible to use synchronous certificate creation by supplying the ``create_immediately`` parameter in your certificate creation requests.
+.. [*] It is possible to use synchronous certificate creation without Celery by supplying the ``create_immediately`` parameter in your certificate creation requests, but this is only recommended for testing and development purposes, given the inherent `limitations of DNS record propagation <https://letsencrypt.org/docs/challenge-types/#dns-01-challenge>`.
 
 .. figure:: letsencrypt_authority_1.png
 

--- a/lemur/plugins/lemur_acme/challenge_types.py
+++ b/lemur/plugins/lemur_acme/challenge_types.py
@@ -20,6 +20,8 @@ from lemur.plugins.base import plugins
 from lemur.destinations import service as destination_service
 from lemur.plugins.lemur_acme.acme_handlers import AcmeHandler, AcmeDnsHandler
 
+from retrying import retry
+
 
 class AcmeChallengeMissmatchError(LemurException):
     pass
@@ -192,16 +194,18 @@ class AcmeDnsChallenge(AcmeChallenge):
         authority = issuer_options.get("authority")
         create_immediately = issuer_options.get("create_immediately", False)
         acme_client, registration = self.acme.setup_acme_client(authority)
+        domains = self.acme.get_domains(issuer_options)
         dns_provider = issuer_options.get("dns_provider", {})
 
         if dns_provider:
-            dns_provider_options = dns_provider.options
+            for domain in domains:
+                # Currently, we only support specifying one DNS provider per certificate, even if that
+                # certificate has multiple SANs that may belong to different provid
+                self.acme.dns_providers_for_domain[domain] = [dns_provider]
+
             credentials = json.loads(dns_provider.credentials)
             current_app.logger.debug(
                 "Using DNS provider: {0}".format(dns_provider.provider_type)
-            )
-            dns_provider_plugin = __import__(
-                dns_provider.provider_type, globals(), locals(), [], 1
             )
             account_number = credentials.get("account_id")
             provider_type = dns_provider.provider_type
@@ -213,38 +217,39 @@ class AcmeDnsChallenge(AcmeChallenge):
                 raise InvalidConfiguration(error)
         else:
             dns_provider = {}
-            dns_provider_options = None
             account_number = None
             provider_type = None
 
-        domains = self.acme.get_domains(issuer_options)
+            for domain in domains:
+                self.acme.autodetect_dns_providers(domain)
+
+        # Create pending authorizations that we'll need to do the creation
+        dns_authorization = authorization_service.create(
+            account_number, domains, provider_type
+        )
+
         if not create_immediately:
-            # Create pending authorizations that we'll need to do the creation
-            dns_authorization = authorization_service.create(
-                account_number, domains, provider_type
-            )
             # Return id of the DNS Authorization
             return None, None, dns_authorization.id
 
-        authorizations = self.acme.get_authorizations(
-            acme_client,
-            account_number,
-            domains,
-            dns_provider_plugin,
-            dns_provider_options,
-        )
-        self.acme.finalize_authorizations(
-            acme_client,
-            account_number,
-            dns_provider_plugin,
-            authorizations,
-            dns_provider_options,
-        )
-        pem_certificate, pem_certificate_chain = self.acme.request_certificate(
-            acme_client, authorizations, csr
+        pem_certificate, pem_certificate_chain = self.create_immediately(
+            acme_client, dns_authorization, csr
         )
         # TODO add external ID (if possible)
         return pem_certificate, pem_certificate_chain, None
+
+    @retry(stop_max_attempt_number=5, wait_fixed=5000)
+    def create_immediately(self, acme_client, order_info, csr):
+        order = acme_client.new_order(csr)
+
+        authorizations = self.acme.get_authorizations(
+            acme_client, order, order_info
+        )
+        authorizations = self.acme.finalize_authorizations(acme_client, authorizations)
+
+        return self.acme.request_certificate(
+            acme_client, authorizations, order
+        )
 
     def deploy(self, challenge, acme_client, validation_target):
         pass

--- a/lemur/plugins/lemur_acme/challenge_types.py
+++ b/lemur/plugins/lemur_acme/challenge_types.py
@@ -15,6 +15,7 @@ from acme.messages import errors, STATUS_VALID, ERROR_CODES
 from flask import current_app
 
 from lemur.authorizations import service as authorization_service
+from lemur.constants import ACME_ADDITIONAL_ATTEMPTS
 from lemur.exceptions import LemurException, InvalidConfiguration
 from lemur.plugins.base import plugins
 from lemur.destinations import service as destination_service
@@ -238,7 +239,7 @@ class AcmeDnsChallenge(AcmeChallenge):
         # TODO add external ID (if possible)
         return pem_certificate, pem_certificate_chain, None
 
-    @retry(stop_max_attempt_number=5, wait_fixed=5000)
+    @retry(stop_max_attempt_number=ACME_ADDITIONAL_ATTEMPTS, wait_fixed=5000)
     def create_immediately(self, acme_client, order_info, csr):
         order = acme_client.new_order(csr)
 

--- a/lemur/plugins/lemur_acme/challenge_types.py
+++ b/lemur/plugins/lemur_acme/challenge_types.py
@@ -20,6 +20,7 @@ from sentry_sdk import capture_exception
 from lemur.authorizations import service as authorization_service
 from lemur.constants import ACME_ADDITIONAL_ATTEMPTS
 from lemur.exceptions import LemurException, InvalidConfiguration
+from lemur.extensions import metrics
 from lemur.plugins.base import plugins
 from lemur.destinations import service as destination_service
 from lemur.plugins.lemur_acme.acme_handlers import AcmeHandler, AcmeDnsHandler

--- a/lemur/plugins/lemur_acme/tests/test_acme_dns.py
+++ b/lemur/plugins/lemur_acme/tests/test_acme_dns.py
@@ -308,6 +308,10 @@ class TestAcmeDns(unittest.TestCase):
         result = provider.create_certificate(csr, issuer_options)
         assert result
 
+        issuer_options["create_immediately"] = True
+        immediate_result = provider.create_certificate(csr, issuer_options)
+        assert immediate_result
+
     @patch("lemur.plugins.lemur_acme.plugin.AcmeDnsHandler.start_dns_challenge", return_value="test")
     def test_get_authorizations(self, mock_start_dns_challenge):
         mock_order = Mock()


### PR DESCRIPTION
A seldom-used, but useful feature is the ability to create certificates immediately with `ACMEIssuerPlugin` (specifically for `AcmeDnsChallenge`), rather than [passing the work asynchronously](https://github.com/Netflix/lemur/blob/master/lemur/certificates/service.py#L476) to celery. I noticed that this feature exists already in Lemur, but somewhere along the way, it drifted from changes to the method signatures of `get_authorizations()` and `finalize_authorizations()` and appeared to no longer work.

In addition to updating calls to acme authorizations, I've added an `@retry` decorator to a new `create_immediately()` method, with the goal of roughly recreating the retry logic that celery uses for [`fetch_acme_cert()`](https://github.com/Netflix/lemur/blob/master/lemur/common/celery.py#L307).