### PR TITLE
Downgrade celery to 5.2.2 to unbreak dependabot

### DIFF
--- a/requirements-docs.in
+++ b/requirements-docs.in
@@ -7,7 +7,7 @@ acme
 arrow
 boto3
 botocore
-celery[redis]
+celery[redis] < 5.2.3 # caused by https://github.com/celery/celery/pull/7194, remove once https://github.com/celery/celery/pull/7218 is released
 certbot
 certsrv
 CloudFlare

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ arrow
 asyncpool
 boto3
 botocore
-celery[redis]
+celery[redis] < 5.2.3 # caused by https://github.com/celery/celery/pull/7194, remove once https://github.com/celery/celery/pull/7218 is released
 certbot
 certifi
 certsrv


### PR DESCRIPTION
This should make dependabot functional again. We can remove the lock once celery 5.2.4/5.3.0 is relased.