### PR TITLE
Try adding a sudo apt-get update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
         source ~/env/bin/activate
         python -m pip install --upgrade pip
         pip install coveralls bandit
+        sudo apt-get update
         sudo apt-get install libsasl2-dev libldap2-dev xvfb
     - name: Test
       run: |


### PR DESCRIPTION
We're getting this error for GitHub Actions builds:

```
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/c/cyrus-sasl2/libsasl2-dev_2.1.27~101-g0780600+dfsg-3ubuntu2.3_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```