### PR TITLE
Manual dependency update

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ certifi==2021.10.8
     # via requests
 cfgv==3.3.1
     # via pre-commit
-charset-normalizer==2.0.10
+charset-normalizer==2.0.11
     # via requests
 colorama==0.4.4
     # via twine
@@ -22,7 +22,7 @@ filelock==3.4.2
     # via virtualenv
 flake8==4.0.1
     # via -r requirements-dev.in
-identify==2.4.5
+identify==2.4.7
     # via pre-commit
 idna==3.3
     # via requests

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -11,7 +11,7 @@ acme==1.22.0
     #   certbot
 alabaster==0.7.12
     # via sphinx
-alembic==1.7.5
+alembic==1.7.6
     # via
     #   -r requirements-tests.txt
     #   flask-migrate
@@ -39,7 +39,7 @@ aws-xray-sdk==2.9.0
     #   moto
 babel==2.9.1
     # via sphinx
-bandit==1.7.1
+bandit==1.7.2
     # via -r requirements-tests.txt
 bcrypt==3.2.0
     # via
@@ -49,19 +49,19 @@ beautifulsoup4==4.10.0
     # via cloudflare
 billiard==3.6.4.0
     # via celery
-black==21.12b0
+black==22.1.0
     # via -r requirements-tests.txt
 blinker==1.4
     # via
     #   flask-mail
     #   flask-principal
-boto3==1.20.41
+boto3==1.20.46
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
     #   aws-sam-translator
     #   moto
-botocore==1.23.41
+botocore==1.23.46
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
@@ -88,11 +88,11 @@ cffi==1.15.0
     #   bcrypt
     #   cryptography
     #   pynacl
-cfn-lint==0.57.0
+cfn-lint==0.58.0
     # via
     #   -r requirements-tests.txt
     #   moto
-charset-normalizer==2.0.10
+charset-normalizer==2.0.11
     # via
     #   -r requirements-tests.txt
     #   requests
@@ -121,7 +121,7 @@ configobj==5.0.6
     # via
     #   -r requirements-tests.txt
     #   certbot
-coverage==6.2
+coverage==6.3
     # via -r requirements-tests.txt
 cryptography==36.0.1
     # via
@@ -151,7 +151,7 @@ docker==5.0.3
     # via
     #   -r requirements-tests.txt
     #   moto
-docutils==0.16
+docutils==0.17.1
     # via
     #   sphinx
     #   sphinx-rtd-theme
@@ -165,7 +165,7 @@ ecdsa==0.17.0
     #   sshpubkeys
 factory-boy==3.2.1
     # via -r requirements-tests.txt
-faker==11.3.0
+faker==12.0.0
     # via
     #   -r requirements-tests.txt
     #   factory-boy
@@ -235,6 +235,8 @@ idna==3.3
     #   moto
     #   requests
 imagesize==1.3.0
+    # via sphinx
+importlib-metadata==4.10.1
     # via sphinx
 inflection==0.5.1
     # via -r requirements-docs.in
@@ -319,7 +321,7 @@ marshmallow-sqlalchemy==0.23.1
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
-moto[all]==3.0.0
+moto[all]==3.0.2
     # via -r requirements-tests.txt
 mypy-extensions==0.4.3
     # via
@@ -363,7 +365,7 @@ pluggy==1.0.0
     # via
     #   -r requirements-tests.txt
     #   pytest
-prompt-toolkit==3.0.24
+prompt-toolkit==3.0.26
     # via click-repl
 py==1.11.0
     # via
@@ -382,7 +384,7 @@ pycparser==2.21
     # via
     #   -r requirements-tests.txt
     #   cffi
-pycryptodomex==3.13.0
+pycryptodomex==3.14.0
     # via pyjks
 pyflakes==2.4.0
     # via -r requirements-tests.txt
@@ -394,7 +396,7 @@ pyjwt==2.3.0
     # via -r requirements-docs.in
 pynacl==1.5.0
     # via paramiko
-pyopenssl==21.0.0
+pyopenssl==22.0.0
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
@@ -420,7 +422,7 @@ pytest==6.2.5
     #   pytest-mock
 pytest-flask==1.2.0
     # via -r requirements-tests.txt
-pytest-mock==3.6.1
+pytest-mock==3.7.0
     # via -r requirements-tests.txt
 python-dateutil==2.8.2
     # via
@@ -513,7 +515,6 @@ six==1.16.0
     #   hvac
     #   jsonschema
     #   junit-xml
-    #   pyopenssl
     #   python-dateutil
     #   requests-mock
     #   responses
@@ -573,15 +574,11 @@ stevedore==3.5.0
     #   bandit
 tabulate==0.8.9
     # via -r requirements-docs.in
-text-unidecode==1.3
-    # via
-    #   -r requirements-tests.txt
-    #   faker
 toml==0.10.2
     # via
     #   -r requirements-tests.txt
     #   pytest
-tomli==1.2.3
+tomli==2.0.0
     # via
     #   -r requirements-tests.txt
     #   black
@@ -626,6 +623,8 @@ xmltodict==0.12.0
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
     #   moto
+zipp==3.7.0
+    # via importlib-metadata
 zope.component==5.0.1
     # via
     #   -r requirements-tests.txt
@@ -643,3 +642,6 @@ zope.interface==5.4.0
     #   -r requirements-tests.txt
     #   certbot
     #   zope.component
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -6,7 +6,7 @@
 #
 acme==1.22.0
     # via certbot
