### PR TITLE
Digicert Session re-init after wrong header issues

### DIFF
--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -347,6 +347,13 @@ class DigiCertIssuerPlugin(IssuerPlugin):
             }
         )
 
+        # max_retries applies only to failed DNS lookups, socket connections and connection timeouts,
+        # never to requests where data has made it to the server.
+        # we Retry we also covers HTTP status code 400, 406, 500, 502, 503, 504
+        retry_strategy = Retry(total=3, backoff_factor=0.1, status_forcelist=[400, 406, 500, 502, 503, 504])
+        adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
+        self.session.mount("https://", adapter)
+
         self.session.hooks = dict(response=log_status_code)
 
         super(DigiCertIssuerPlugin, self).__init__(*args, **kwargs)
@@ -501,7 +508,7 @@ class DigiCertCISSourcePlugin(SourcePlugin):
 
         # max_retries applies only to failed DNS lookups, socket connections and connection timeouts,
         # never to requests where data has made it to the server.
-        # we Retry we also covers HTTP status code 500, 502, 503, 504
+        # we Retry we also covers HTTP status code 400, 406, 500, 502, 503, 504
         retry_strategy = Retry(total=3, backoff_factor=0.1, status_forcelist=[400, 406, 500, 502, 503, 504])
         adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
         self.session.mount("https://", adapter)
@@ -577,6 +584,13 @@ class DigiCertCISIssuerPlugin(IssuerPlugin):
         )
 
         self.session.hooks = dict(response=log_status_code)
+
+        # max_retries applies only to failed DNS lookups, socket connections and connection timeouts,
+        # never to requests where data has made it to the server.
+        # we Retry we also covers HTTP status code 400, 406, 500, 502, 503, 504
+        retry_strategy = Retry(total=3, backoff_factor=0.1, status_forcelist=[400, 406, 500, 502, 503, 504])
+        adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
+        self.session.mount("https://", adapter)
 
         super(DigiCertCISIssuerPlugin, self).__init__(*args, **kwargs)
 

--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -26,6 +26,7 @@ from lemur.extensions import metrics
 from lemur.plugins import lemur_digicert as digicert
 from lemur.plugins.bases import IssuerPlugin, SourcePlugin
 from retrying import retry
+from requests.packages.urllib3.util.retry import Retry
 
 
 def log_status_code(r, *args, **kwargs):

--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -218,8 +218,8 @@ def handle_response(response):
 
 def reset_cis_session(session):
     """
-    The current session might be in a bad state with wrong headers. Let's attempt to update the session back the initial
-    state.
+    The current session might be in a bad state with wrong headers.
+    Let's attempt to update the session back to the initial state.
     :param session:
     :return:
     """
@@ -349,8 +349,8 @@ class DigiCertIssuerPlugin(IssuerPlugin):
 
         # max_retries applies only to failed DNS lookups, socket connections and connection timeouts,
         # never to requests where data has made it to the server.
-        # we Retry we also covers HTTP status code 400, 406, 500, 502, 503, 504
-        retry_strategy = Retry(total=3, backoff_factor=0.1, status_forcelist=[400, 406, 500, 502, 503, 504])
+        # we Retry we also covers HTTP status code 406, 500, 502, 503, 504
+        retry_strategy = Retry(total=3, backoff_factor=0.1, status_forcelist=[406, 500, 502, 503, 504])
         adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
         self.session.mount("https://", adapter)
 
@@ -508,8 +508,8 @@ class DigiCertCISSourcePlugin(SourcePlugin):
 
         # max_retries applies only to failed DNS lookups, socket connections and connection timeouts,
         # never to requests where data has made it to the server.
-        # we Retry we also covers HTTP status code 400, 406, 500, 502, 503, 504
-        retry_strategy = Retry(total=3, backoff_factor=0.1, status_forcelist=[400, 406, 500, 502, 503, 504])
+        # we Retry we also covers HTTP status code 406, 500, 502, 503, 504
+        retry_strategy = Retry(total=3, backoff_factor=0.1, status_forcelist=[406, 500, 502, 503, 504])
         adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
         self.session.mount("https://", adapter)
 
