### PR TITLE
Acme remaining validation

### DIFF
--- a/lemur/plugins/lemur_acme/acme_handlers.py
+++ b/lemur/plugins/lemur_acme/acme_handlers.py
@@ -289,6 +289,7 @@ class AcmeHandler(object):
                 log_data['message'] = "already validated, skipping."
                 current_app.logger.info(log_data)
 
+
 class AcmeDnsHandler(AcmeHandler):
 
     def __init__(self):

--- a/lemur/plugins/lemur_acme/acme_handlers.py
+++ b/lemur/plugins/lemur_acme/acme_handlers.py
@@ -12,7 +12,7 @@
 .. moduleauthor:: Curtis Castrapel <ccastrapel@netflix.com>
 .. moduleauthor:: Mathias Petermann <mathias.petermann@projektfokus.ch>
 """
-import datetime
+from datetime import datetime, timezone, timedelta
 import json
 import time
 
@@ -93,7 +93,7 @@ class AcmeHandler(object):
             for authz in authorization.authz:
                 authorization_resource, _ = acme_client.poll(authz)
 
-        deadline = datetime.datetime.now() + datetime.timedelta(seconds=360)
+        deadline = datetime.now() + timedelta(seconds=360)
 
         try:
             orderr = acme_client.poll_authorizations(order, deadline)
@@ -119,6 +119,8 @@ class AcmeHandler(object):
 
         pem_certificate, pem_certificate_chain = self.extract_cert_and_chain(orderr.fullchain_pem,
                                                                              orderr.alternative_fullchains_pem)
+        acme_uri = acme_client.client.net.account.uri.replace('https://', '')
+        self.log_remaining_validation(orderr.authorizations, acme_uri)
 
         current_app.logger.debug(
             "{0} {1}".format(type(pem_certificate), type(pem_certificate_chain))
@@ -272,6 +274,20 @@ class AcmeHandler(object):
         metrics.send("acme_revoke_certificate_success", "counter", 1)
         return True
 
+    def log_remaining_validation(self, authorizations, acme_account):
+        for authz in authorizations:
+            if authz.body.status == STATUS_VALID:
+                log_data = {'type': authz.body.identifier.typ.name,
+                            'valid_hours':
+                                int((authz.body.expires - datetime.now(timezone.utc)).total_seconds() / 3600),
+                            'san': authz.body.identifier.value,
+                            'account': acme_account}
+                metrics.send("acme_authz_validation_status",
+                             "gauge",
+                             log_data['valid_hours'],
+                             metric_tags=log_data)
+                log_data['message'] = "already validated, skipping."
+                current_app.logger.info(log_data)
 
 class AcmeDnsHandler(AcmeHandler):
 
@@ -308,7 +324,10 @@ class AcmeDnsHandler(AcmeHandler):
             # skip valid challenge, as long as this challenge is for the domain_to_validate
             if authz.body.status == STATUS_VALID:
                 metrics.send("get_acme_challenges_already_valid", "counter", 1)
+                log_data = {"message": "already validated, skipping", "hostname": authz.body.identifier.value}
+                current_app.logger.info(log_data)
                 return [], True
+
             for combo in authz.body.challenges:
                 if isinstance(combo.chall, challenges.DNS01):
                     dns_challenges.append(combo)

--- a/lemur/plugins/lemur_acme/challenge_types.py
+++ b/lemur/plugins/lemur_acme/challenge_types.py
@@ -7,7 +7,7 @@
 
 .. moduleauthor:: Mathias Petermann <mathias.petermann@projektfokus.ch>
 """
-import datetime
+from datetime import datetime, timezone, timedelta
 import json
 
 from acme import challenges
@@ -100,7 +100,9 @@ class AcmeHttpChallenge(AcmeChallenge):
                     if isinstance(i.chall, challenges.HTTP01):
                         chall.append(i)
             else:
-                current_app.logger.info("{} already validated, skipping".format(authz.body.identifier.value))
+                metrics.send("get_acme_challenges_already_valid", "counter", 1)
+                log_data = {"message": "already validated, skipping", "hostname": authz.body.identifier.value}
+                current_app.logger.info(log_data)
 
         if len(chall) == 0 and not all_pre_validated:
             raise Exception('HTTP-01 challenge was not offered by the CA server at {}'.format(orderr.uri))
@@ -125,7 +127,7 @@ class AcmeHttpChallenge(AcmeChallenge):
             current_app.logger.info("Uploaded HTTP-01 challenge tokens, trying to poll and finalize the order")
 
         try:
-            deadline = datetime.datetime.now() + datetime.timedelta(seconds=90)
+            deadline = datetime.now() + timedelta(seconds=90)
             orderr = acme_client.poll_authorizations(orderr, deadline)
             finalized_orderr = acme_client.finalize_order(orderr, deadline, fetch_alternative_chains=True)
 
@@ -140,6 +142,8 @@ class AcmeHttpChallenge(AcmeChallenge):
 
         pem_certificate, pem_certificate_chain = self.acme.extract_cert_and_chain(finalized_orderr.fullchain_pem,
                                                                                   finalized_orderr.alternative_fullchains_pem)
+        acme_uri = acme_client.client.net.account.uri.replace('https://', '')
+        self.acme.log_remaining_validation(finalized_orderr.authorizations, acme_uri)
 
         if len(deployed_challenges) != 0:
             for token_path in deployed_challenges:

--- a/lemur/plugins/lemur_acme/challenge_types.py
+++ b/lemur/plugins/lemur_acme/challenge_types.py
@@ -7,7 +7,7 @@
 
 .. moduleauthor:: Mathias Petermann <mathias.petermann@projektfokus.ch>
 """
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
 import json
 
 from acme import challenges

--- a/lemur/plugins/lemur_acme/tests/test_acme_http.py
+++ b/lemur/plugins/lemur_acme/tests/test_acme_http.py
@@ -148,6 +148,7 @@ idWw1VrejtwclobqNMVtG3EiPUIpJGpbMcJgbiLSmKkrvQtGng==
 -----END CERTIFICATE-----
 """
         mock_finalized_order.alternative_fullchains_pem = [mock_finalized_order.fullchain_pem]
+        mock_finalized_order.authorizations = [Mock()]
         mock_client.finalize_order.return_value = mock_finalized_order
 
         mock_acme.return_value = (mock_client, "")


### PR DESCRIPTION
Emit metrics and log the remaining ACME validation per hostname.

Example log:
```
{'type': 'dns', 'valid_hours': 706, 'san': 'something.net, 'account': 'acme-staging-v02.api.letsencrypt.org/acme/acct/NUMBER', 'message': 'already validated, skipping.'}
```
Example metric:
```
metric [{"timestamp": 1629981908877, "type": "GAUGE", "name": "acme_authz_validation_status", "tags": {"type": "dns", "valid_hours": 706, "san": "something.net", "account": "acme-staging-v02.api.letsencrypt.org/acme/acct/NUMBER"}, "value": 706}]
```