### PR TITLE
Add support for additional AWS partitions

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -218,8 +218,16 @@ Basic Configuration
 .. data:: LEMUR_AWS_REGION
     :noindex:
 
-        This is an optional config applicable for settings where Lemur is deployed in AWS. For accessing regionalized
-        STS endpoints, LEMUR_AWS_REGION defines the region where Lemur is deployed.
+        This is an optional config applicable for settings where Lemur is deployed in AWS.
+        When specified, this will override the default regional AWS endpoints that are used
+        for accessing STS and services such as IAM for example. You must set this if running
+        in an alternative AWS partition such as GovCloud, for example.
+
+.. data:: LEMUR_AWS_PARTITION
+   :noindex:
+
+       Specifies the AWS partition that Lemur should use. Valid values are 'aws', 'aws-us-gov', and 'aws-cn'. Defaults to 'aws'.
+       If Lemur is deployed in and managing endpoints AWS GovCloud, for example, you must set this to `aws-us-gov`.
 
 .. data:: SENTRY_DSN
     :noindex:

--- a/lemur/plugins/lemur_aws/iam.py
+++ b/lemur/plugins/lemur_aws/iam.py
@@ -84,27 +84,27 @@ def get_registry_type_from_arn(arn):
     :param arn: IAM TLS certificate arn
     :return: iam or acm or unkown
     """
-    if arn.startswith("arn:aws:iam"):
+    if arn.startswith("arn:aws:iam") or arn.startswith("arn:aws-us-gov:iam") or arn.startswith("arn:aws-cn:iam"):
         return 'iam'
-    elif arn.startswith("arn:aws:acm"):
+    elif arn.startswith("arn:aws:acm") or arn.startswith("arn:aws-us-gov:acm") or arn.startswith("arn:aws-cn:acm"):
         return 'acm'
     else:
         return 'unknown'
 
 
-def create_arn_from_cert(account_number, region, certificate_name, path=''):
+def create_arn_from_cert(account_number, partition, certificate_name, path=''):
     """
     Create an ARN from a certificate.
     :param path:
     :param account_number:
