### PR TITLE
Ensure checking task status doesn't unnecessarily raise an exception

### DIFF
--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -75,6 +75,8 @@ def is_task_active(fun, task_id, args):
 
     i = inspect()
     active_tasks = i.active()
+    if active_tasks is None:
+        return False
     for _, tasks in active_tasks.items():
         for task in tasks:
             if task.get("id") == task_id:


### PR DESCRIPTION
If there are no active tasks, then the call to the `active()` method returns a `None` object. To prevent an exception that will crash the celery worker, this change tweaks the `is_active_task()` method to handle this case explicitly. Closes #3921.