### PR TITLE
Require numeric input in ID filters.

### DIFF
--- a/lemur/static/app/angular/certificates/view/view.tpl.html
+++ b/lemur/static/app/angular/certificates/view/view.tpl.html
@@ -29,7 +29,7 @@
         <table ng-table="certificateTable" class="table" show-filter="showFilter" template-pagination="angular/pager.html">
           <tbody>
           <tr ng-class="{'even-row': $even }" ng-repeat-start="certificate in $data track by $index">
-            <td data-title="'Id'" filter="{'id': 'text'}">
+            <td data-title="'Id'" filter="{'id': 'number'}">
               {{ certificate.id }}
             </td>
             <td data-title="'Name'" sortable="'name'" filter="{ 'name': 'text' }">

--- a/lemur/static/app/angular/pending_certificates/view/view.tpl.html
+++ b/lemur/static/app/angular/pending_certificates/view/view.tpl.html
@@ -16,7 +16,7 @@
         <table ng-table="pendingCertificateTable" class="table" show-filter="showFilter" template-pagination="angular/pager.html">
           <tbody>
           <tr ng-class="{'even-row': $even }" ng-repeat-start="pendingCertificate in $data track by $index">
-            <td data-title="'Id'" filter="{'id': 'text'}">
+            <td data-title="'Id'" filter="{'id': 'number'}">
               {{ pendingCertificate.id }}
             </td>
             <td data-title="'Name'" sortable="'name'" filter="{ 'name': 'text' }">


### PR DESCRIPTION
Avoids logging exceptions caused by users providing non-numeric IDs to filter by.