### PR TITLE
Deduplicate domains table

### DIFF
--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -169,7 +169,10 @@ class Certificate(db.Model):
     sources = relationship(
         "Source", secondary=certificate_source_associations, backref="certificate"
     )
+
+    # This is set by default, do we need to update it?
     domains = association_proxy('certificate_associations', 'domain')
+
     roles = relationship("Role", secondary=roles_certificates, backref="certificate")
     replaces = relationship(
         "Certificate",
@@ -242,7 +245,11 @@ class Certificate(db.Model):
         self.dns_provider_id = kwargs.get("dns_provider_id")
 
         for domain in defaults.domains(cert):
+            # Currently, this creates a new Domain object for each domain, and a new association for each.
             self.domains.append(Domain(name=domain))
+
+            # New Logic
+            # Create a new association with existing Domain if it exists, otherwise, create a new Domain.
 
         # Check integrity before saving anything into the database.
         # For user-facing API calls, validation should also be done in schema validators.

--- a/lemur/database.py
+++ b/lemur/database.py
@@ -150,7 +150,8 @@ def get_all(model, value, field="id"):
     query = session_query(model)
     return query.filter(get_model_column(model, field) == value)
 
-def get_all_sorted(model, value, field="id", sort_by="id", sort_dir="asc" ):
+
+def get_all_sorted(model, value, field="id", sort_by="id", sort_dir="asc"):
     """
     Returns query object with the fields and value filtered and sorted
 

--- a/lemur/database.py
+++ b/lemur/database.py
@@ -150,6 +150,23 @@ def get_all(model, value, field="id"):
     query = session_query(model)
     return query.filter(get_model_column(model, field) == value)
 
+def get_all_sorted(model, value, field="id", sort_by="id", sort_dir="asc" ):
+    """
+    Returns query object with the fields and value filtered and sorted
+
+    :param model:
+    :param value:
+    :param field:
+    :param sort_by:
+    :param sort_dir:
+    :return:
+    """
+    query = session_query(model)
+    column = get_model_column(model, field) == value
+    query = query.filter(column)
+    query = sort(query, model, sort_by, sort_dir)
+    return query
+
 
 def create(model):
     """

--- a/lemur/domains/service.py
+++ b/lemur/domains/service.py
@@ -42,6 +42,7 @@ def get_by_name(name):
     """
     return database.get_all(Domain, name, field="name").all()
 
+
 def get_by_name_sorted_by_id(name, sort_dir="asc"):
     """
     Fetches domain by its name

--- a/lemur/domains/service.py
+++ b/lemur/domains/service.py
@@ -42,6 +42,16 @@ def get_by_name(name):
     """
     return database.get_all(Domain, name, field="name").all()
 
+def get_by_name_sorted_by_id(name, sort_dir="asc"):
+    """
+    Fetches domain by its name
+
+    :param name:
+    :param sort_dir:
+    :return:
+    """
+    return database.get_all_sorted(Domain, name, field="name", sort_by="id", sort_dir=sort_dir).all()
+
 
 def is_domain_sensitive(name):
     """
@@ -65,6 +75,10 @@ def create(name, sensitive):
     :param sensitive:
     :return:
     """
+    domain = get_by_name(name)
+    if domain:
+        return domain
+
     domain = Domain(name=name, sensitive=sensitive)
     return database.create(domain)
 

--- a/lemur/migrations/versions/614f0f51b553_.py
+++ b/lemur/migrations/versions/614f0f51b553_.py
@@ -1,0 +1,89 @@
+"""This Database upgrade will make the domains table unique and is required fro future versions of Lemur.
+
+Revision ID: 614f0f51b553
+Revises: 4fe230f7a26e
+Create Date: 2021-06-22 23:22:30.078483
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '614f0f51b553'
+down_revision = '4fe230f7a26e'
+
+import datetime
+import time
+from logging import Formatter, FileHandler, getLogger
+
+from alembic import op
+from flask import current_app
+from sqlalchemy.sql import text
+
+log = getLogger(__name__)
+handler = FileHandler(current_app.config.get("LOG_UPGRADE_FILE", "db_upgrade.log"))
+handler.setFormatter(
+    Formatter(
+        "%(asctime)s %(levelname)s: %(message)s " "[in %(pathname)s:%(lineno)d]"
+    )
+)
+handler.setLevel(current_app.config.get("LOG_LEVEL", "DEBUG"))
+log.setLevel(current_app.config.get("LOG_LEVEL", "DEBUG"))
+log.addHandler(handler)
+
+
+def upgrade():
+    log.info("\n*** Starting DB upgrade(%s) ***\n" % datetime.datetime.now())
+    start_time = time.time()
+
+    # Do Upgrade
+    dedup_domains_table()
+
+    log.info("---Upgrade Complete - Total %s seconds ---\n" % (time.time() - start_time))
+
+
+def downgrade():
+    log.info("\n*** Request to downgrade at (%s) ***\n" % datetime.datetime.now())
+    log.info("It is not possible to downgrade this change since duplicated domains were already deleted.")
+    log.info("If you need to restore the duplicated domains for some reason, you will need to restore from backup.")
+
+
+def dedup_domains_table():
+    conn = op.get_bind()
+
+    # Loop through all domains and get a list of them by count
+    for name, count in conn.execute(text(
+            "SELECT name,count(*) FROM domains GROUP BY name HAVING COUNT(*) > 1 ORDER BY count(*) DESC")):
+
+        # Find all duplicates for each domain.
+        id = False
+        sensitive = False
+        for cur_id, _, cur_sensitive in conn.execute(text(
+                f"SELECT id, name, sensitive FROM domains WHERE name = {name} ORDER BY id ASC")):
+
+            #  Keep only the first one (lowest id number), and update the rest
+            if id == False:
+                id = cur_id
+                sensitive = cur_sensitive
+            else:
+                if sensitive != cur_sensitive:
+                    log.error(
+                        f"Error in domain deduplication. {name} has conflicting sensitivities in domains table.  Fix these and run again.")
+                    return
+
+                # Update association to point to single domain entry
+                conn.execute(
+                    text(
+                        f"UPDATE certificate_associations SET domain_id = {id} WHERE domain_id = {cur_id}"
+                    )
+                )
+                # Delete current domain entry
+                conn.execute(
+                    text(
+                        f"DELETE FROM domains WHERE id = {cur_id}"
+                    )
+                )
+    # Update the Schema so the domains table has unique names
+    conn.execute(
+        text(
+            "ALTER TABLE domains ADD UNIQUE(name)"
+        )
+    )

--- a/lemur/migrations/versions/614f0f51b553_.py
+++ b/lemur/migrations/versions/614f0f51b553_.py
@@ -51,12 +51,12 @@ def dedup_domains_table():
 
     # Loop through all domains and get a list of them by count
     for name, count in conn.execute(text(
-            "SELECT name,count(*) FROM domains GROUP BY name HAVING COUNT(*) > 1 ORDER BY count(*) DESC")):
+            "SELECT name,count(*) FROM domains GROUP BY name HAVING COUNT(*) > 1 ORDER BY count(*) ASC")):
 
         # Find all duplicates for each domain.
         domain_id = False
         sensitive = False
