### PR TITLE
Add OAuth2 & Ping Config Params

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -858,6 +858,13 @@ For more information about how to use social logins, see: `Satellizer <https://g
 
             PING_CLIENT_ID = "client-id"
 
+.. data:: PING_URL
+    :noindex:
+
+        ::
+
+            PING_URL = "https://<yourlemurserver>"
+
 .. data:: PING_REDIRECT_URI
     :noindex:
 
@@ -914,6 +921,13 @@ For more information about how to use social logins, see: `Satellizer <https://g
         ::
 
             OAUTH2_CLIENT_ID = "client-id"
+
+.. data:: OAUTH2_URL
+    :noindex:
+
+        ::
+
+            OAUTH2_URL = "https://<yourlemurserver>"
 
 .. data:: OAUTH2_REDIRECT_URI
     :noindex:

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -994,6 +994,16 @@ For more information about how to use social logins, see: `Satellizer <https://g
 
             GOOGLE_SECRET = "somethingsecret"
 
+.. data:: TOKEN_AUTH_HEADER_CASE_SENSITIVE
+    :noindex:
+
+        This is an optional parameter to change the case sensitivity of the access token request authorization header.
+        This is required if the oauth provider has implemented the access token request authorization header in a case-sensitive way
+
+        ::
+
+            TOKEN_AUTH_HEADER_CASE_SENSITIVE = True
+
 .. data:: USER_MEMBERSHIP_PROVIDER
     :noindex:
 

--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -632,7 +632,7 @@ class Providers(Resource):
                 active_providers.append(
                     {
                         "name": current_app.config.get("PING_NAME"),
-                        "url": current_app.config.get("PING_REDIRECT_URI"),
+                        "url": current_app.config.get("PING_URL", current_app.config.get("PING_REDIRECT_URI")),
                         "redirectUri": current_app.config.get("PING_REDIRECT_URI"),
                         "clientId": current_app.config.get("PING_CLIENT_ID"),
                         "responseType": "code",
@@ -650,7 +650,7 @@ class Providers(Resource):
                 active_providers.append(
                     {
                         "name": current_app.config.get("OAUTH2_NAME"),
-                        "url": current_app.config.get("OAUTH2_REDIRECT_URI"),
+                        "url": current_app.config.get("OAUTH2_URL", current_app.config.get("OAUTH2_REDIRECT_URI")),
                         "redirectUri": current_app.config.get("OAUTH2_REDIRECT_URI"),
                         "clientId": current_app.config.get("OAUTH2_CLIENT_ID"),
                         "responseType": "code",

--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -65,7 +65,7 @@ def exchange_for_access_token(
     basic = base64.b64encode(bytes(token, "utf-8"))
     headers = {
         "Content-Type": "application/x-www-form-urlencoded",
-        "authorization": "basic {0}".format(basic.decode("utf-8")),
+        "Authorization": "Basic {0}".format(basic.decode("utf-8")),
     }
 
     # exchange authorization code for access token.

--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -64,9 +64,13 @@ def exchange_for_access_token(
 
     basic = base64.b64encode(bytes(token, "utf-8"))
     headers = {
-        "Content-Type": "application/x-www-form-urlencoded",
-        "Authorization": "Basic {0}".format(basic.decode("utf-8")),
+        "Content-Type": "application/x-www-form-urlencoded"
     }
+
+    if current_app.config.get("TOKEN_AUTH_HEADER_CASE_SENSITIVE"):
+        headers["Authorization"] = "Basic {0}".format(basic.decode("utf-8"))
+    else:
+        headers["authorization"] = "basic {0}".format(basic.decode("utf-8"))
 
     # exchange authorization code for access token.
     r = requests.post(


### PR DESCRIPTION
Relates to the following issue - https://github.com/Netflix/lemur/issues/3656

By adding the `PING_URL` and `OAUTH2_URL` params this addresses applications that have a separate front-end and back-end and need the `url` and `redirectUri` to have different parameter values for OAuth2 to function properly. Both params are defaulted to `PING_REDIRECT_URI` and `OAUTH2_REDIRECT_URI` to ensure backwards compatibility.

Also, added the `TOKEN_AUTH_HEADER_CASE_SENSITIVE` param to fix the issue if the oauth provider has implemented the access token request authorization header in a case-sensitive way. This has also been implemented to ensure backwards compatibility.