### PR TITLE
Preparing for major release (1.0.0)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+
+1.0.0 - `2022-01-06`
+~~~~~~~~~~~~~~~~~~~~
+
+This is our first major release due to a dependency on Python 3.8.
+Lemur is now using flake8>=4.0 and pyflakes>=2.4, requiring Python 3.8 or higher.
+Our Travis Builds are currently on Python 3.8 and Python 3.9.
+
+
 0.11.0 - `2022-01-05`
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,8 @@ Lemur
 Lemur manages TLS certificate creation. While not able to issue certificates itself, Lemur acts as a broker between CAs
 and environments providing a central portal for developers to issue TLS certificates with 'sane' defaults.
 
-It works on Python 3.7. We deploy on Ubuntu and develop on OS X.
+Lemur runs on Python 3.8 and 3.9.
+We deploy on Ubuntu and develop moslty on OS X.
 
 
 Project resources

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Lemur manages TLS certificate creation. While not able to issue certificates its
 and environments providing a central portal for developers to issue TLS certificates with 'sane' defaults.
 
 Lemur runs on Python 3.8 and 3.9.
-We deploy on Ubuntu and develop moslty on OS X.
+We deploy on Ubuntu and develop mostly on OS X.
 
 
 Project resources

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ docutils==0.17.1
     # via readme-renderer
 filelock==3.0.12
     # via virtualenv
-flake8==3.9.2
+flake8==4.0.1
     # via -r requirements-dev.in
 identify==2.2.10
     # via pre-commit
@@ -62,11 +62,11 @@ pkginfo==1.8.2
     # via twine
 pre-commit==2.16.0
     # via -r requirements-dev.in
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via flake8
 pycparser==2.20
     # via cffi
-pyflakes==2.3.1
+pyflakes==2.4.0
     # via flake8
 pygments==2.9.0
     # via readme-renderer

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -359,7 +359,7 @@ pycparser==2.20
     #   cffi
 pycryptodomex==3.10.1
     # via pyjks
-pyflakes==2.3.1
+pyflakes==2.4.0
     # via -r requirements-tests.txt
 pygments==2.9.0
     # via sphinx

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -173,7 +173,7 @@ pyasn1==0.4.8
     #   rsa
 pycparser==2.20
     # via cffi
-pyflakes==2.3.1
+pyflakes==2.4.0
     # via -r requirements-tests.in
 pyopenssl==21.0.0
     # via


### PR DESCRIPTION
This is our first major release due to a dependency on Python 3.8.
Lemur is now using flake8>=4.0 and pyflakes>=2.4, requiring Python 3.8 or higher.
Our Travis Builds are currently on Python 3.8 and Python 3.9.