### PR TITLE
Fix sqlalchemy import alias in DB migration file

### DIFF
--- a/lemur/migrations/versions/3097d57f3f0b_.py
+++ b/lemur/migrations/versions/3097d57f3f0b_.py
@@ -20,7 +20,7 @@ def upgrade():
         'certificates',
         ['root_authority_id'],
         unique=False,
-        postgresql_where=sqlalchemy.text("root_authority_id IS NOT NULL"))
+        postgresql_where=sa.text("root_authority_id IS NOT NULL"))
     op.create_index(
         'certificate_associations_certificate_id_idx',
         'certificate_associations',


### PR DESCRIPTION
`sqlalchemy` is imported as the alias `sa`, but is reference in the migration using `sqlalchemy`. As a result, running `lemur db upgrade` from master against a 0.10.0 Lemur instance fails.