### PR TITLE
Move Audit logs to JSON format

### DIFF
--- a/lemur/logs/service.py
+++ b/lemur/logs/service.py
@@ -24,11 +24,15 @@ def create(user, type, certificate=None):
     :param certificate:
     :return:
     """
-    current_app.logger.info(
-        "[lemur-audit] action: {0}, user: {1}, certificate: {2}.".format(
-            type, user.email, certificate.name
-        )
-    )
+    log_data = {
+        "function": "lemur-audit",
+        "action": type,
+        "user": user.email,
+        "certificate": certificate.name
+    }
+    # format before August 2021: f"[lemur-audit] action: {type}, user: {user.email}, certificate: {certificate.name}."
+    current_app.logger.info(log_data)
+
     view = Log(user_id=user.id, log_type=type, certificate_id=certificate.id)
     database.add(view)
     database.commit()
@@ -42,10 +46,17 @@ def audit_log(action, entity, message):
     :param message: Additional info e.g. Role being assigned to user X
     :return:
     """
+
     user = g.current_user.email if hasattr(g, 'current_user') else "LEMUR"
-    current_app.logger.info(
-        f"[lemur-audit] action: {action}, user: {user}, entity: {entity}, details: {message}"
-    )
+    log_data = {
+        "function": "lemur-audit",
+        "action": action,
+        "user": user,
+        "entity": entity,
+        "details": message
+    }
+    # format before August 2021: f"[lemur-audit] action: {action}, user: {user}, entity: {entity}, details: {message}"
+    current_app.logger.info(log_data)
 
 
 def get_all():


### PR DESCRIPTION
Are audit have historically been in text format, this changes audit logs to JSON format, which allows for better search. 