### PR TITLE
Use directory object fetched from ACME server

### DIFF
--- a/lemur/plugins/lemur_acme/acme_handlers.py
+++ b/lemur/plugins/lemur_acme/acme_handlers.py
@@ -201,7 +201,7 @@ class AcmeHandler(object):
                 eab = messages.ExternalAccountBinding.from_data(account_public_key=key.public_key(),
                                                                 kid=eab_kid,
                                                                 hmac_key=eab_hmac_key,
-                                                                directory={'newAccount': directory_url})
+                                                                directory=client.directory)
                 registration = client.new_account_and_tos(
                     messages.NewRegistration.from_data(email=email, external_account_binding=eab)
                 )


### PR DESCRIPTION
This change updates the ACME client to configure itself using the [directory](https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.1) object [fetched](https://github.com/certbot/certbot/blob/master/acme/acme/client.py#L824) from the ACME server when the client is initialized.

Without this change, issuing certificates from some ACME authorities with external account binding support enabled will fail. I'm able to reproduce this issue using DigiCert's ACME API, but it should also be reproducible using a test server such as [Pebble](https://github.com/letsencrypt/pebble) (which is what DigiCert appears to be using for their ACME server) as well:

```json
{"detail":"the 'url' field in external account binding differs from outer JWS","status":400,"type":"malformed"}
```

