### PR TITLE
ACME plugin improvement

### DIFF
--- a/lemur/plugins/lemur_acme/acme_handlers.py
+++ b/lemur/plugins/lemur_acme/acme_handlers.py
@@ -22,7 +22,7 @@ import dns.resolver
 from acme import challenges, errors, messages
 from acme.client import BackwardsCompatibleClientV2, ClientNetwork
 from acme.errors import TimeoutError
-from acme.messages import Error as AcmeError
+from acme.messages import Error as AcmeError, STATUS_VALID
 from certbot import crypto_util as acme_crypto_util
 from flask import current_app
 from sentry_sdk import capture_exception
@@ -292,7 +292,9 @@ class AcmeDnsHandler(AcmeHandler):
         return dns_provider_plugin.get_zones(account_number=account_number)
 
     def get_dns_challenges(self, host, authorizations):
-        """Get dns challenges for provided domain"""
+        """Get dns challenges for provided domain
+            Also indicate if the hostname is already validated
+        """
 
         domain_to_validate, is_wildcard = self.strip_wildcard(host)
         dns_challenges = []
@@ -304,10 +306,14 @@ class AcmeDnsHandler(AcmeHandler):
             if not is_wildcard and authz.body.wildcard:
                 continue
             for combo in authz.body.challenges:
+                # skip valid domain
+                if combo.body.status == STATUS_VALID:
+                    metrics.send("get_acme_challenges_already_valid", "counter", 1)
+                    return [], True
                 if isinstance(combo.chall, challenges.DNS01):
                     dns_challenges.append(combo)
 
