### PR TITLE
[plugin/lemur_statsd] Upgrade datadog dependency to 0.42.0

### DIFF
--- a/lemur/plugins/lemur_statsd/docs/requirements.txt
+++ b/lemur/plugins/lemur_statsd/docs/requirements.txt
@@ -1,1 +1,1 @@
-datadog==0.14.0
+datadog==0.42.0

--- a/lemur/plugins/lemur_statsd/lemur_statsd/plugin.py
+++ b/lemur/plugins/lemur_statsd/lemur_statsd/plugin.py
@@ -37,7 +37,7 @@ class StatsdMetricPlugin(MetricPlugin):
                     "Invalid Metric Tags for Statsd: Tags must be in dict format"
                 )
             else:
-                tags = map(lambda e: "{0}:{1}".format(*e), metric_tags.items())
+                tags = list(map(lambda e: "{0}:{1}".format(*e), metric_tags.items()))
 
         if metric_type.upper() == "COUNTER":
             self.statsd.increment(metric_name, metric_value, tags)


### PR DESCRIPTION
The plugin was using an outdated version of datadog and was also broken.

Here is the error obtained by running the current code of this plugin:
```
ERROR:lemur:Request finalizing failed with an error while handling an error
Traceback (most recent call last):
  File "/opt/venv/lib/python3.8/site-packages/flask/app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "/opt/venv/lib/python3.8/site-packages/flask/app.py", line 1953, in full_dispatch_request
    return self.finalize_request(rv)
  File "/opt/venv/lib/python3.8/site-packages/flask/app.py", line 1970, in finalize_request
    response = self.process_response(response)
  File "/opt/venv/lib/python3.8/site-packages/ddtrace/contrib/flask/helpers.py", line 25, in wrapper
    return func(pin, wrapped, instance, args, kwargs)
  File "/opt/venv/lib/python3.8/site-packages/ddtrace/contrib/flask/helpers.py", line 36, in wrapper
    return wrapped(*args, **kwargs)
  File "/opt/venv/lib/python3.8/site-packages/flask/app.py", line 2267, in process_response
    response = handler(response)
  File "/opt/venv/lib/python3.8/site-packages/ddtrace/contrib/flask/wrappers.py", line 25, in trace_func
    return wrapped(*args, **kwargs)
  File "/opt/lemur/lemur/__init__.py", line 126, in after_request
    metrics.send("response_time", "TIMER", elapsed, metric_tags=tags)
  File "/opt/lemur/lemur/metrics.py", line 36, in send
    p.submit(metric_name, metric_type, metric_value, *args, **kwargs)
  File "/opt/lemur/lemur/plugins/lemur_statsd/lemur_statsd/plugin.py", line 47, in submit
    self.statsd.timing(metric_name, metric_value, tags)
  File "/opt/venv/lib/python3.8/site-packages/datadog/dogstatsd/base.py", line 458, in timing
    self._report(metric, "ms", value, tags, sample_rate)
  File "/opt/venv/lib/python3.8/site-packages/datadog/dogstatsd/base.py", line 576, in _report
    tags = self._add_constant_tags(tags)
  File "/opt/venv/lib/python3.8/site-packages/datadog/dogstatsd/base.py", line 781, in _add_constant_tags
    return tags + self.constant_tags
TypeError: unsupported operand type(s) for +: 'map' and 'list'
```