### PR TITLE
Adds async reissue notifications

### DIFF
--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -162,9 +162,9 @@ def request_reissue(certificate, notify, commit):
         print_certificate_details(details)
 
         if commit:
-            new_cert = reissue_certificate(certificate, replace=True)
+            new_cert = reissue_certificate(certificate, notify=notify, replace=True)
             print("[+] New certificate named: {0}".format(new_cert.name))
-            if notify:
+            if notify and isinstance(new_cert, Certificate):  # let celery handle PendingCertificates
                 send_reissue_no_endpoints_notification(certificate, new_cert)
 
         status = SUCCESS_METRIC_STATUS

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -504,7 +504,7 @@ def create(**kwargs):
         from lemur.common.celery import fetch_acme_cert
 
         if not current_app.config.get("ACME_DISABLE_AUTORESOLVE", False):
-            fetch_acme_cert.apply_async((pending_cert.id, kwargs.get("async_reissue_notification", False)), countdown=5)
+            fetch_acme_cert.apply_async((pending_cert.id, kwargs.get("async_reissue_notification_cert", None)), countdown=5)
 
     return cert
 
@@ -917,9 +917,9 @@ def reissue_certificate(certificate, notify=None, replace=None, user=None):
     if (certificate.owner in ecc_reissue_owner_list) and (certificate.cn not in ecc_reissue_exclude_cn_list):
         primitives["key_type"] = "ECCPRIME256V1"
 
-    # allow celery to send notifications for PendingCertificates
+    # allow celery to send notifications for PendingCertificates using the old cert
     if notify:
-        primitives["async_reissue_notification"] = True
+        primitives["async_reissue_notification_cert"] = certificate
 
     new_cert = create(**primitives)
 

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -504,7 +504,7 @@ def create(**kwargs):
         from lemur.common.celery import fetch_acme_cert
 
         if not current_app.config.get("ACME_DISABLE_AUTORESOLVE", False):
-            fetch_acme_cert.apply_async((pending_cert.id,), countdown=5)
+            fetch_acme_cert.apply_async((pending_cert.id, kwargs.get("async_reissue_notification", False)), countdown=5)
 
     return cert
 
@@ -872,10 +872,11 @@ def get_certificate_primitives(certificate):
     return data
 
 
-def reissue_certificate(certificate, replace=None, user=None):
+def reissue_certificate(certificate, notify=None, replace=None, user=None):
     """
     Reissue certificate with the same properties of the given certificate.
     :param certificate:
+    :param notify:
     :param replace:
     :param user:
     :return:
@@ -915,6 +916,10 @@ def reissue_certificate(certificate, replace=None, user=None):
 
     if (certificate.owner in ecc_reissue_owner_list) and (certificate.cn not in ecc_reissue_exclude_cn_list):
         primitives["key_type"] = "ECCPRIME256V1"
+
+    # allow celery to send notifications for PendingCertificates
+    if notify:
+        primitives["async_reissue_notification"] = True
 
     new_cert = create(**primitives)
 

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -232,13 +232,13 @@ def report_revoked_task(**kwargs):
 
 
 @celery.task(soft_time_limit=600)
-def fetch_acme_cert(id, notify_reissue=False):
+def fetch_acme_cert(id, notify_reissue_cert=None):
     """
     Attempt to get the full certificate for the pending certificate listed.
 
     Args:
         id: an id of a PendingCertificate
-        notify_reissue: whether to send reissue notifications for the PendingCertificate
+        notify_reissue_cert: existing Certificate to use for reissue notifications, if supplied
     """
     task_id = None
     if celery.current_task:
@@ -299,8 +299,8 @@ def fetch_acme_cert(id, notify_reissue=False):
             pending_certificate_service.update(
                 cert.get("pending_cert").id, resolved=True
             )
-            if notify_reissue:
-                send_reissue_no_endpoints_notification(final_cert)
+            if notify_reissue_cert is not None:
+                send_reissue_no_endpoints_notification(notify_reissue_cert, final_cert)
             # add metrics to metrics extension
             new += 1
         else:
@@ -316,7 +316,7 @@ def fetch_acme_cert(id, notify_reissue=False):
                 send_pending_failure_notification(
                     pending_cert, notify_owner=pending_cert.notify
                 )
-                if notify_reissue:
+                if notify_reissue_cert is not None:
                     send_reissue_failed_notification(pending_cert)
                 # Mark the pending cert as resolved
                 pending_certificate_service.update(
@@ -328,7 +328,7 @@ def fetch_acme_cert(id, notify_reissue=False):
                     cert.get("pending_cert").id, status=str(cert.get("last_error"))
                 )
                 # Add failed pending cert task back to queue
-                fetch_acme_cert.delay(id, notify_reissue)
+                fetch_acme_cert.delay(id, notify_reissue_cert)
             current_app.logger.error(error_log)
     log_data["message"] = "Complete"
     log_data["new"] = new


### PR DESCRIPTION
This PR allows celery to handle reissue notifications (`send_reissue_no_endpoints_notification` and `send_reissue_failed_notification`) for `PendingCertificate`s upon their resolution to a full `Certificate`, as opposed to sending reissue notifications while a cert is still in a pending state. This is a subtle change that unlocks, for example, the ability to further customize notifications to include more details about the final certificate, such as its expiration date, rotation settings, and so forth.