-        return dns_challenges
+        return dns_challenges, False
 
     def get_dns_provider(self, type):
         provider_types = {
@@ -336,9 +342,13 @@ class AcmeDnsHandler(AcmeHandler):
 
         change_ids = []
         cname_delegation = domain != target_domain
-        dns_challenges = self.get_dns_challenges(domain, order.authorizations)
+        # This method will consider and skip valid HTTP01 challenges
+        dns_challenges, hostname_still_validatd = self.get_dns_challenges(domain, order.authorizations)
         host_to_validate, _ = self.strip_wildcard(target_domain)
         host_to_validate = self.maybe_add_extension(host_to_validate, dns_provider_options)
+
+        if hostname_still_validatd:
+            return
 
         if not dns_challenges:
             capture_exception()
@@ -394,6 +404,11 @@ class AcmeDnsHandler(AcmeHandler):
                     raise
 
             for dns_challenge in authz_record.dns_challenge:
+                # abort if the status is already valid, no DNS challenge to complete
+                if dns_challenge["status"] == STATUS_VALID:
+                    metrics.send("acme_challenge_already_valid", "counter", 1)
+                    return
+
                 response = dns_challenge.response(acme_client.client.net.key)
 
                 verified = response.simple_verify(
@@ -411,6 +426,7 @@ class AcmeDnsHandler(AcmeHandler):
             current_app.logger.debug(f"answer_challenge response: {res}")
 
     def get_authorizations(self, acme_client, order, order_info):
+        """ The list can be empty if all hostname validations are still valid"""
         authorizations = []
 
         for domain in order_info.domains:
@@ -447,7 +463,9 @@ class AcmeDnsHandler(AcmeHandler):
                     order,
                     dns_provider.options,
                 )
-                authorizations.append(authz_record)
+                # it can be null, if hostname is still valid
+                if authz_record:
+                    authorizations.append(authz_record)
         return authorizations
 
     def autodetect_dns_providers(self, domain):

--- a/lemur/plugins/lemur_acme/acme_handlers.py
+++ b/lemur/plugins/lemur_acme/acme_handlers.py
@@ -405,7 +405,7 @@ class AcmeDnsHandler(AcmeHandler):
 
             for dns_challenge in authz_record.dns_challenge:
                 # abort if the status is already valid, no DNS challenge to complete
-                if dns_challenge["status"] == STATUS_VALID:
+                if "status" in dns_challenge and dns_challenge["status"] == STATUS_VALID:
                     metrics.send("acme_challenge_already_valid", "counter", 1)
                     return
 

--- a/lemur/plugins/lemur_acme/acme_handlers.py
+++ b/lemur/plugins/lemur_acme/acme_handlers.py
@@ -343,11 +343,11 @@ class AcmeDnsHandler(AcmeHandler):
         change_ids = []
         cname_delegation = domain != target_domain
         # This method will consider and skip valid HTTP01 challenges
-        dns_challenges, hostname_still_validatd = self.get_dns_challenges(domain, order.authorizations)
+        dns_challenges, hostname_still_validated = self.get_dns_challenges(domain, order.authorizations)
         host_to_validate, _ = self.strip_wildcard(target_domain)
         host_to_validate = self.maybe_add_extension(host_to_validate, dns_provider_options)
 
-        if hostname_still_validatd:
+        if hostname_still_validated:
             return
 
         if not dns_challenges:

--- a/lemur/plugins/lemur_acme/challenge_types.py
+++ b/lemur/plugins/lemur_acme/challenge_types.py
@@ -92,11 +92,6 @@ class AcmeHttpChallenge(AcmeChallenge):
         all_pre_validated = True
         for authz in orderr.authorizations:
             # Choosing challenge.
-            # check if authorizations is already in a valid state
-            # authz.body.identifier.value the domain we are validating
-            # if authz.body.wildcard:
-            #   no wildcard support, we shall validate this via the dnsName
-            #   continue
             if authz.body.status != STATUS_VALID:
                 all_pre_validated = False
                 # authz.body.challenges is a set of ChallengeBody objects.
@@ -104,8 +99,6 @@ class AcmeHttpChallenge(AcmeChallenge):
                     # Find the supported challenge.
                     if isinstance(i.chall, challenges.HTTP01):
                         chall.append(i)
-#                    if isinstance(i.chall, challenges.DNS01) and wildcard.Identifier:
-#                        dns_challenges.append(i)
             else:
                 current_app.logger.info("{} already validated, skipping".format(authz.body.identifier.value))
 

--- a/lemur/plugins/lemur_acme/challenge_types.py
+++ b/lemur/plugins/lemur_acme/challenge_types.py
@@ -93,6 +93,10 @@ class AcmeHttpChallenge(AcmeChallenge):
         for authz in orderr.authorizations:
             # Choosing challenge.
             # check if authorizations is already in a valid state
+            # authz.body.identifier.value the domain we are validating
+            # if authz.body.wildcard:
+            #   no wildcard support, we shall validate this via the dnsName
+            #   continue
             if authz.body.status != STATUS_VALID:
                 all_pre_validated = False
                 # authz.body.challenges is a set of ChallengeBody objects.
@@ -100,6 +104,8 @@ class AcmeHttpChallenge(AcmeChallenge):
                     # Find the supported challenge.
                     if isinstance(i.chall, challenges.HTTP01):
                         chall.append(i)
+#                    if isinstance(i.chall, challenges.DNS01) and wildcard.Identifier:
+#                        dns_challenges.append(i)
             else:
                 current_app.logger.info("{} already validated, skipping".format(authz.body.identifier.value))
 

--- a/lemur/plugins/lemur_acme/tests/test_acme_dns.py
+++ b/lemur/plugins/lemur_acme/tests/test_acme_dns.py
@@ -2,6 +2,8 @@ import unittest
 from unittest.mock import patch, Mock
 
 import josepy as jose
+
+from acme.messages import STATUS_PENDING, STATUS_VALID
 from cryptography.x509 import DNSName
 from flask import Flask, current_app
 from lemur.plugins.lemur_acme import plugin
@@ -99,7 +101,8 @@ class TestAcmeDns(unittest.TestCase):
         mock_authz.change_id = []
         mock_authz.change_id.append("123")
         mock_authz.dns_challenge = []
-        dns_challenge = Mock()
+        dns_challenge = MagicMock()
+        dns_challenge["status"] == STATUS_PENDING
         mock_authz.dns_challenge.append(dns_challenge)
         self.acme.complete_dns_challenge(mock_acme, mock_authz)
 
@@ -111,10 +114,11 @@ class TestAcmeDns(unittest.TestCase):
         mock_dns_provider = Mock()
         mock_dns_provider.wait_for_dns_change = Mock(return_value=True)
 
-        mock_dns_challenge = Mock()
+        mock_dns_challenge = MagicMock()
         response = Mock()
         response.simple_verify = Mock(return_value=False)
         mock_dns_challenge.response = Mock(return_value=response)
+        mock_dns_challenge["status"] == STATUS_PENDING
 
         mock_authz = Mock()
         mock_authz.dns_challenge = []

--- a/lemur/plugins/lemur_acme/tests/test_acme_dns.py
+++ b/lemur/plugins/lemur_acme/tests/test_acme_dns.py
@@ -64,7 +64,7 @@ class TestAcmeDns(unittest.TestCase):
         host = "example.com"
         c = challenges.DNS01()
 
-        mock_authz = MagicMock
+        mock_authz = MagicMock()
         mock_authz.body = STATUS_VALID
         mock_authz.body.resolved_combinations = []
         mock_entry = Mock()

--- a/lemur/plugins/lemur_acme/tests/test_acme_dns.py
+++ b/lemur/plugins/lemur_acme/tests/test_acme_dns.py
@@ -73,7 +73,8 @@ class TestAcmeDns(unittest.TestCase):
         mock_dns_provider = Mock()
         mock_dns_provider.create_txt_record = Mock(return_value=1)
 
-        values = [mock_entry]
+        hostname_still_validated = False
+        values = [mock_entry, hostname_still_validated]
         iterable = mock_get_dns_challenges.return_value
         iterator = iter(values)
         iterable.__iter__.return_value = iterator

--- a/lemur/plugins/lemur_acme/tests/test_acme_dns.py
+++ b/lemur/plugins/lemur_acme/tests/test_acme_dns.py
@@ -55,6 +55,25 @@ class TestAcmeDns(unittest.TestCase):
         self.assertEqual(result, mock_entry)
         self.assertFalse(hostname_still_validated)
 
+    @patch("lemur.plugins.lemur_acme.plugin.len", return_value=1)
+    def test_get_dns_challenges_already_valid(self, mock_len):
+        assert mock_len
+
+        from acme import challenges
+
+        host = "example.com"
+        c = challenges.DNS01()
+
+        mock_authz = MagicMock
+        mock_authz.body = STATUS_VALID
+        mock_authz.body.resolved_combinations = []
+        mock_entry = Mock()
+        mock_entry.chall = c
+        mock_authz.body.resolved_combinations.append(mock_entry)
+        result, hostname_still_validatd = yield self.acme.get_dns_challenges(host, mock_authz)
+        self.assertEqual(result, mock_entry)
+        self.assertTrue(hostname_still_validatd)
+
     @patch("acme.client.Client")
     @patch("lemur.plugins.lemur_acme.plugin.len", return_value=1)
     @patch("lemur.plugins.lemur_acme.plugin.AcmeDnsHandler.get_dns_challenges")

--- a/lemur/plugins/lemur_acme/tests/test_acme_dns.py
+++ b/lemur/plugins/lemur_acme/tests/test_acme_dns.py
@@ -51,8 +51,9 @@ class TestAcmeDns(unittest.TestCase):
         mock_entry = Mock()
         mock_entry.chall = c
         mock_authz.body.resolved_combinations.append(mock_entry)
-        result = yield self.acme.get_dns_challenges(host, mock_authz)
+        result, hostname_still_validated = yield self.acme.get_dns_challenges(host, mock_authz)
         self.assertEqual(result, mock_entry)
+        self.assertFalse(hostname_still_validated)
 
     @patch("acme.client.Client")
     @patch("lemur.plugins.lemur_acme.plugin.len", return_value=1)


### PR DESCRIPTION
Lemur's ACME DNS plugin was not considering already valid hostnames, and repeating the expensive DNS domain ownership validation. This improvement would allow the ACME DNS to benefit from still valid hostnames.