### PR TITLE
Use a unique role for each authority

### DIFF
--- a/lemur/authorities/service.py
+++ b/lemur/authorities/service.py
@@ -94,21 +94,19 @@ def create_authority_roles(roles, owner, plugin_title, creator):
     role_objs = []
     for r in roles:
         role = role_service.get_by_name(r["name"])
-        if not role:
-            role = role_service.create(
-                r["name"],
-                password=r["password"],
-                description="Auto generated role for {0}".format(plugin_title),
-                username=r["username"],
-            )
-
-        # the user creating the authority should be able to administer it
-        if role.username == "admin":
-            creator.roles.append(role)
+        # error out if the role already exists, because we want a unique role per authority
+        if role:
+            raise Exception("Unable to create authority role {} because it already exists".format(r["name"]))
+        role = role_service.create(
+            r["name"],
+            password=r["password"],
+            description="Auto generated role for {0}".format(plugin_title),
+            username=r["username"],
+        )
 
         role_objs.append(role)
 
-    # create an role for the owner and assign it
+    # get or create a role for the owner
     owner_role = role_service.get_by_name(owner)
     if not owner_role:
         owner_role = role_service.create(
@@ -130,8 +128,6 @@ def create(**kwargs):
         raise Exception(f"Admin and/or operator roles for authority {ca_name} already exist")
 
     body, private_key, chain, roles = mint(**kwargs)
-
-    kwargs["creator"].roles = list(set(list(kwargs["creator"].roles) + roles))
 
     kwargs["body"] = body
     kwargs["private_key"] = private_key

--- a/lemur/authorities/views.py
+++ b/lemur/authorities/views.py
@@ -8,6 +8,7 @@
 from flask import Blueprint, g
 from flask_restful import reqparse, Api
 
+from lemur.common import validators
 from lemur.common.utils import paginated_parser
 from lemur.common.schema import validate_schema
 from lemur.auth.service import AuthenticatedResource
@@ -226,6 +227,10 @@ class AuthoritiesList(AuthenticatedResource):
            :statuscode 403: unauthenticated
            :statuscode 200: no error
         """
+        if not validators.is_valid_owner(data["owner"]):
+            return dict(message=f"Invalid owner: check if {data['owner']} is a valid group email. Individuals cannot "
+                                f"be authority owners."), 412
+
         data["creator"] = g.current_user
         return service.create(**data)
 

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -1241,18 +1241,6 @@ def get_expiring_deployed_certificates(exclude=None):
     return certs_domains_and_ports_by_owner
 
 
-def is_valid_owner(email):
-    user_membership_provider = None
-    if current_app.config.get("USER_MEMBERSHIP_PROVIDER") is not None:
-        user_membership_provider = plugins.get(current_app.config.get("USER_MEMBERSHIP_PROVIDER"))
-    if user_membership_provider is None:
-        # nothing to check since USER_MEMBERSHIP_PROVIDER is not configured
-        return True
-
-    # expecting owner to be an existing team DL
-    return user_membership_provider.does_group_exist(email)
-
-
 def allowed_issuance_for_domain(common_name, extensions):
     check_permission_for_cn = True if common_name else False
 

--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -10,6 +10,8 @@ from builtins import str
 
 from flask import Blueprint, make_response, jsonify, g, current_app
 from flask_restful import reqparse, Api, inputs
+
+from lemur.common import validators
 from lemur.plugins.bases.authorization import UnauthorizedError
 from sentry_sdk import capture_exception
 
@@ -500,7 +502,7 @@ class CertificatesList(AuthenticatedResource):
            :statuscode 403: unauthenticated
 
         """
-        if not service.is_valid_owner(data["owner"]):
+        if not validators.is_valid_owner(data["owner"]):
             return dict(message=f"Invalid owner: check if {data['owner']} is a valid group email. Individuals cannot be certificate owners."), 412
 
         role = role_service.get_by_name(data["authority"].owner)

--- a/lemur/common/validators.py
+++ b/lemur/common/validators.py
@@ -9,6 +9,7 @@ from marshmallow.exceptions import ValidationError
 
 from lemur.auth.permissions import SensitiveDomainPermission
 from lemur.common.utils import check_cert_signature, is_weekend
+from lemur.plugins.base import plugins
 
 
 def common_name(value):
@@ -203,3 +204,15 @@ def verify_cert_chain(certs, error_class=ValidationError):
 
         # Next loop will validate that *this issuer* cert is signed by the next chain cert.
         cert = issuer
+
+
+def is_valid_owner(email):
+    user_membership_provider = None
+    if current_app.config.get("USER_MEMBERSHIP_PROVIDER") is not None:
+        user_membership_provider = plugins.get(current_app.config.get("USER_MEMBERSHIP_PROVIDER"))
+    if user_membership_provider is None:
+        # nothing to check since USER_MEMBERSHIP_PROVIDER is not configured
+        return True
+
+    # expecting owner to be an existing team DL
+    return user_membership_provider.does_group_exist(email)

--- a/lemur/plugins/lemur_acme/plugin.py
+++ b/lemur/plugins/lemur_acme/plugin.py
@@ -279,9 +279,7 @@ class ACMEIssuerPlugin(IssuerPlugin):
         :param options:
         :return:
         """
-        name = "acme"
-        if options.get("authority"):
-            name += "_" + '_'.join(options['name'].split(" "))
+        name = "acme_" + "_".join(options['name'].split(" ")) + "_admin"
         role = {"username": "", "password": "", "name": name}
 
         plugin_options = options.get("plugin", {}).get("plugin_options")
@@ -416,9 +414,7 @@ class ACMEHttpIssuerPlugin(IssuerPlugin):
         :param options:
         :return:
         """
-        name = "acme"
-        if options['name']:
-            name += "_" + '_'.join(options['name'].split(" "))
+        name = "acme_" + "_".join(options['name'].split(" ")) + "_admin"
         role = {"username": "", "password": "", "name": name}
 
         plugin_options = options.get("plugin", {}).get("plugin_options")

--- a/lemur/plugins/lemur_acme/tests/test_acme_dns.py
+++ b/lemur/plugins/lemur_acme/tests/test_acme_dns.py
@@ -311,12 +311,13 @@ class TestAcmeDns(unittest.TestCase):
 
     def test_create_authority(self):
         options = {
+            "name": "test ACME authority",
             "plugin": {"plugin_options": [{"name": "certificate", "value": "123"}]}
         }
         acme_root, b, role = self.ACMEIssuerPlugin.create_authority(options)
         self.assertEqual(acme_root, "123")
         self.assertEqual(b, "")
-        self.assertEqual(role, [{"username": "", "password": "", "name": "acme"}])
+        self.assertEqual(role, [{"username": "", "password": "", "name": "acme_test_ACME_authority_admin"}])
 
     @patch("lemur.plugins.lemur_acme.acme_handlers.dns_provider_service")
     def test_get_dns_provider(self, mock_dns_provider_service):

--- a/lemur/plugins/lemur_acme/tests/test_acme_http.py
+++ b/lemur/plugins/lemur_acme/tests/test_acme_http.py
@@ -30,7 +30,7 @@ class TestAcmeHttp(unittest.TestCase):
         acme_root, b, role = self.ACMEHttpIssuerPlugin.create_authority(options)
         self.assertEqual(acme_root, "123")
         self.assertEqual(b, "")
-        self.assertEqual(role, [{"username": "", "password": "", "name": "acme_mock_authority"}])
+        self.assertEqual(role, [{"username": "", "password": "", "name": "acme_mock_authority_admin"}])
 
     @patch("lemur.plugins.lemur_acme.plugin.AcmeHandler.setup_acme_client")
     @patch("lemur.plugins.base.manager.PluginManager.get")

--- a/lemur/plugins/lemur_adcs/plugin.py
+++ b/lemur/plugins/lemur_adcs/plugin.py
@@ -32,7 +32,8 @@ class ADCSIssuerPlugin(IssuerPlugin):
         """
         adcs_root = current_app.config.get("ADCS_ROOT")
         adcs_issuing = current_app.config.get("ADCS_ISSUING")
-        role = {"username": "", "password": "", "name": "adcs"}
+        name = "adcs_" + "_".join(options['name'].split(" ")) + "_admin"
+        role = {"username": "", "password": "", "name": name}
         return adcs_root, adcs_issuing, [role]
 
     def create_certificate(self, csr, issuer_options):

--- a/lemur/plugins/lemur_adcs/tests/test_adcs.py
+++ b/lemur/plugins/lemur_adcs/tests/test_adcs.py
@@ -1,0 +1,25 @@
+import unittest
+
+from flask import Flask
+
+
+class TestAdcs(unittest.TestCase):
+    def setUp(self):
+        # Creates a new Flask application for a test duration. In python 3.8, manual push of application context is
+        # needed to run tests in dev environment without getting error 'Working outside of application context'.
+        _app = Flask('lemur_test_adcs')
+        self.ctx = _app.app_context()
+        assert self.ctx
+        self.ctx.push()
+
+    def tearDown(self):
+        self.ctx.pop()
+
+    def test_create_authority(self):
+        from lemur.plugins.lemur_adcs.plugin import ADCSIssuerPlugin
+
+        options = {
+            "name": "test ADCS authority"
+        }
+        adcs_root, intermediate, role = ADCSIssuerPlugin.create_authority(options)
+        assert role == [{"username": "", "password": "", "name": "adcs_test_ADCS_authority_admin"}]

--- a/lemur/plugins/lemur_cfssl/plugin.py
+++ b/lemur/plugins/lemur_cfssl/plugin.py
@@ -100,7 +100,8 @@ class CfsslIssuerPlugin(IssuerPlugin):
         :param options:
         :return:
         """
-        role = {"username": "", "password": "", "name": "cfssl"}
+        name = "cfssl_" + "_".join(options['name'].split(" ")) + "_admin"
+        role = {"username": "", "password": "", "name": name}
         return current_app.config.get("CFSSL_ROOT"), "", [role]
 
     def revoke_certificate(self, certificate, reason):

--- a/lemur/plugins/lemur_cfssl/tests/test_cfssl.py
+++ b/lemur/plugins/lemur_cfssl/tests/test_cfssl.py
@@ -3,3 +3,14 @@ def test_get_certificates(app):
 
     p = plugins.get("cfssl-issuer")
     assert p
+
+
+def test_create_authority(app):
+    from lemur.plugins.base import plugins
+
+    options = {
+        "name": "test CFSSL authority"
+    }
+    p = plugins.get("cfssl-issuer")
+    cfssl_root, intermediate, role = p.create_authority(options)
+    assert role == [{"username": "", "password": "", "name": "cfssl_test_CFSSL_authority_admin"}]

--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -469,7 +469,8 @@ class DigiCertIssuerPlugin(IssuerPlugin):
         :param options:
         :return:
         """
-        role = {"username": "", "password": "", "name": "digicert"}
+        name = "digicert_" + "_".join(options['name'].split(" ")) + "_admin"
+        role = {"username": "", "password": "", "name": name}
         return current_app.config.get("DIGICERT_ROOT"), "", [role]
 
 
@@ -649,5 +650,6 @@ class DigiCertCISIssuerPlugin(IssuerPlugin):
         :param options:
         :return:
         """
-        role = {"username": "", "password": "", "name": "digicert"}
+        name = "digicert_" + "_".join(options['name'].split(" ")) + "_admin"
+        role = {"username": "", "password": "", "name": name}
         return current_app.config.get("DIGICERT_CIS_ROOTS", {}).get(options['authority'].name), "", [role]

--- a/lemur/plugins/lemur_digicert/tests/test_digicert.py
+++ b/lemur/plugins/lemur_digicert/tests/test_digicert.py
@@ -16,6 +16,7 @@ def config_mock(*args):
         "DIGICERT_DEFAULT_SIGNING_ALGORITHM": "sha256",
         "DIGICERT_CIS_PROFILE_NAMES": {"digicert": 'digicert'},
         "DIGICERT_CIS_SIGNING_ALGORITHMS": {"digicert": 'digicert'},
+        "DIGICERT_CIS_ROOTS": {"root": "ROOT"},
     }
     return values[args[0]]
 
