### PR TITLE
Rename config property to make consistent with other properties

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -374,7 +374,7 @@ All eligible certificates are then grouped by owner and applicable notification.
 Lemur will send the expiration notification using whichever plugin was configured for that notification object.
 In addition, Lemur will send an email to the certificate owner and security team (as specified by the
 ``LEMUR_SECURITY_TEAM_EMAIL`` configuration parameter). The security team will be omitted if
-``DISABLE_SECURITY_TEAM_EXPIRATION_EMAILS`` is enabled.
+``LEMUR_DISABLE_SECURITY_TEAM_EXPIRATION_EMAILS`` is enabled.
 
 **CA certificate expiration**
 
@@ -550,14 +550,14 @@ The following configuration options are supported:
             LEMUR_SECURITY_TEAM_EMAIL = ['security@example.com']
 
 
-.. data:: DISABLE_SECURITY_TEAM_EXPIRATION_EMAILS
+.. data:: LEMUR_DISABLE_SECURITY_TEAM_EXPIRATION_EMAILS
     :noindex:
 
         This specifies whether or not LEMUR_SECURITY_TEAM_EMAIL will be included on all expiration emails. IMPORTANT: You will also need to disable the DEFAULT_SECURITY_X_DAY notifications to truly disable sending expiration emails to the security team. This double configuration is required for backwards compatibility.
 
         ::
 
-            DISABLE_SECURITY_TEAM_EXPIRATION_EMAILS = True
+            LEMUR_DISABLE_SECURITY_TEAM_EXPIRATION_EMAILS = True
 
 .. data:: LEMUR_DEFAULT_EXPIRATION_NOTIFICATION_INTERVALS
     :noindex:

--- a/lemur/notifications/cli.py
+++ b/lemur/notifications/cli.py
@@ -51,7 +51,7 @@ def expirations(exclude, disabled_notification_plugins):
     status = FAILURE_METRIC_STATUS
     try:
         print("Starting to notify subscribers about expiring certificates!")
-        disable_security_team_emails = current_app.config.get("DISABLE_SECURITY_TEAM_EXPIRATION_EMAILS", False)
+        disable_security_team_emails = current_app.config.get("LEMUR_DISABLE_SECURITY_TEAM_EXPIRATION_EMAILS", False)
         success, failed = send_expiration_notifications(exclude, disabled_notification_plugins, disable_security_team_emails)
         print(
             f"Finished notifying subscribers about expiring certificates! Sent: {success} Failed: {failed}"


### PR DESCRIPTION
Renaming to make this more consistent with existing behavior. This is a breaking change, but I assume nobody has had a chance to uptake the old property since I merged it an hour ago.