### PR TITLE
Disallow creating certificates with more than one account per destination

### DIFF
--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -34,6 +34,7 @@ from lemur.notifications.messaging import send_revocation_notification
 from lemur.notifications.models import Notification
 from lemur.pending_certificates.models import PendingCertificate
 from lemur.plugins.base import plugins
+from lemur.plugins.utils import get_plugin_option
 from lemur.roles import service as role_service
 from lemur.roles.models import Role
 
@@ -457,6 +458,15 @@ def create(**kwargs):
     """
     Creates a new certificate.
     """
+    # Validate destinations do not overlap accounts
+    if "destinations" in kwargs:
+        dest_accounts = {}
+        for dest in kwargs["destinations"]:
+            account = get_plugin_option("accountNumber", dest.options)
+            if account in dest_accounts:
+                raise Exception(f"Only one destination allowed per account: {account}")
+            dest_accounts[account] = True
+
     try:
         cert_body, private_key, cert_chain, external_id, csr = mint(**kwargs)
     except Exception:


### PR DESCRIPTION
When both an ELB and CloudFront destination are given for the same
certificate, Lemur will upload it twice to IAM, once for each path, but
with the same name. IAM succeeds both operations but keeps only one of
the certificates.

When certificates are needed for both ELBs and CloudFront distributions in the
same account, seperate certificates for each must be minted in Lemur, to reflect
the way they are managed in IAM.

This change enforces that accountNumber must be unique across destinations
for a newly created cert.