@@ -249,3 +250,28 @@ def test_cancel_ordered_certificate(mock_pending_cert):
     # A non-existing order id, does not raise exception because if it doesn't exist, then it doesn't matter
     mock_pending_cert.external_id = 111
     subject.cancel_ordered_certificate(mock_pending_cert, **data)
+
+
+@patch("lemur.plugins.lemur_digicert.plugin.current_app")
+def test_create_authority(mock_current_app):
+    from lemur.plugins.lemur_digicert.plugin import DigiCertIssuerPlugin
+
+    options = {
+        "name": "test Digicert authority"
+    }
+    digicert_root, intermediate, role = DigiCertIssuerPlugin.create_authority(options)
+    assert role == [{"username": "", "password": "", "name": "digicert_test_Digicert_authority_admin"}]
+
+
+@patch("lemur.plugins.lemur_digicert.plugin.current_app")
+def test_create_cis_authority(mock_current_app, authority):
+    from lemur.plugins.lemur_digicert.plugin import DigiCertCISIssuerPlugin
+
+    mock_current_app.config.get = Mock(side_effect=config_mock)
+
+    options = {
+        "name": "test Digicert CIS authority",
+        "authority": authority
+    }
+    digicert_root, intermediate, role = DigiCertCISIssuerPlugin.create_authority(options)
+    assert role == [{"username": "", "password": "", "name": "digicert_test_Digicert_CIS_authority_admin"}]

