### PR TITLE
preparing for a new release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,39 @@
 Changelog
 =========
 
+0.11.0 - `2022-01-05`
+~~~~~~~~~~~~~~~~~~~~~
+
+This release includes multiple improvements on many fronts.
+The next release will be a major release, requiring Python 3.8 or higher.
+
+Some of the notable changes in this release are:
+
+- CloudFront Plugin: a new endpoint with rotation support
+- Improved Endpoint expiration flow; the Sync job now expires old endpoints
+- AWS ELB tag supports to opt-out of auto-rotate for load balancers
+- Membership plugin
+- Moving Travis Build to Node 16
+- OAuth2 & Ping Config improvement
+- Improved Certificate status check
+- Improved ACME plugin:
+    - reuse existing domain validation resulting in faster issuance
+    - IP certificate issuance support, accompanied by UI support
+    - emit remaining domain validation
+- Azure destination: Switch to PCKS12 upload
+- Improved logs, such as:
+    - Warning logs for admin role assignment and authority creation
+    - Audit logs in JSON format for better search
+    - Improved SES logging
+
+Special thanks to all who contributed to this release, notably:
+- `Bob Shannon <https://github.com/bobmshannon>`_
+- `sirferl <https://github.com/sirferl>`_
+- `Sam Havron <https://github.com/havron>`_
+- `Guillaume Dumont <https://github.com/dumontg>`_
+- `Joe McRobot <https://github.com/JoeMcRobot>`_
+
+
 0.10.0 - `2021-06-28`
 ~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This is preparing for a minor release one, before our first major release to follow shortly, which requires Python 3.8 or higher.