-alembic==1.7.5
+alembic==1.7.6
     # via flask-migrate
 attrs==21.4.0
     # via
@@ -18,15 +18,15 @@ aws-sam-translator==1.42.0
     # via cfn-lint
 aws-xray-sdk==2.9.0
     # via moto
-bandit==1.7.1
+bandit==1.7.2
     # via -r requirements-tests.in
-black==21.12b0
+black==22.1.0
     # via -r requirements-tests.in
-boto3==1.20.41
+boto3==1.20.46
     # via
     #   aws-sam-translator
     #   moto
-botocore==1.23.41
+botocore==1.23.46
     # via
     #   aws-xray-sdk
     #   boto3
@@ -38,9 +38,9 @@ certifi==2021.10.8
     # via requests
 cffi==1.15.0
     # via cryptography
-cfn-lint==0.57.0
+cfn-lint==0.58.0
     # via moto
-charset-normalizer==2.0.10
+charset-normalizer==2.0.11
     # via requests
 click==8.0.3
     # via
@@ -50,7 +50,7 @@ configargparse==1.5.3
     # via certbot
 configobj==5.0.6
     # via certbot
-coverage==6.2
+coverage==6.3
     # via -r requirements-tests.in
 cryptography==36.0.1
     # via
@@ -74,7 +74,7 @@ ecdsa==0.17.0
     #   sshpubkeys
 factory-boy==3.2.1
     # via -r requirements-tests.in
-faker==11.3.0
+faker==12.0.0
     # via
     #   -r requirements-tests.in
     #   factory-boy
@@ -149,7 +149,7 @@ marshmallow==2.20.4
     #   marshmallow-sqlalchemy
 marshmallow-sqlalchemy==0.23.1
     # via -r requirements-tests.in
-moto[all]==3.0.0
+moto[all]==3.0.2
     # via -r requirements-tests.in
 mypy-extensions==0.4.3
     # via black
@@ -184,7 +184,7 @@ pycparser==2.21
     # via cffi
 pyflakes==2.4.0
     # via -r requirements-tests.in
-pyopenssl==21.0.0
+pyopenssl==22.0.0
     # via
     #   acme
     #   josepy
@@ -203,7 +203,7 @@ pytest==6.2.5
     #   pytest-mock
 pytest-flask==1.2.0
     # via -r requirements-tests.in
-pytest-mock==3.6.1
+pytest-mock==3.7.0
     # via -r requirements-tests.in
 python-dateutil==2.8.2
     # via
@@ -256,7 +256,6 @@ six==1.16.0
     #   fakeredis
     #   jsonschema
     #   junit-xml
-    #   pyopenssl
     #   python-dateutil
     #   requests-mock
     #   responses
@@ -274,11 +273,9 @@ sshpubkeys==3.3.1
     # via moto
 stevedore==3.5.0
     # via bandit
-text-unidecode==1.3
-    # via faker
 toml==0.10.2
     # via pytest
-tomli==1.2.3
+tomli==2.0.0
     # via black
 typing-extensions==4.0.1
     # via black
@@ -310,3 +307,6 @@ zope.interface==5.4.0
     # via
     #   certbot
     #   zope.component
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ acme==1.22.0
     # via
     #   -r requirements.in
     #   certbot
-alembic==1.7.5
+alembic==1.7.6
     # via flask-migrate
 alembic-autogenerate-enums==0.0.2
     # via -r requirements.in
@@ -34,9 +34,9 @@ blinker==1.4
     # via
     #   flask-mail
     #   flask-principal
-boto3==1.20.41
+boto3==1.20.46
     # via -r requirements.in
-botocore==1.23.41
+botocore==1.23.46
     # via
     #   -r requirements.in
     #   boto3
@@ -57,7 +57,7 @@ cffi==1.15.0
     #   bcrypt
     #   cryptography
     #   pynacl
-charset-normalizer==2.0.10
+charset-normalizer==2.0.11
     # via requests
 click==8.0.3
     # via
@@ -183,7 +183,7 @@ parsedatetime==2.6
     # via certbot
 pem==21.2.0
     # via -r requirements.in
-prompt-toolkit==3.0.24
+prompt-toolkit==3.0.26
     # via click-repl
 psycopg2==2.9.3
     # via -r requirements.in
@@ -199,7 +199,7 @@ pyasn1-modules==0.2.8
     #   python-ldap
 pycparser==2.21
     # via cffi
-pycryptodomex==3.13.0
+pycryptodomex==3.14.0
     # via pyjks
 pyjks==20.0.0
     # via -r requirements.in
@@ -207,7 +207,7 @@ pyjwt==2.3.0
     # via -r requirements.in
 pynacl==1.5.0
     # via paramiko
-pyopenssl==21.0.0
+pyopenssl==22.0.0
     # via
     #   -r requirements.in
     #   acme
@@ -265,7 +265,6 @@ six==1.16.0
     #   flask-cors
     #   flask-restful
     #   hvac
-    #   pyopenssl
     #   python-dateutil
     #   retrying
     #   sqlalchemy-utils
@@ -315,3 +314,6 @@ zope.interface==5.4.0
     # via
     #   certbot
     #   zope.component
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
Another manual dependency update due to the dependabot issue.

I've determined that the root cause appears to be addressed by https://github.com/celery/celery/pull/7218, which will hopefully be released in celery 5.2.4. Until then, we'll be stuck doing manual updates.