-    :param region:
+    :param partition:
     :param certificate_name:
     :return:
     """
     if path is None or path == '':
-        return f"arn:aws:iam::{account_number}:server-certificate/{certificate_name}"
+        return f"arn:{partition}:iam::{account_number}:server-certificate/{certificate_name}"
     else:
-        return f"arn:aws:iam::{account_number}:server-certificate/{path}/{certificate_name}"
+        return f"arn:{partition}:iam::{account_number}:server-certificate/{path}/{certificate_name}"
 
 
 @sts_client("iam")

--- a/lemur/plugins/lemur_aws/sts.py
+++ b/lemur/plugins/lemur_aws/sts.py
@@ -27,9 +27,10 @@ def sts_client(service, service_type="client"):
                                    config=config)
             else:
                 sts = boto3.client("sts", config=config)
-            arn = "arn:aws:iam::{0}:role/{1}".format(
-                kwargs.pop("account_number"),
-                current_app.config.get("LEMUR_INSTANCE_PROFILE", "Lemur"),
+            arn = "arn:{partition}:iam::{account_number}:role/{profile}".format(
+                partition=current_app.config.get("LEMUR_AWS_PARTITION", "aws"),
+                account_number=kwargs.pop("account_number"),
+                profile=current_app.config.get("LEMUR_INSTANCE_PROFILE", "Lemur"),
             )
 
             # TODO add user specific information to RoleSessionName
@@ -38,7 +39,7 @@ def sts_client(service, service_type="client"):
             if service_type == "client":
                 client = boto3.client(
                     service,
-                    region_name=kwargs.pop("region", "us-east-1"),
+                    region_name=kwargs.pop("region", current_app.config.get("LEMUR_AWS_REGION", "us-east-1")),
                     aws_access_key_id=role["Credentials"]["AccessKeyId"],
                     aws_secret_access_key=role["Credentials"]["SecretAccessKey"],
                     aws_session_token=role["Credentials"]["SessionToken"],
@@ -48,7 +49,7 @@ def sts_client(service, service_type="client"):
             elif service_type == "resource":
                 resource = boto3.resource(
                     service,
-                    region_name=kwargs.pop("region", "us-east-1"),
+                    region_name=kwargs.pop("region", current_app.config.get("LEMUR_AWS_REGION", "us-east-1")),
                     aws_access_key_id=role["Credentials"]["AccessKeyId"],
                     aws_secret_access_key=role["Credentials"]["SecretAccessKey"],
                     aws_session_token=role["Credentials"]["SessionToken"],

--- a/lemur/plugins/lemur_aws/tests/test_iam.py
+++ b/lemur/plugins/lemur_aws/tests/test_iam.py
@@ -70,7 +70,27 @@ def test_get_registery_type_from_arn():
         get_registry_type_from_arn(arn) == "iam"
     )
 
+    arn = "arn:aws-us-gov:iam::123456789012:server-certificate/cloudfront/2/tttt2.netflixtest.net-NetflixInc-20150624-20150625"
+    assert (
+        get_registry_type_from_arn(arn) == "iam"
+    )
+
+    arn = "arn:aws-cn:iam::123456789012:server-certificate/cloudfront/2/tttt2.netflixtest.net-NetflixInc-20150624-20150625"
+    assert (
+        get_registry_type_from_arn(arn) == "iam"
+    )
+
     arn = "arn:aws:acm:us-west-2:123456789012:server-certificate/tttt2.netflixtest.net-NetflixInc-20150624-20150625"
+    assert (
+        get_registry_type_from_arn(arn) == "acm"
+    )
+
+    arn = "arn:aws-us-gov:acm:us-west-2:123456789012:server-certificate/tttt2.netflixtest.net-NetflixInc-20150624-20150625"
+    assert (
+        get_registry_type_from_arn(arn) == "acm"
+    )
+
+    arn = "arn:aws-cn:acm:us-west-2:123456789012:server-certificate/tttt2.netflixtest.net-NetflixInc-20150624-20150625"
     assert (
         get_registry_type_from_arn(arn) == "acm"
     )
@@ -86,24 +106,44 @@ def test_create_arn_from_cert():
 
     account_number = '123456789012'
     certificate_name = 'tttt2.netflixtest.net-NetflixInc-20150624-20150625'
-    region = ''  # not used
+    partition_commercial = 'aws'
+    partition_gov = 'aws-us-gov'
+    partition_cn = 'aws-cn'
 
     arn = "arn:aws:iam::123456789012:server-certificate/tttt2.netflixtest.net-NetflixInc-20150624-20150625"
     path = ""
     assert (
-        create_arn_from_cert(account_number, region, certificate_name, path) == arn
+        create_arn_from_cert(account_number, partition_commercial, certificate_name, path) == arn
     )
 
     arn = "arn:aws:iam::123456789012:server-certificate/cloudfront/tttt2.netflixtest.net-NetflixInc-20150624-20150625"
     path = "cloudfront"
     assert (
-        create_arn_from_cert(account_number, region, certificate_name, path) == arn
+        create_arn_from_cert(account_number, partition_commercial, certificate_name, path) == arn
     )
 
     arn = "arn:aws:iam::123456789012:server-certificate/cloudfront/2/tttt2.netflixtest.net-NetflixInc-20150624-20150625"
     path = "cloudfront/2"
     assert (
-        create_arn_from_cert(account_number, region, certificate_name, path) == arn
+        create_arn_from_cert(account_number, partition_commercial, certificate_name, path) == arn
+    )
+
+    arn = "arn:aws:iam::123456789012:server-certificate/cloudfront/2/tttt2.netflixtest.net-NetflixInc-20150624-20150625"
+    path = "cloudfront/2"
+    assert (
+        create_arn_from_cert(account_number, partition_commercial, certificate_name, path) == arn
+    )
+
+    arn = "arn:aws-us-gov:iam::123456789012:server-certificate/cloudfront/2/tttt2.netflixtest.net-NetflixInc-20150624-20150625"
+    path = "cloudfront/2"
+    assert (
+        create_arn_from_cert(account_number, partition_gov, certificate_name, path) == arn
+    )
+
+    arn = "arn:aws-cn:iam::123456789012:server-certificate/cloudfront/2/tttt2.netflixtest.net-NetflixInc-20150624-20150625"
+    path = "cloudfront/2"
+    assert (
+        create_arn_from_cert(account_number, partition_cn, certificate_name, path) == arn
     )
 
 


### PR DESCRIPTION
This PR adds support for allowing the Lemur AWS plugin to be used with other [AWS partitions](https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/Partitions.html), including `aws-us-gov` and `aws-cn`.

To achieve this a new configuration option called `LEMUR_AWS_PARTITION` has been added which modifies the ARNs the AWS plugin uses. Additionally, the STS wrapper may now optionally default to the region specified via `LEMUR_AWS_REGION`. This is to ensure that the credentials fetched by the `boto3` client use regional endpoints located within the AWS partition that the credentials were fetched from.

Closes https://github.com/Netflix/lemur/issues/3947.