-        stmt = text("SELECT domain_id, name, sensitive FROM domains WHERE name=:name ORDER BY domain_id ASC")
+        stmt = text("SELECT id, name, sensitive FROM domains WHERE name=:name ORDER BY id ASC")
         stmt = stmt.bindparams(name=name)
         for cur_id, _, cur_sensitive in conn.execute(stmt):
 
@@ -80,12 +80,12 @@ def dedup_domains_table():
                 # Delete current domain entry
                 conn.execute(
                     text(
-                        "DELETE FROM domains WHERE domain_id=:cur_id"
+                        "DELETE FROM domains WHERE id=:cur_id"
                     ).bindparams(cur_id=cur_id)
                 )
-    # Update the Schema so the domains table has unique names
-    conn.execute(
-        text(
-            "ALTER TABLE domains ADD UNIQUE(name)"
-        )
-    )
+                commit()
+
+
+def commit():
+    stmt = text("commit")
+    op.execute(stmt)

--- a/lemur/migrations/versions/614f0f51b553_.py
+++ b/lemur/migrations/versions/614f0f51b553_.py
@@ -1,4 +1,4 @@
-"""This Database upgrade will make the domains table unique and is required fro future versions of Lemur.
+"""This Database upgrade will make the domains table unique and is required for future versions of Lemur.
 
 Revision ID: 614f0f51b553
 Revises: 4fe230f7a26e


### PR DESCRIPTION
Background: Whenever a new certificate is minted, every domain in the CN and SANs fields are written as new entries in the domains table.  This has let to hundreds and even thousands of duplicate domains listed in the domains table which slows down queries and leads to table bloat.

This change changes the way that new entries are added to the domains table.  First, it is searched for the current domain, and if found, an association is created with the lowest id.  This change will work even if the next step is not performed, but is not ideal. A new db migration script has been created which will "de-dup" the domains table and update the certificate associations.  This script, however, runs in series and if the table contains many entries, may take days or even weeks to complete.  A better migration/update script may be needed for larger Lemur installations.
