### PR TITLE
Make some changes to the asynchronous reissue notification logic to avoid passing a Certificate directly

### DIFF
--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -515,7 +515,7 @@ def create(**kwargs):
         from lemur.common.celery import fetch_acme_cert
 
         if not current_app.config.get("ACME_DISABLE_AUTORESOLVE", False):
-            fetch_acme_cert.apply_async((pending_cert.id, kwargs.get("async_reissue_notification_cert", None)), countdown=5)
+            fetch_acme_cert.apply_async(pending_cert.id, countdown=5)
 
     return cert
 
@@ -927,10 +927,6 @@ def reissue_certificate(certificate, notify=None, replace=None, user=None):
 
     if (certificate.owner in ecc_reissue_owner_list) and (certificate.cn not in ecc_reissue_exclude_cn_list):
         primitives["key_type"] = "ECCPRIME256V1"
-
-    # allow celery to send notifications for PendingCertificates using the old cert
-    if notify:
-        primitives["async_reissue_notification_cert"] = certificate
 
     new_cert = create(**primitives)
 

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -232,13 +232,12 @@ def report_revoked_task(**kwargs):
 
 
 @celery.task(soft_time_limit=600)
-def fetch_acme_cert(id, notify_reissue_cert=None):
+def fetch_acme_cert(id):
     """
     Attempt to get the full certificate for the pending certificate listed.
 
     Args:
         id: an id of a PendingCertificate
-        notify_reissue_cert: existing Certificate to use for reissue notifications, if supplied
     """
     task_id = None
     if celery.current_task:
@@ -299,8 +298,8 @@ def fetch_acme_cert(id, notify_reissue_cert=None):
             pending_certificate_service.update(
                 cert.get("pending_cert").id, resolved=True
             )
-            if notify_reissue_cert is not None:
-                send_reissue_no_endpoints_notification(notify_reissue_cert, final_cert)
+            if real_cert.replaces is not None:
+                send_reissue_no_endpoints_notification(real_cert.replaces, final_cert)
             # add metrics to metrics extension
             new += 1
         else:
@@ -316,7 +315,7 @@ def fetch_acme_cert(id, notify_reissue_cert=None):
                 send_pending_failure_notification(
                     pending_cert, notify_owner=pending_cert.notify
                 )
-                if notify_reissue_cert is not None:
+                if pending_cert.replaces is not None:
                     send_reissue_failed_notification(pending_cert)
                 # Mark the pending cert as resolved
                 pending_certificate_service.update(
@@ -328,7 +327,7 @@ def fetch_acme_cert(id, notify_reissue_cert=None):
                     cert.get("pending_cert").id, status=str(cert.get("last_error"))
                 )
                 # Add failed pending cert task back to queue
-                fetch_acme_cert.delay(id, notify_reissue_cert)
+                fetch_acme_cert.delay(id)
             current_app.logger.error(error_log)
     log_data["message"] = "Complete"
     log_data["new"] = new

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -298,7 +298,7 @@ def fetch_acme_cert(id):
             pending_certificate_service.update(
                 cert.get("pending_cert").id, resolved=True
             )
-            if real_cert.replaces is not None:
+            if real_cert.notify and real_cert.replaces is not None:
                 send_reissue_no_endpoints_notification(real_cert.replaces, final_cert)
             # add metrics to metrics extension
             new += 1
@@ -315,7 +315,7 @@ def fetch_acme_cert(id):
                 send_pending_failure_notification(
                     pending_cert, notify_owner=pending_cert.notify
                 )
-                if pending_cert.replaces is not None:
+                if pending_cert.notify and pending_cert.replaces is not None:
                     send_reissue_failed_notification(pending_cert)
                 # Mark the pending cert as resolved
                 pending_certificate_service.update(


### PR DESCRIPTION
With the existing code, we were seeing errors `TypeError: Object of type Certificate is not JSON serializable`. It looks like passing the `Certificate` directly to Celery wasn't working as intended. Instead, I'm refactoring the code to look up the replaced cert at notification time (when the `PendingCertificate` is resolved).