### PR TITLE
Log when an expiring deployed certificate is detected

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,8 +39,7 @@ jobs:
     
     # Install prerequisites for python-ldap. See: https://www.python-ldap.org/en/python-ldap-3.3.0/installing.html#build-prerequisites
     - name: Install python-ldap prerequisites
-      run: sudo apt-get update
-      run: sudo apt-get install libldap2-dev libsasl2-dev
+      run: sudo apt-get update && sudo apt-get install libldap2-dev libsasl2-dev
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,8 +39,9 @@ jobs:
     
     # Install prerequisites for python-ldap. See: https://www.python-ldap.org/en/python-ldap-3.3.0/installing.html#build-prerequisites
     - name: Install python-ldap prerequisites
+      run: sudo apt-get update
       run: sudo apt-get install libldap2-dev libsasl2-dev
-    
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -1209,6 +1209,8 @@ def find_and_persist_domains_where_cert_is_deployed(certificate, excluded_domain
                     if parsed_serial == int(certificate.serial):
                         matched_ports_for_domain.append(port)
                         match = True
+                        current_app.logger.info(f'Identified expiring deployed certificate {certificate.name} '
+                                                f'at domain {domain_name} on port {port}')
                     status = SUCCESS_METRIC_STATUS
                 except Exception:
                     current_app.logger.info(f'Unable to check certificate for domain {domain_name} on port {port}',

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -1209,8 +1209,8 @@ def find_and_persist_domains_where_cert_is_deployed(certificate, excluded_domain
                     if parsed_serial == int(certificate.serial):
                         matched_ports_for_domain.append(port)
                         match = True
-                        current_app.logger.info(f'Identified expiring deployed certificate {certificate.name} '
-                                                f'at domain {domain_name} on port {port}')
+                        current_app.logger.warning(f'Identified expiring deployed certificate {certificate.name} '
+                                                   f'at domain {domain_name} on port {port}')
                     status = SUCCESS_METRIC_STATUS
                 except Exception:
                     current_app.logger.info(f'Unable to check certificate for domain {domain_name} on port {port}',


### PR DESCRIPTION
Log (in addition to writing a metric) whenever an expiring deployed certificate is detected. This could be useful when using log-based alerting/detection, rather than metric-based.