### PR TITLE
Warning logs for admin role assignment and authority creation

### DIFF
--- a/lemur/authorities/service.py
+++ b/lemur/authorities/service.py
@@ -11,6 +11,8 @@
 
 import json
 
+from flask import current_app
+
 from lemur import database
 from lemur.common.utils import truthiness, data_encrypt
 from lemur.extensions import metrics
@@ -154,6 +156,10 @@ def create(**kwargs):
     kwargs["creator"].authorities.append(authority)
 
     log_service.audit_log("create_authority", ca_name, "Created new authority")
+
+    issuer = kwargs["plugin"]["plugin_object"]
+    current_app.logger.warning(f"Created new authority {ca_name} with issuer {issuer.title}")
+
     metrics.send(
         "authority_created", "counter", 1, metric_tags=dict(owner=authority.owner)
     )

--- a/lemur/roles/service.py
+++ b/lemur/roles/service.py
@@ -24,7 +24,7 @@ def warn_user_updates(role_name, current_users, new_users):
 
     added_users = list(u.username for u in set(new_users) - set(current_users))
     if added_users:
-        current_app.logger.warning(f"Added {role_name} role for {removed_users}")
+        current_app.logger.warning(f"Added {role_name} role for {added_users}")
 
 
 def update(role_id, name, description, users):

--- a/lemur/users/service.py
+++ b/lemur/users/service.py
@@ -7,6 +7,8 @@
     :license: Apache, see LICENSE for more details.
 .. moduleauthor:: Kevin Glisson <kglisson@netflix.com>
 """
+from flask import current_app
+
 from lemur import database
 from lemur.logs import service as log_service
 from lemur.users.models import User
@@ -76,6 +78,8 @@ def update_roles(user, roles):
         else:
             user.roles.remove(ur)
             removed_roles.append(ur.name)
+            if ur.name == 'admin':
+                current_app.logger.warning(f"Removing admin role for {user.username}")
 
     if removed_roles:
         log_service.audit_log("unassign_role", user.username, f"Un-assigning roles {removed_roles}")
@@ -88,6 +92,8 @@ def update_roles(user, roles):
         else:
             user.roles.append(r)
             added_roles.append(r.name)
+            if r.name == 'admin':
+                current_app.logger.warning(f"{user.username} added as admin")
 
     if added_roles:
         log_service.audit_log("assign_role", user.username, f"Assigning roles {added_roles}")


### PR DESCRIPTION
Warning logs in addition to existing audit logs to highlight some important events like 
1. Adding admin role (via role edit or user edit)
2. Removing admin role (via role edit or user edit)
3. New authority creation