### PR TITLE
Fix typo in expiring certificates periodic task name

### DIFF
--- a/docs/production/index.rst
+++ b/docs/production/index.rst
@@ -326,7 +326,7 @@ celery tasks or cron jobs that run these commands.
 The following commands that could/should be run on a periodic basis:
 
 - `notify expirations`, `notify authority_expirations`, `notify security_expiration_summary`, and `notify expiring_deployed_certificates` (see :ref:`NotificationOptions` for configuration info)
-- `certificate identity_expiring_deployed_certificates`
+- `certificate identify_expiring_deployed_certificates`
 - `check_revoked`
 - `sync`
 
@@ -427,8 +427,8 @@ Example Celery configuration (To be placed in your configuration file)::
             },
             'schedule': crontab(hour=22, minute=0),
         },
-        'identity_expiring_deployed_certificates': {
-            'task': 'lemur.common.celery.identity_expiring_deployed_certificates',
+        'identify_expiring_deployed_certificates': {
+            'task': 'lemur.common.celery.identify_expiring_deployed_certificates',
             'options': {
                 'expires': 180
             },

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -1002,9 +1002,16 @@ def notify_expiring_deployed_certificates():
     metrics.send(f"{function}.success", "counter", 1)
     return log_data
 
+@celery.task(soft_time_limit=10800)  # 3 hours
+def identity_expiring_deployed_certificates:
+    """
+    DEPRECATED: Use identify_expiring_deployed_certificates instead.
+    """
+    current_app.logger.warn("identity_expiring_deployed_certificates is deprecated and will be removed in a future release, please use identify_expiring_deployed_certificates instead")
+    return identify_expiring_deployed_certificates()
 
 @celery.task(soft_time_limit=10800)  # 3 hours
-def identity_expiring_deployed_certificates():
+def identify_expiring_deployed_certificates():
     """
     This celery task attempts to find any certificates that are expiring soon but are still deployed,
     and stores information on which port(s) the certificate is currently being used for TLS.

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -1002,6 +1002,7 @@ def notify_expiring_deployed_certificates():
     metrics.send(f"{function}.success", "counter", 1)
     return log_data
 
+
 @celery.task(soft_time_limit=10800)  # 3 hours
 def identity_expiring_deployed_certificates():
     """
@@ -1009,6 +1010,7 @@ def identity_expiring_deployed_certificates():
     """
     current_app.logger.warn("identity_expiring_deployed_certificates is deprecated and will be removed in a future release, please use identify_expiring_deployed_certificates instead")
     return identify_expiring_deployed_certificates()
+
 
 @celery.task(soft_time_limit=10800)  # 3 hours
 def identify_expiring_deployed_certificates():

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -1003,7 +1003,7 @@ def notify_expiring_deployed_certificates():
     return log_data
 
 @celery.task(soft_time_limit=10800)  # 3 hours
-def identity_expiring_deployed_certificates:
+def identity_expiring_deployed_certificates():
     """
     DEPRECATED: Use identify_expiring_deployed_certificates instead.
     """

--- a/lemur/notifications/cli.py
+++ b/lemur/notifications/cli.py
@@ -116,7 +116,7 @@ def notify_expiring_deployed_certificates(exclude):
     """
     Attempt to find any certificates that are expiring soon but are still deployed, and notify the certificate owner.
     This information is retrieved from the database, and is based on the previous run of
-    identity_expiring_deployed_certificates.
+    identify_expiring_deployed_certificates.
     """
     status = FAILURE_METRIC_STATUS
     try:


### PR DESCRIPTION
When configuring Lemur tasks, I noticed that the task `identity_expiring_deployed_certificates` had a misspelling when searching for the corresponding metric which monitors how often this task runs. While this change is purely cosmetic, I figured it wouldn't be a bad idea to clean it up. I've renamed in such a way that existing users won't be broken until the old task is removed completely in a future release with breaking changes.