--- a/lemur/plugins/lemur_entrust/plugin.py
+++ b/lemur/plugins/lemur_entrust/plugin.py
@@ -342,7 +342,8 @@ class EntrustIssuerPlugin(IssuerPlugin):
         """
         entrust_root = current_app.config.get("ENTRUST_ROOT")
         entrust_issuing = current_app.config.get("ENTRUST_ISSUING")
-        role = {"username": "", "password": "", "name": "entrust"}
+        name = "entrust_" + "_".join(options['name'].split(" ")) + "_admin"
+        role = {"username": "", "password": "", "name": name}
         current_app.logger.info(f"Creating Auth: {options} {entrust_issuing}")
         # body, chain, role
         return entrust_root, "", [role]

--- a/lemur/plugins/lemur_entrust/tests/test_entrust.py
+++ b/lemur/plugins/lemur_entrust/tests/test_entrust.py
@@ -63,3 +63,14 @@ def test_process_options(mock_current_app, authority):
 
     client_id = 1
     assert expected == plugin.process_options(options, client_id)
+
+
+def test_create_authority(app):
+    from lemur.plugins.base import plugins
+
+    options = {
+        "name": "test Entrust authority"
+    }
+    p = plugins.get("entrust-issuer")
+    entrust_root, intermediate, role = p.create_authority(options)
+    assert role == [{"username": "", "password": "", "name": "entrust_test_Entrust_authority_admin"}]

--- a/lemur/plugins/lemur_verisign/plugin.py
+++ b/lemur/plugins/lemur_verisign/plugin.py
@@ -239,7 +239,8 @@ class VerisignIssuerPlugin(IssuerPlugin):
         :param options:
         :return:
         """
