### PR TITLE
Avoid assigning duplicate roles when creating authorities/certs

### DIFF
--- a/lemur/authorities/service.py
+++ b/lemur/authorities/service.py
@@ -133,10 +133,9 @@ def create(**kwargs):
     kwargs["private_key"] = private_key
     kwargs["chain"] = chain
 
-    if kwargs.get("roles"):
-        kwargs["roles"] += roles
-    else:
-        kwargs["roles"] = roles
+    if not kwargs.get("roles"):
+        kwargs["roles"] = []
+    kwargs["roles"] += [role for role in roles if role not in kwargs["roles"]]
 
     cert = upload(**kwargs)
     kwargs["authority_certificate"] = cert

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -439,10 +439,9 @@ def upload(**kwargs):
     """
     roles = create_certificate_roles(**kwargs)
 
-    if kwargs.get("roles"):
-        kwargs["roles"] += roles
-    else:
-        kwargs["roles"] = roles
+    if not kwargs.get("roles"):
+        kwargs["roles"] = []
+    kwargs["roles"] += [role for role in roles if role not in kwargs["roles"]]
 
     cert = Certificate(**kwargs)
     cert.authority = kwargs.get("authority")


### PR DESCRIPTION
There was an issue with the authority/certificate creation code where a single role would be duplicated in certain cases. This fixes the issue by assuring we don't add duplicate roles.