### PR TITLE
Switch to default validity when authority changes

### DIFF
--- a/lemur/static/app/angular/certificates/certificate/certificate.js
+++ b/lemur/static/app/angular/certificates/certificate/certificate.js
@@ -127,6 +127,11 @@ angular.module('lemur')
       opened: false
     };
 
+    $scope.clearDatesAndDefaultValidity = function () {
+      $scope.clearDates();
+      $scope.certificate.validityType = 'defaultDays';
+    };
+
     $scope.clearDates = function () {
       $scope.certificate.validityStart = null;
       $scope.certificate.validityEnd = null;

--- a/lemur/static/app/angular/certificates/certificate/tracking.tpl.html
+++ b/lemur/static/app/angular/certificates/certificate/tracking.tpl.html
@@ -96,7 +96,7 @@
         Certificate Authority
       </label>
       <div class="col-sm-10">
-        <ui-select class="input-md" ng-model="certificate.authority" theme="bootstrap" title="choose an authority" ng-change="clearDates()">
+        <ui-select class="input-md" ng-model="certificate.authority" theme="bootstrap" title="choose an authority" ng-change="clearDatesAndDefaultValidity()">
           <ui-select-match placeholder="select an authority...">{{$select.selected.name}}</ui-select-match>
           <ui-select-choices class="form-control" repeat="authority in authorities"
                              refresh="getAuthoritiesByName($select.search)"


### PR DESCRIPTION
For certificate creation, Lemur gives 2 options to select certificate validity from UI - (1)Use default days(varies as per selected authority) OR (2)custom date range. Changing authority takes care of populating the default days displayed on UI and also clears selected custom date range, if any. This helps to ensure that validity is selected as per current CA's validity range.

Issue: In certificate create form, select custom date range and then change authority to Let's Encrypt. Since Let's Encrypt is configured to issue 90days valid cert, user cannot select specific validity. Submitting this form with valid values results in error `Valid start and end dates are needed, else select Default option`.

Fix: This PR takes care of switching to default validity when user changes authority in UI to fix above error. One can always go with default or select custom date range (the old behavior which is unchanged)