### PR TITLE
Remove redis lock

### DIFF
--- a/requirements-docs.in
+++ b/requirements-docs.in
@@ -37,7 +37,7 @@ pem
 pyjks >= 19 # pyjks < 19 depends on pycryptodome, which conflicts with dyn's usage of pycrypto
 pyjwt
 pyOpenSSL
-redis==4.0.2 # remove once fakeredis supports 4.1.0 https://github.com/jamesls/fakeredis/pull/324
+redis
 retrying
 sentry-sdk
 SQLAlchemy-Utils

--- a/requirements.in
+++ b/requirements.in
@@ -42,7 +42,7 @@ pyjwt
 pyOpenSSL
 pyyaml>=4.2b1 #high severity alert
 python_ldap
-redis==4.0.2  # remove once fakeredis supports 4.1.0 https://github.com/jamesls/fakeredis/pull/324
+redis
 requests
 retrying
 sentry-sdk


### PR DESCRIPTION
Solves this dependabot error:

```
Dependabot encountered the following error:

Could not find a version that matches redis<4.0.0,<4.1.0,==4.0.2,>=3.4.1 (from -r requirements-docs.in (line 40))
Tried: 0.6.0, 0.6.1, 1.34, 1.34.1, 2.0.0, 2.2.0, 2.2.2, 2.2.4, 2.4.0, 2.4.1, 2.4.2, 2.4.3, 2.4.4, 2.4.5, 2.4.6, 2.4.7, 2.4.8, 2.4.9, 2.4.10, 2.4.11, 2.4.12, 2.4.13, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.7.2, 2.7.3, 2.7.4, 2.7.5, 2.7.6, 2.8.0, 2.9.0, 2.9.1, 2.10.0, 2.10.1, 2.10.2, 2.10.3, 2.10.5, 2.10.5, 2.10.6, 2.10.6, 3.0.0, 3.0.0, 3.0.0.post1, 3.0.0.post1, 3.0.1, 3.0.1, 3.1.0, 3.1.0, 3.2.0, 3.2.0, 3.2.1, 3.2.1, 3.3.0, 3.3.0, 3.3.1, 3.3.1, 3.3.2, 3.3.2, 3.3.3, 3.3.3, 3.3.4, 3.3.4, 3.3.5, 3.3.5, 3.3.6, 3.3.6, 3.3.7, 3.3.7, 3.3.8, 3.3.8, 3.3.9, 3.3.9, 3.3.10, 3.3.10, 3.3.11, 3.3.11, 3.4.0, 3.4.0, 3.4.1, 3.4.1, 3.5.0, 3.5.0, 3.5.1, 3.5.1, 3.5.2, 3.5.2, 3.5.3, 3.5.3, 4.0.0, 4.0.0, 4.0.1, 4.0.1, 4.0.2, 4.0.2, 4.1.0, 4.1.0, 4.1.1, 4.1.1, 4.1.2, 4.1.2, 4.1.3, 4.1.3
Skipped pre-versions: 4.0.0b1, 4.0.0b2, 4.0.0b3, 4.0.0rc1, 4.0.0rc1, 4.0.0rc2, 4.0.0rc2, 4.1.0rc1, 4.1.0rc1, 4.1.0rc2, 4.1.0rc2
There are incompatible versions in the resolved dependencies:
  redis==4.0.2 (from -r requirements-docs.in (line 40))
  redis==4.0.2 (from -r requirements-tests.txt (line 228))
  redis<4.0.0,>=3.4.1 (from celery[redis]==5.2.2->-r requirements-docs.in (line 10))
  redis<4.1.0 (from fakeredis==1.7.0->-r requirements-tests.txt (line 81))
```

The new fakeredis was released just today.