### PR TITLE
Add the ability to exclude certs belonging to specific owners for the deployed expiring cert check

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -602,6 +602,15 @@ The following configuration options are supported:
 
           LEMUR_DEPLOYED_CERTIFICATE_CHECK_EXCLUDED_DOMAINS = ['excluded.com']
 
+.. data:: LEMUR_DEPLOYED_CERTIFICATE_CHECK_EXCLUDED_OWNERS
+    :noindex:
+
+       Specifies a set of owners to exclude from the deployed certificate checks. Anything specified here is treated as an exact match, NOT as a substring.
+
+       ::
+
+          LEMUR_DEPLOYED_CERTIFICATE_CHECK_EXCLUDED_OWNERS = ['excludedowner@example.com']
+
 
 .. data:: LEMUR_REISSUE_NOTIFICATION_EXCLUDED_DESTINATIONS
     :noindex:

--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -1047,10 +1047,18 @@ def is_duplicate(matching_cert, compare_to):
 @manager.option(
     "-e",
     "--exclude",
-    dest="exclude",
+    dest="exclude_domains",
     action="append",
     default=[],
     help="Domains that should be excluded from check.",
+)
+@manager.option(
+    "-eo",
+    "--exclude-owners",
+    dest="exclude_owners",
+    action="append",
+    default=[],
+    help="Owners that should be excluded from check.",
 )
 @manager.option(
     "-c",
@@ -1060,10 +1068,10 @@ def is_duplicate(matching_cert, compare_to):
     default=False,
     help="Persist changes.",
 )
-def identify_expiring_deployed_certificates(exclude, commit):
+def identify_expiring_deployed_certificates(exclude_domains, exclude_owners, commit):
     status = FAILURE_METRIC_STATUS
     try:
-        identify_and_persist_expiring_deployed_certificates(exclude, commit)
+        identify_and_persist_expiring_deployed_certificates(exclude_domains, exclude_owners, commit)
         status = SUCCESS_METRIC_STATUS
     except Exception:
         capture_exception()

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -1087,7 +1087,8 @@ def remove_destination_association(certificate, destination):
     )
 
 
-def identify_and_persist_expiring_deployed_certificates(exclude_domains, exclude_owners, commit, timeout_seconds_per_network_call=1):
+def identify_and_persist_expiring_deployed_certificates(exclude_domains, exclude_owners, commit,
+                                                        timeout_seconds_per_network_call=1):
     """
     Finds all certificates expiring soon but are still being used for TLS at any domain with which they are associated.
     Identified ports will then be persisted on the certificate_associations row for the given cert/domain combo.

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -1087,7 +1087,7 @@ def remove_destination_association(certificate, destination):
     )
 
 
-def identify_and_persist_expiring_deployed_certificates(exclude, commit, timeout_seconds_per_network_call=1):
+def identify_and_persist_expiring_deployed_certificates(exclude_domains, exclude_owners, commit, timeout_seconds_per_network_call=1):
     """
     Finds all certificates expiring soon but are still being used for TLS at any domain with which they are associated.
     Identified ports will then be persisted on the certificate_associations row for the given cert/domain combo.
