### PR TITLE
cert status check fix

### DIFF
--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -707,7 +707,10 @@ def check_revoked():
                 ocsp_err_count += ocsp_err
                 crl_err_count += crl_err
 
-                cert.status = "valid" if status else "revoked"
+                if status is None:
+                    cert.status = "unknown"
+                else:
+                    cert.status = "valid" if status else "revoked"
 
                 if cert.status == "revoked":
                     log_data["valid"] = cert.status

--- a/lemur/certificates/verify.py
+++ b/lemur/certificates/verify.py
@@ -73,8 +73,8 @@ def ocsp_verify(cert, cert_path, issuer_chain_path):
     if "unauthorized" in p_message:
         # indicates the OCSP server does not know this certificate
         metrics.send("check_revocation_ocsp_verify", "counter", 1, metric_tags={"status": "unauthorized", "url": url})
-        current_app.logger.warning(f"OCSP unauthorized error:{url}")
-        raise Exception(f"OCSP unauthorized error: {url}, certificate serial number {cert.serial_number:02X}")
+        raise Exception(f"OCSP unauthorized error: {url}, certificate serial number {cert.serial_number:02X}. Response:"
+                        f" {p_message}")
 
     elif "error" in p_message or "Error" in p_message:
         metrics.send("check_revocation_ocsp_verify", "counter", 1, metric_tags={"status": "error", "url": url})
@@ -83,7 +83,7 @@ def ocsp_verify(cert, cert_path, issuer_chain_path):
 
     elif "revoked" in p_message:
         current_app.logger.debug(
-            "OCSP reports certificate revoked: {}".format(cert.serial_number)
+            f"OCSP reports certificate revoked, serial number: {cert.serial_number:02X}"
         )
         return False
 


### PR DESCRIPTION
1. The unauthorized error from OCSP says `Responder Error: unauthorized (6)` which makes it enter the first if looking for `error`. Changing order to catch unauthorized ones separately.
2. When status could not be determined, [verify()](https://github.com/Netflix/lemur/blob/master/lemur/certificates/verify.py#L196) returns None (all exceptions are caught already, none thrown). Thus `cert.status = "valid" if status else "revoked"` does not look sufficient. This PR updates the status to unknown `if status is None:`