### PR TITLE
Try moving to dependabot's auto versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,5 +13,5 @@
         - "charhate"
         - "jtschladen"
         - "douglasc-nflx"
-      versioning-strategy: lockfile-only
+      versioning-strategy: auto
       open-pull-requests-limit: 20


### PR DESCRIPTION
I'm hoping this may help get dependabot functional again. [Docs](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#versioning-strategy).