@@ -1095,14 +1095,14 @@ def identify_and_persist_expiring_deployed_certificates(exclude, commit, timeout
     Note that this makes actual TLS network calls in order to establish the "deployed" part of this check.
     """
     all_certs = defaultdict(dict)
-    for c in get_certs_for_expiring_deployed_cert_check(exclude):
-        domains_for_cert = find_and_persist_domains_where_cert_is_deployed(c, exclude, commit,
+    for c in get_certs_for_expiring_deployed_cert_check(exclude_domains, exclude_owners):
+        domains_for_cert = find_and_persist_domains_where_cert_is_deployed(c, exclude_domains, commit,
                                                                            timeout_seconds_per_network_call)
         if len(domains_for_cert) > 0:
             all_certs[c] = domains_for_cert
 
 
-def get_certs_for_expiring_deployed_cert_check(exclude):
+def get_certs_for_expiring_deployed_cert_check(exclude_domains, exclude_owners):
     threshold_days = current_app.config.get("LEMUR_EXPIRING_DEPLOYED_CERT_THRESHOLD_DAYS", 14)
     max_not_after = arrow.utcnow().shift(days=+threshold_days).format("YYYY-MM-DD")
 
@@ -1115,9 +1115,15 @@ def get_certs_for_expiring_deployed_cert_check(exclude):
     )
 
     exclude_conditions = []
-    if exclude:
-        for e in exclude:
+    if exclude_domains:
+        for e in exclude_domains:
             exclude_conditions.append(~Certificate.name.ilike("%{}%".format(e)))
+
+        q = q.filter(and_(*exclude_conditions))
+
+    if exclude_owners:
+        for e in exclude_owners:
+            exclude_conditions.append(~Certificate.owner.ilike("{}".format(e)))
 
         q = q.filter(and_(*exclude_conditions))
 
@@ -1189,7 +1195,7 @@ def get_expiring_deployed_certificates(exclude=None):
     :return: A dictionary with owner as key, and a list of certificates associated with domains/ports.
     """
     certs_domains_and_ports = defaultdict(dict)
-    for certificate in get_certs_for_expiring_deployed_cert_check(exclude):
+    for certificate in get_certs_for_expiring_deployed_cert_check(exclude, None):
         matched_domains = defaultdict(list)
         for cert_association in [assoc for assoc in certificate.certificate_associations if assoc.ports]:
             matched_domains[cert_association.domain.name] = cert_association.ports

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -1100,9 +1100,10 @@ def identity_expiring_deployed_certificates():
 
     current_app.logger.debug(log_data)
     try:
-        exclude = current_app.config.get("LEMUR_DEPLOYED_CERTIFICATE_CHECK_EXCLUDED_DOMAINS", [])
+        exclude_domains = current_app.config.get("LEMUR_DEPLOYED_CERTIFICATE_CHECK_EXCLUDED_DOMAINS", [])
+        exclude_owners = current_app.config.get("LEMUR_DEPLOYED_CERTIFICATE_CHECK_EXCLUDED_OWNERS", [])
         commit = current_app.config.get("LEMUR_DEPLOYED_CERTIFICATE_CHECK_COMMIT_MODE", False)
-        cli_certificate.identify_expiring_deployed_certificates(exclude, commit)
+        cli_certificate.identify_expiring_deployed_certificates(exclude_domains, exclude_owners, commit)
     except SoftTimeLimitExceeded:
         log_data["message"] = "Time limit exceeded."
         current_app.logger.error(log_data)

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -1461,12 +1461,14 @@ def test_identify_and_persist_expiring_deployed_certificates():
     In this test, the serial number is always the same, since it's parsed from the hardcoded test cert.
     """
 
-    # one non-expiring cert, two expiring certs, one cert that doesn't match a running server, and one cert using an excluded domain
+    # one non-expiring cert, two expiring certs, one cert that doesn't match a running server,
+    # one cert using an excluded domain, and one cert belonging to an excluded owner.
     cert_1 = create_cert_that_expires_in_days(180, domains=[Domain(name='localhost')], owner='testowner1@example.com')
     cert_2 = create_cert_that_expires_in_days(10, domains=[Domain(name='localhost')], owner='testowner2@example.com')
     cert_3 = create_cert_that_expires_in_days(10, domains=[Domain(name='localhost')], owner='testowner3@example.com')
     cert_4 = create_cert_that_expires_in_days(10, domains=[Domain(name='not-localhost')], owner='testowner4@example.com')
     cert_5 = create_cert_that_expires_in_days(10, domains=[Domain(name='abc.excluded.com')], owner='testowner5@example.com')
+    cert_6 = create_cert_that_expires_in_days(10, domains=[Domain(name='localhost')], owner='excludedowner@example.com')
 
     # test certs are all hardcoded with the same body/chain so we don't need to use the created cert here
     cert_file_data = SAN_CERT_STR + INTERMEDIATE_CERT_STR + ROOTCA_CERT_STR + SAN_CERT_KEY
@@ -1483,11 +1485,12 @@ def test_identify_and_persist_expiring_deployed_certificates():
             assert len(c.certificate_associations) == 1
             for ca in c.certificate_associations:
                 assert ca.ports is None
-        identify_and_persist_expiring_deployed_certificates(['excluded.com'], True)
-        for c in [cert_1, cert_5]:
+        identify_and_persist_expiring_deployed_certificates(['excluded.com'], ['excludedowner@example.com'], True)
+        for c in [cert_1, cert_5, cert_6]:
             assert len(c.certificate_associations) == 1
             for ca in c.certificate_associations:
-                assert ca.ports is None  # cert_1 is not expiring, cert_5 is excluded, so neither should be update
+                assert ca.ports is None  # cert_1 is not expiring, cert_5 is excluded by domain,
+                # and cert_6 is excluded by owner, so none of them should be updated
         for c in [cert_4]:
             assert len(c.certificate_associations) == 1
             for ca in c.certificate_associations:


### PR DESCRIPTION
In addition to the existing ability to exclude specific domains, this adds the ability to exclude certs based on owner. This is an alternative way to skip this check if specific owner need to be excluded.