### PR TITLE
Updating cffi package across all requirements to help Dependabot

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -83,7 +83,7 @@ certifi==2021.5.30
     #   sentry-sdk
 certsrv==2.1.1
     # via -r requirements-docs.in
-cffi==1.14.5
+cffi==1.14.6
     # via
     #   -r requirements-tests.txt
     #   bcrypt

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -36,7 +36,7 @@ certbot==1.16.0
     # via -r requirements-tests.in
 certifi==2021.5.30
     # via requests
-cffi==1.14.5
+cffi==1.14.6
     # via cryptography
 cfn-lint==0.50.0
     # via moto

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ certifi==2021.5.30
     #   sentry-sdk
 certsrv==2.1.1
     # via -r requirements.in
-cffi==1.14.5
+cffi==1.14.6
     # via
     #   bcrypt
     #   cryptography


### PR DESCRIPTION
Dependabot failed to upgrade cffi across all requirements, and ran into inconsistencies for

[Bump twine from 3.4.1 to 3.4.2](https://github.com/Netflix/lemur/pull/3698) 

[Bump requests from 2.25.1 to 2.26.0](https://github.com/Netflix/lemur/pull/3688)

[Bump invoke from 1.5.0 to 1.6.0](https://github.com/Netflix/lemur/pull/3676)

