### PR TITLE
CORS Update & New Config Params

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -62,6 +62,40 @@ Basic Configuration
         CORS = False
 
 
+.. data:: CORS_ORIGIN
+    :noindex:
+
+    Sets the Access-Control-Allow-Origin response header. The Access-Control-Allow-Origin response header
+    indicates whether the response can be shared with requesting code from the given origin.
+
+    ::
+
+        CORS_ORIGIN = *
+
+
+.. data:: CORS_ALLOW_HEADERS
+    :noindex:
+
+    Sets the Access-Control-Allow-Headers response header. The Access-Control-Allow-Headers response header
+    is used in response to a preflight request which includes the Access-Control-Request-Headers to indicate
+    which HTTP headers can be used during the actual request.
+
+    ::
+
+        CORS_ALLOW_HEADERS = Content-Type
+
+
+.. data:: CORS_ALLOW_METHODS
+    :noindex:
+
+    Sets the Access-Control-Allow-Methods response header. The Access-Control-Allow-Methods response header
+    specifies one or more methods allowed when accessing a resource in response to a preflight request.
+
+    ::
+
+        CORS_ALLOW_METHODS = GET,PUT,POST,DELETE,OPTIONS
+
+
 .. data:: SQLALCHEMY_DATABASE_URI
     :noindex:
 

--- a/lemur/factory.py
+++ b/lemur/factory.py
@@ -160,14 +160,17 @@ def configure_extensions(app):
             environment=app.config.get("LEMUR_ENV", ''),
         )
 
-    if app.config["CORS"]:
-        app.config["CORS_HEADERS"] = "Content-Type"
+    if app.config.get("CORS"):
+        origins = app.config.get("CORS_ORIGIN", "*")
+        allow_headers = app.config.get("CORS_ALLOW_HEADERS", "Content-Type")
+        methods = app.config.get("CORS_ALLOW_METHODS", "GET,PUT,POST,DELETE,OPTIONS")
         cors.init_app(
             app,
             resources=r"/api/*",
-            headers="Content-Type",
-            origin="*",
-            supports_credentials=True,
+            origins=origins if origins == "*" else [origin.strip() for origin in origins.split(',')],
+            allow_headers=[header.strip() for header in allow_headers.split(',')],
+            methods=[method.strip() for method in methods.split(',')],
+            supports_credentials=True
         )
 
 


### PR DESCRIPTION
Applications that have a separate front-end and back-end need to be able to update the CORS Origin, Allow Headers, and Allow Methods. We were running into various CORS errors on the front-end and need to be able to change these params.

The `cors.init_app` function has been updated with new params and the following config params have been added `CORS_ORIGIN`, `CORS_ALLOW_HEADERS`, and `CORS_ALLOW_METHODS` The admin docs have been updated as well.