### PR TITLE
Revert fetch_acme_cert to use old syntax

### DIFF
--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -515,7 +515,7 @@ def create(**kwargs):
         from lemur.common.celery import fetch_acme_cert
 
         if not current_app.config.get("ACME_DISABLE_AUTORESOLVE", False):
-            fetch_acme_cert.apply_async((pending_cert.id, None), countdown=5)
+            fetch_acme_cert.apply_async((pending_cert.id,), countdown=5)
 
     return cert
 


### PR DESCRIPTION
Another followup to #3680; reverts to syntax used prior to #3654: https://github.com/Netflix/lemur/pull/3654/files#diff-6cdb5b288be1b6c86d89080b40e8d2398ce8f85c355c7393cbd6017f00744864L507