-        role = {"username": "", "password": "", "name": "verisign"}
+        name = "verisign_" + "_".join(options['name'].split(" ")) + "_admin"
+        role = {"username": "", "password": "", "name": name}
         return current_app.config.get("VERISIGN_ROOT"), "", [role]
 
     def get_available_units(self):

--- a/lemur/plugins/lemur_verisign/tests/test_verisign.py
+++ b/lemur/plugins/lemur_verisign/tests/test_verisign.py
@@ -2,3 +2,13 @@ def test_get_certificates(app):
     from lemur.plugins.base import plugins
 
     p = plugins.get("verisign-issuer")
+
+
+def test_create_cis_authority(app):
+    from lemur.plugins.lemur_verisign.plugin import VerisignIssuerPlugin
+
+    options = {
+        "name": "test Verisign authority"
+    }
+    digicert_root, intermediate, role = VerisignIssuerPlugin.create_authority(options)
+    assert role == [{"username": "", "password": "", "name": "verisign_test_Verisign_authority_admin"}]

--- a/lemur/tests/plugins/issuer_plugin.py
+++ b/lemur/tests/plugins/issuer_plugin.py
@@ -30,7 +30,8 @@ class TestIssuerPlugin(IssuerPlugin):
 
     @staticmethod
     def create_authority(options):
-        role = {"username": "", "password": "", "name": "test"}
+        name = "test_" + "_".join(options['name'].split(" ")) + "_admin"
+        role = {"username": "", "password": "", "name": name}
         return SAN_CERT_STR, "", [role]
 
 
@@ -53,7 +54,8 @@ class TestAsyncIssuerPlugin(IssuerPlugin):
 
     @staticmethod
     def create_authority(options):
-        role = {"username": "", "password": "", "name": "test"}
+        name = "test_" + "_".join(options['name'].split(" ")) + "_admin"
+        role = {"username": "", "password": "", "name": name}
         return SAN_CERT_STR, "", [role]
 
     def cancel_ordered_certificate(self, pending_certificate, **kwargs):

--- a/lemur/tests/test_authorities.py
+++ b/lemur/tests/test_authorities.py
@@ -76,14 +76,23 @@ def test_user_authority(session, client, authority, role, user, issuer_plugin):
 
 def test_create_authority(issuer_plugin, user):
     from lemur.authorities.service import create
+    from lemur.tests.factories import RoleFactory
 
     authority = create(
         plugin={"plugin_object": issuer_plugin, "slug": issuer_plugin.slug},
-        owner="jim@example.com",
+        owner=user["user"].email,
         type="root",
+        name="example authority",
         creator=user["user"],
+        roles=[RoleFactory(name="new-role-test_create_authority")]
     )
     assert authority.authority_certificate
+    assert authority.owner == user["user"].email
+    assert len(authority.roles) == 3
+    for role in authority.roles:
+        assert role.name in [user["user"].email, "test_example_authority_admin", "new-role-test_create_authority"]
+    assert "test_example_authority_admin" not in user["user"].roles
+    assert "new-role-test_create_authority" not in user["user"].roles
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR modifies the authority creation flow to create a brand new, unique role for each authority, rather than a sharing a single issuer plugin role across all authorities using the same issuer plugin.

This change does NOT affect existing authorities. If desired, existing authority roles would need to be manually updated.

This also adds validation that an authority owner is valid (only if `USER_MEMBERSHIP_PROVIDER` is configured).