### PR TITLE
determine cert name before handling destination

### DIFF
--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -218,7 +218,6 @@ class Certificate(db.Model):
             self.csr = kwargs["csr"].strip()
 
         self.notify = kwargs.get("notify", True)
-        self.destinations = kwargs.get("destinations", [])
         self.notifications = kwargs.get("notifications", [])
         self.description = kwargs.get("description")
         self.roles = list(set(kwargs.get("roles", [])))
@@ -235,7 +234,8 @@ class Certificate(db.Model):
         for domain in defaults.domains(cert):
             self.domains.append(Domain(name=domain))
 
-        # when destinations are appended they require a valid name.
+        # when destinations are appended they require a valid name
+        # do not attempt to modify self.destinations before this step
         if kwargs.get("name"):
             self.name = get_or_increase_name(
                 defaults.text_to_slug(kwargs["name"]), self.serial
@@ -247,6 +247,8 @@ class Certificate(db.Model):
                 ),
                 self.serial,
             )
+
+        self.destinations = kwargs.get("destinations", [])
 
         # Check integrity before saving anything into the database.
         # For user-facing API calls, validation should also be done in schema validators.


### PR DESCRIPTION
[Cert upload ](https://github.com/Netflix/lemur/blob/master/lemur/certificates/models.py#L474)is tied to append on destinations. 
```
@event.listens_for(Certificate.destinations, "append")
def update_destinations(target, value, initiator):
```

Thus handle destination after determining certificate name. Else AWS plugin complains about cert name being None.
```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter ServerCertificateName, value: None, type: <class 'NoneType'>, valid types: <class 'str'>
  at botocore.validate.serialize_to_request(botocore/validate.py:360)
```

Relevant code was moved recently [here](https://github.com/Netflix/lemur/pull/3845/files#diff-783a8c89bf633e7bf681ac5713d44cfd28104dea5c734ce3969b0c9d5f758ef4L209).