### PR TITLE
server options only for sub-plugin options, not for option of type plugin

### DIFF
--- a/lemur/tests/test_schemas.py
+++ b/lemur/tests/test_schemas.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 from marshmallow.exceptions import ValidationError
 
@@ -56,3 +57,74 @@ def test_fetch_objects(session):
     with pytest.raises(ValidationError):
         data = {"name": "nah"}
         fetch_objects(Role, data)
+
+
+def test_plugin_input_schema(session):
+    from lemur.schemas import PluginInputSchema
+
+    input_data = {
+        "description": "Allow the uploading of certificates to Amazon S3",
+        "slug": "aws-s3",
+        "plugin_options": [
+            {
+                "name": "exportPlugin",
+                "type": "export-plugin",
+                "required": True,
+                "helpMessage": "Export plugin to use before sending data to destination.",
+                "value": {
+                    "title": "export",
+                    "description": "Exports a CSR",
+                    "slug": "openssl-csr",
+                    "route": "plugins"
+                }
+            },
+            {
+                "name": "bucket",
+                "type": "str",
+                "validation": "[0-9a-z.-]{3,63}",
+                "value": "nflx"
+            },
+            {
+                "name": "accountNumber",
+                "type": "str",
+                "required": True,
+                "value": "555555555555"
+            },
+        ],
+        "title": "AWS-S3"
+    }
+
+    data, errors = PluginInputSchema().load(input_data)
+
+    assert not errors
+    assert data
+    assert "plugin_object" in data
+
+    for plugin_option in data["plugin_options"]:
+        if "plugin" in plugin_option["type"]:
+            assert "plugin_object" in plugin_option["value"]
+        else:
+            assert "helpMessage" in plugin_option
+
+
+def test_plugin_input_schema_invalid_account_number(session):
+    from lemur.schemas import PluginInputSchema
+
+    input_data = {
+        "description": "Allow the uploading of certificates to Amazon S3",
+        "slug": "aws-s3",
+        "plugin_options": [
+            {
+                "name": "accountNumber",
+                "type": "str",
+                "required": True,
+                "value": "1234"  # invalid account number
+            },
+        ],
+        "title": "AWS-S3"
+    }
+
+    data, errors = PluginInputSchema().load(input_data)
+
+    assert errors
+    assert '\'accountNumber\' cannot be validated' in json.dumps(errors)


### PR DESCRIPTION
Creating a destination with Export Plugin is resulting in below error.
```
KeyError: 'plugin_object'
  at lemur.destinations.service.create(lemur/destinations/service.py:32)
```
I believe the changes #3570 are relevant to options of type other than plugin, otherwise later in the code it errors on missing plugin details like one above.