@@ -587,8 +587,8 @@ class DigiCertCISIssuerPlugin(IssuerPlugin):
 
         # max_retries applies only to failed DNS lookups, socket connections and connection timeouts,
         # never to requests where data has made it to the server.
-        # we Retry we also covers HTTP status code 400, 406, 500, 502, 503, 504
-        retry_strategy = Retry(total=3, backoff_factor=0.1, status_forcelist=[400, 406, 500, 502, 503, 504])
+        # we Retry we also covers HTTP status code 406, 500, 502, 503, 504
+        retry_strategy = Retry(total=3, backoff_factor=0.1, status_forcelist=[406, 500, 502, 503, 504])
         adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
         self.session.mount("https://", adapter)
 

--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -270,6 +270,7 @@ def get_cis_certificate(session, base_url, order_id):
     certificate_url = "{0}/platform/cis/certificate/{1}/download".format(base_url, order_id)
     session.headers.update({"Accept": "application/x-pkcs7-certificates"})
     response = session.get(certificate_url)
+    session.headers.pop("Accept")
     response_content = handle_cis_response(session, response)
 
     cert_chain_pem = convert_pkcs7_bytes_to_pem(response_content)
@@ -593,7 +594,6 @@ class DigiCertCISIssuerPlugin(IssuerPlugin):
         # retrieve certificate
         certificate_chain_pem = get_cis_certificate(self.session, base_url, data["id"])
 
-        self.session.headers.pop("Accept")
         end_entity = certificate_chain_pem[0]
         intermediate = certificate_chain_pem[1]
 

--- a/lemur/plugins/lemur_entrust/plugin.py
+++ b/lemur/plugins/lemur_entrust/plugin.py
@@ -4,6 +4,7 @@ import json
 import sys
 from flask import current_app
 from retrying import retry
+from requests.packages.urllib3.util.retry import Retry
 
 from lemur.constants import CRLReason
 from lemur.plugins import lemur_entrust as entrust
@@ -216,6 +217,14 @@ class EntrustIssuerPlugin(IssuerPlugin):
         self.session.auth = (user, password)
         self.session.hooks = dict(response=log_status_code)
         # self.session.config['keep_alive'] = False
+
+        # max_retries applies only to failed DNS lookups, socket connections and connection timeouts,
+        # never to requests where data has made it to the server.
+        # we Retry we also covers HTTP status code 500, 502, 503, 504
+        retry_strategy = Retry(total=3, backoff_factor=0.1, status_forcelist=[500, 502, 503, 504])
+        adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
+        self.session.mount("https://", adapter)
+
         super(EntrustIssuerPlugin, self).__init__(*args, **kwargs)
 
     def create_certificate(self, csr, issuer_options):
@@ -356,6 +365,14 @@ class EntrustSourcePlugin(SourcePlugin):
         self.session.cert = (cert_file, key_file)
         self.session.auth = (user, password)
         self.session.hooks = dict(response=log_status_code)
+
+        # max_retries applies only to failed DNS lookups, socket connections and connection timeouts,
+        # never to requests where data has made it to the server.
+        # we Retry we also covers HTTP status code 500, 502, 503, 504
+        retry_strategy = Retry(total=3, backoff_factor=0.1, status_forcelist=[500, 502, 503, 504])
+        adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
+        self.session.mount("https://", adapter)
+
         super(EntrustSourcePlugin, self).__init__(*args, **kwargs)
 
     def get_certificates(self, options, **kwargs):


### PR DESCRIPTION
This PR also improves the retry strategy. Before retries applied only to failed DNS lookups, socket connections and connection timeouts, but not to requests where data has made it to the server.
With the new retry strategy we also covers HTTP status code 400, 406, 500, 502, 503, 504.

This is also applied to Entrust Plugin

https://findwork.dev/blog/advanced-usage-python-requests-timeouts-retries-hooks/