### PR TITLE
pip 21.3.1 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ endif
 	pip install "setuptools>=0.9.8"
 	# order matters here, base package must install first
 	pip install -e .
-	pip install "file://`pwd`#egg=lemur[dev]"
-	pip install "file://`pwd`#egg=lemur[tests]"
+	pip install -e "file://`pwd`#egg=lemur[dev]"
+	pip install -e "file://`pwd`#egg=lemur[tests]"
 	node_modules/.bin/gulp build
 	node_modules/.bin/gulp package --urlContextPath=$(urlContextPath)
 	@echo ""


### PR DESCRIPTION
```
DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
```

With pip 21.3.x, `make test` is failing in local with `ImportPathMismatchError` error
```
--> Running Python tests
coverage run --source lemur -m py.test
.
collected 0 items / 1 error  
.
 raise ImportPathMismatchError(module_name, module_file, path)
_pytest.pathlib.ImportPathMismatchError: ('lemur.tests.conftest', '/Users/xyz/lemur/build/lib/lemur/tests/conftest.py', PosixPath('/Users/xyz/lemur/lemur/tests/conftest.py'))
```

This can be reproduced with lower pip version by adding `--use-feature=in-tree-build` (as per suggestion by deprecation warning)

With `pip install -e`, it does not create additional `build/lib/` directory, which seems to be the cause of above issue.
