### PR TITLE
Entrust deactivate resiliency

### DIFF
--- a/lemur/plugins/lemur_entrust/plugin.py
+++ b/lemur/plugins/lemur_entrust/plugin.py
@@ -301,8 +301,8 @@ class EntrustIssuerPlugin(IssuerPlugin):
 
         # Let's first check the status of the certificate
         base_url = current_app.config.get("ENTRUST_URL")
-        deactivate_url = f"{base_url}/certificates/{certificate.external_id}"
-        response = self.session.get(deactivate_url)
+        status_url = f"{base_url}/certificates/{certificate.external_id}"
+        response = self.session.get(status_url)
 
         try:
             data = handle_response(response)

--- a/lemur/plugins/lemur_entrust/plugin.py
+++ b/lemur/plugins/lemur_entrust/plugin.py
@@ -306,7 +306,7 @@ class EntrustIssuerPlugin(IssuerPlugin):
 
         try:
             data = handle_response(response)
-        except:
+        except (ValueError, Exception):
             # if the certificate cannot be found, there is no need to deactivate it
             log_data['message'] = "No certificate found for the ID"
             current_app.logger.info(log_data)

--- a/lemur/plugins/lemur_entrust/plugin.py
+++ b/lemur/plugins/lemur_entrust/plugin.py
@@ -293,12 +293,33 @@ class EntrustIssuerPlugin(IssuerPlugin):
 
     @retry(stop_max_attempt_number=3, wait_fixed=1000)
     def deactivate_certificate(self, certificate):
-        """Deactivates an Entrust certificate."""
+        """Deactivates an Entrust certificate, as long as it is still active, and not already deactivcated. """
+        log_data = {
+            "function": f"{__name__}.{sys._getframe().f_code.co_name}",
+            "external_id": f"{certificate.external_id}"
+        }
+
+        # Let's first check the status of the certificate
         base_url = current_app.config.get("ENTRUST_URL")
-        deactivate_url = f"{base_url}/certificates/{certificate.external_id}/deactivations"
-        response = self.session.post(deactivate_url)
-        metrics.send("entrust_deactivate_certificate", "counter", 1)
-        return handle_response(response)
+        deactivate_url = f"{base_url}/certificates/{certificate.external_id}"
+        response = self.session.get(deactivate_url)
+
+        try:
+            data = handle_response(response)
+        except:
+            # if the certificate cannot be found, there is no need to deactivate it
+            log_data['message'] = "No certificate found for the ID"
+            current_app.logger.info(log_data)
+            return 200
+
+        if data and data['status'] == 'Active':
+            deactivate_url = f"{base_url}/certificates/{certificate.external_id}/deactivations"
+            response = self.session.post(deactivate_url)
+            metrics.send("entrust_deactivate_certificate", "counter", 1)
+            return handle_response(response)
+        else:
+            # the certificate is no longer valid, or doesn't exist and cannot be deacticated
+            return 200
 
     @staticmethod
     def create_authority(options):


### PR DESCRIPTION
In Entrust test environment, one can issue test certificates. However, each certificate needs to be deactivate to free up the certificate issuance quota.
This improvement catches the corner-cases of a certificate already having been deactivated, or when the certificate cannot be found.