### PR TITLE
Concatenate enum name instead of enum itself to avoid the error

### DIFF
--- a/lemur/plugins/lemur_cfssl/plugin.py
+++ b/lemur/plugins/lemur_cfssl/plugin.py
@@ -118,7 +118,7 @@ class CfsslIssuerPlugin(IssuerPlugin):
             + '","authority_key_id": "'
             + get_authority_key(certificate.body)
             + '", "reason": "'
-            + crl_reason
+            + crl_reason.name
             + '"}'
         )
         current_app.logger.debug("Revoking cert: {0}".format(data))


### PR DESCRIPTION
This error shows up when revoking certificates with CFSSL plugin:

```
Failed to revoke: can only concatenate str (not "CRLReason") to str
```

So I concatenate enum name instead of enum itself to avoid this error.