### PR TITLE
Fix CloudFront distribution creation.

### DIFF
--- a/lemur/endpoints/service.py
+++ b/lemur/endpoints/service.py
@@ -97,9 +97,11 @@ def create(**kwargs):
     :param kwargs:
     :return:
     """
-    endpoint = Endpoint(**kwargs)
+    aliases = []
     if "aliases" in kwargs:
-        endpoint.aliases = [EndpointDnsAlias(alias=name) for name in kwargs.pop("aliases")]
+        aliases = [EndpointDnsAlias(alias=name) for name in kwargs.pop("aliases")]
+    endpoint = Endpoint(**kwargs)
+    endpoint.aliases = aliases
     database.create(endpoint)
     metrics.send(
         "endpoint_added", "counter", 1, metric_tags={"source": endpoint.source.label}

--- a/lemur/plugins/lemur_aws/plugin.py
+++ b/lemur/plugins/lemur_aws/plugin.py
@@ -232,7 +232,7 @@ def get_distribution_endpoint(account_number, cert_id_to_name, distrib_dict):
 class AWSSourcePlugin(SourcePlugin):
     title = "AWS"
     slug = "aws-source"
-    description = "Discovers all SSL certificates and ELB endpoints in an AWS account"
+    description = "Discovers all SSL certificates and ELB or Cloudfront endpoints in an AWS account"
     version = aws.VERSION
 
     author = "Kevin Glisson"


### PR DESCRIPTION
A change in sqlalchemy now disallows the incorrect use of relationship
fields on instantiation; translate list of alias strings to EndpointDnsAlias
records before assigning them an Endpoint record.

Also fix AWS plugin doc string.