### PR TITLE
Membership plugin

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -872,33 +872,6 @@ For more information about how to use social logins, see: `Satellizer <https://g
 
             PING_AUTH_ENDPOINT = "https://<yourpingserver>/oauth2/authorize"
 
-.. data:: PING_USER_MEMBERSHIP_URL
-    :noindex:
-
-        An optional additional endpoint to learn membership details post the user validation.
-
-        ::
-
-            PING_USER_MEMBERSHIP_URL = "https://<yourmembershipendpoint>"
-
-.. data:: PING_USER_MEMBERSHIP_TLS_PROVIDER
-    :noindex:
-
-        A custom TLS session provider plugin name
-
-        ::
-
-            PING_USER_MEMBERSHIP_TLS_PROVIDER = "slug-name"
-
-.. data:: PING_USER_MEMBERSHIP_SERVICE
-    :noindex:
-
-        Membership service name used by PING_USER_MEMBERSHIP_TLS_PROVIDER to create a session
-
-        ::
-
-            PING_USER_MEMBERSHIP_SERVICE = "yourmembershipservice"
-
 .. data:: OAUTH2_SECRET
     :noindex:
 
@@ -1007,6 +980,15 @@ For more information about how to use social logins, see: `Satellizer <https://g
 
             GOOGLE_SECRET = "somethingsecret"
 
+.. data:: USER_MEMBERSHIP_PROVIDER
+    :noindex:
+
+        An optional plugin to provide membership details. Provide plugin slug here. Plugin is used post user validation
+        to update membership details in Lemur. Also, it is configured to provide APIs to validate user email, team email/DL.
+
+        ::
+
+            USER_MEMBERSHIP_PROVIDER = "<yourmembershippluginslug>"
 
 Metric Providers
 ~~~~~~~~~~~~~~~~

--- a/docs/developer/plugins/index.rst
+++ b/docs/developer/plugins/index.rst
@@ -287,6 +287,21 @@ The `ExportPlugin` object requires the implementation of one function::
     Support of various formats sometimes relies on external tools system calls. Always be mindful of sanitizing any input to these calls.
 
 
+Membership
+----------
+Membership plugin allows Lemur to learn and validate membership details from an external service. Currently the plugin is configured to
+support 3 APIs::
+
+    def does_principal_exist(self, principal_email):
+        raise NotImplementedError
+
+    def does_group_exist(self, group_email):
+        # check if a group (Team DL) exists
+
+    def retrieve_user_memberships(self, user_id):
+        # get a list of groups a user belongs to
+
+
 Custom TLS Provider
 -------------------
 

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -1209,3 +1209,13 @@ def get_expiring_deployed_certificates(exclude=None):
                                              key=lambda x: x[0].owner), lambda x: x[0].owner):
         certs_domains_and_ports_by_owner[owner] = list(owner_certs)
     return certs_domains_and_ports_by_owner
+
+
+def is_valid_owner(email):
+    user_membership_provider = plugins.get(current_app.config.get("USER_MEMBERSHIP_PROVIDER"))
+    if user_membership_provider is None:
+        # nothing to check since USER_MEMBERSHIP_PROVIDER is not configured
+        return true
+
+    # expecting owner to be an existing team DL
+    return user_membership_provider.does_group_exist(email)

--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -480,6 +480,9 @@ class CertificatesList(AuthenticatedResource):
            :statuscode 403: unauthenticated
 
         """
+        if not service.is_valid_owner(data["owner"]):
+            return dict(message=f"Invalid owner: check if email {data['owner']} exists as a Team DL"), 412
+
         role = role_service.get_by_name(data["authority"].owner)
 
         # all the authority role members should be allowed

--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -481,7 +481,7 @@ class CertificatesList(AuthenticatedResource):
 
         """
         if not service.is_valid_owner(data["owner"]):
-            return dict(message=f"Invalid owner: check if email {data['owner']} exists as a Team DL"), 412
+            return dict(message=f"Invalid owner: check if {data['owner']} is a valid group email. Individuals cannot be certificate owners."), 412
 
         role = role_service.get_by_name(data["authority"].owner)
 

--- a/lemur/plugins/bases/__init__.py
+++ b/lemur/plugins/bases/__init__.py
@@ -4,3 +4,4 @@ from .source import SourcePlugin  # noqa
 from .notification import NotificationPlugin, ExpirationNotificationPlugin  # noqa
 from .export import ExportPlugin  # noqa
 from .tls import TLSPlugin  # noqa
+from .membership import MembershipPlugin # noqa

--- a/lemur/plugins/bases/membership.py
+++ b/lemur/plugins/bases/membership.py
@@ -1,0 +1,28 @@
+"""
+.. module: lemur.plugins.bases.membership
+    :platform: Unix
+    :copyright: (c) 2021 by Netflix Inc., see AUTHORS for more
+    :license: Apache, see LICENSE for more details.
+
+.. moduleauthor:: Sayali Charhate <scharhate@netflix.com>
+"""
+from lemur.plugins.base import Plugin
+
+
+class MembershipPlugin(Plugin):
+    """
+    This is the base class for membership API providers.
+    """
+    type = "membership"
+
+    # check if principal exists as a user or a group (Team DL)
+    def does_principal_exist(self, principal_email):
+        raise NotImplementedError
+
+    # check if a group (Team DL) exists
+    def does_group_exist(self, group_email):
+        raise NotImplementedError
+
+    # get a list of groups a user belongs to
+    def retrieve_user_memberships(self, user_id):
+        raise NotImplementedError


### PR DESCRIPTION
Changing implementation from #3414 to use a plugin allowing it to be generic. As mentioned in #3414, we are unaware of the usage of this code across the community. Hopefully current change makes it more flexible. This PR also cleans up configs specifically introduced for #3414.

The membership plugin currently offers 3 APIs
```
    def does_principal_exist(self, principal_email):
        raise NotImplementedError

    def does_group_exist(self, group_email):
        # check if a group (Team DL) exists

    def retrieve_user_memberships(self, user_id):
        # get a list of groups a user belongs to
```

If provided `USER_MEMBERSHIP_PROVIDER `, the API `retrieve_user_memberships` is used to retrieve user memberships details to store in Lemur. This is the same old behavior which is now driven via plugin.

Additionally, certificate creation now validated owner, if provided `USER_MEMBERSHIP_PROVIDER`. Currently, it has form validation to ensure it is an email. The UI suggests it to be a team email, however there is no validation that the email is valid. Now the validation can be added `does_group_exist` API from membership plugin.