### PR TITLE
Fix decorator conflict

### DIFF
--- a/requirements-tests.in
+++ b/requirements-tests.in
@@ -4,6 +4,7 @@ bandit
 black
 coverage
 certbot
+decorator >= 5.1.0
 factory-boy
 Faker
 fakeredis


### PR DESCRIPTION
Trying to resolve this conflict showing up in Dependabot PRs:

```
Requirement already satisfied: coverage==5.5 in /home/travis/virtualenv/python3.7.6/lib/python3.7/site-packages (from lemur[tests]) (5.5)
ERROR: Cannot install lemur[tests]==develop because these package versions have conflicting dependencies.

The conflict is caused by:
    lemur[tests] develop depends on decorator==5.1.0
    lemur[tests] develop depends on decorator==4.4.2

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
Makefile:7: recipe for target 'develop' failed
make: *** [develop] Error 1
The command "make test" exited with 2.
```