### PR TITLE
Change pkg_resources call in plugin loading to use resolve rather than load

### DIFF
--- a/lemur/factory.py
+++ b/lemur/factory.py
@@ -243,7 +243,7 @@ def install_plugins(app):
     # },
     for ep in pkg_resources.iter_entry_points("lemur.plugins"):
         try:
-            plugin = ep.load()
+            plugin = ep.resolve()
         except Exception:
             import traceback
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,16 +8,12 @@ bleach==4.1.0
     # via readme-renderer
 certifi==2021.10.8
     # via requests
-cffi==1.15.0
-    # via cryptography
 cfgv==3.3.1
     # via pre-commit
 charset-normalizer==2.0.12
     # via requests
 colorama==0.4.4
     # via twine
-cryptography==36.0.2
-    # via secretstorage
 distlib==0.3.4
     # via virtualenv
 docutils==0.18.1
@@ -36,10 +32,6 @@ importlib-metadata==4.11.3
     #   twine
 invoke==1.7.0
     # via -r requirements-dev.in
-jeepney==0.7.1
-    # via
-    #   keyring
-    #   secretstorage
 keyring==23.5.0
     # via twine
 marshmallow==2.20.4
@@ -64,8 +56,6 @@ pre-commit==2.17.0
     # via -r requirements-dev.in
 pycodestyle==2.8.0
     # via flake8
-pycparser==2.21
-    # via cffi
 pyflakes==2.4.0
     # via flake8
 pygments==2.11.2
@@ -86,8 +76,6 @@ requests-toolbelt==0.9.1
     # via twine
 rfc3986==2.0.0
     # via twine
-secretstorage==3.3.1
-    # via keyring
 six==1.16.0
     # via
     #   bleach
@@ -106,7 +94,7 @@ urllib3==1.26.9
     # via
     #   requests
     #   twine
-virtualenv==20.13.3
+virtualenv==20.13.4
     # via pre-commit
 webencodings==0.5.1
     # via bleach

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -341,7 +341,7 @@ packaging==21.3
     #   pytest
     #   redis
     #   sphinx
-paramiko==2.10.2
+paramiko==2.10.3
     # via -r requirements-docs.in
 parsedatetime==2.6
     # via
@@ -500,7 +500,7 @@ sarif-om==1.0.4
     # via
     #   -r requirements-tests.txt
     #   cfn-lint
-sentry-sdk==1.5.7
+sentry-sdk==1.5.8
     # via -r requirements-docs.in
 six==1.16.0
     # via
@@ -624,23 +624,23 @@ xmltodict==0.12.0
     #   moto
 zipp==3.7.0
     # via importlib-metadata
-zope.component==5.0.1
+zope-component==5.0.1
     # via
     #   -r requirements-tests.txt
     #   certbot
-zope.event==4.5.0
+zope-event==4.5.0
     # via
     #   -r requirements-tests.txt
-    #   zope.component
-zope.hookable==5.1.0
+    #   zope-component
+zope-hookable==5.1.0
     # via
     #   -r requirements-tests.txt
-    #   zope.component
-zope.interface==5.4.0
+    #   zope-component
+zope-interface==5.4.0
     # via
     #   -r requirements-tests.txt
     #   certbot
-    #   zope.component
+    #   zope-component
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -22,11 +22,11 @@ bandit==1.7.4
     # via -r requirements-tests.in
 black==22.1.0
     # via -r requirements-tests.in
-boto3==1.21.21
+boto3==1.21.22
     # via
     #   aws-sam-translator
     #   moto
-botocore==1.24.21
+botocore==1.24.22
     # via
     #   aws-xray-sdk
     #   boto3
@@ -90,7 +90,7 @@ flask-migrate==2.7.0
     # via -r requirements-tests.in
 flask-sqlalchemy==2.5.1
     # via flask-migrate
-freezegun==1.2.0
+freezegun==1.2.1
     # via -r requirements-tests.in
 future==0.18.2
     # via aws-xray-sdk
@@ -151,7 +151,7 @@ marshmallow==2.20.4
     #   marshmallow-sqlalchemy
 marshmallow-sqlalchemy==0.23.1
     # via -r requirements-tests.in
-moto[all]==3.1.0
+moto[all]==3.1.1
     # via -r requirements-tests.in
 mypy-extensions==0.4.3
     # via black
@@ -216,7 +216,7 @@ python-dateutil==2.8.2
     #   moto
 python-jose[cryptography]==3.3.0
     # via moto
-pytz==2021.3
+pytz==2022.1
     # via
     #   acme
     #   certbot
@@ -242,7 +242,7 @@ requests-mock==1.9.3
     # via -r requirements-tests.in
 requests-toolbelt==0.9.1
     # via acme
-responses==0.19.0
+responses==0.20.0
     # via moto
 rsa==4.8
     # via python-jose
@@ -299,16 +299,16 @@ wrapt==1.14.0
     #   deprecated
 xmltodict==0.12.0
     # via moto
-zope.component==5.0.1
+zope-component==5.0.1
     # via certbot
-zope.event==4.5.0
-    # via zope.component
-zope.hookable==5.1.0
-    # via zope.component
-zope.interface==5.4.0
+zope-event==4.5.0
+    # via zope-component
+zope-hookable==5.1.0
+    # via zope-component
+zope-interface==5.4.0
     # via
     #   certbot
-    #   zope.component
+    #   zope-component
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,9 +34,9 @@ blinker==1.4
     # via
     #   flask-mail
     #   flask-principal
-boto3==1.21.21
+boto3==1.21.22
     # via -r requirements.in
-botocore==1.24.21
+botocore==1.24.22
     # via
     #   -r requirements.in
     #   boto3
@@ -181,7 +181,7 @@ ndg-httpsclient==0.5.1
     # via -r requirements.in
 packaging==21.3
     # via redis
-paramiko==2.10.2
+paramiko==2.10.3
     # via -r requirements.in
 parsedatetime==2.6
     # via certbot
@@ -231,7 +231,7 @@ python-json-logger==2.0.2
     # via logmatic-python
 python-ldap==3.4.0
     # via -r requirements.in
-pytz==2021.3
+pytz==2022.1
     # via
     #   acme
     #   celery
@@ -260,7 +260,7 @@ retrying==1.3.3
     # via -r requirements.in
 s3transfer==0.5.2
     # via boto3
-sentry-sdk==1.5.7
+sentry-sdk==1.5.8
     # via -r requirements.in
 six==1.16.0
     # via
@@ -311,16 +311,16 @@ wrapt==1.14.0
     # via deprecated
 xmltodict==0.12.0
     # via -r requirements.in
-zope.component==5.0.1
+zope-component==5.0.1
     # via certbot
-zope.event==4.5.0
-    # via zope.component
-zope.hookable==5.1.0
-    # via zope.component
-zope.interface==5.4.0
+zope-event==4.5.0
+    # via zope-component
+zope-hookable==5.1.0
+    # via zope-component
+zope-interface==5.4.0
     # via
     #   certbot
-    #   zope.component
+    #   zope-component
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
This change affects the plugin loading code. Instead of calling `load()`, which triggers requirements checking, we now call `resolve()` which does not check requirements.

The main purpose of this change is to work around an issue in setuptools resulting in conflicting package names:
1. The logic for parsing available package names parses the file name from `site-packages` directory (thus parsing `zope.component`, for example)
2. The logic for parsing required package names parses the name from `requirements.txt` (thus parsing `zope-component`)

The `requirements.txt` change to use hyphens (`zope-component`) instead of periods (`zope.component`) is fairly new, and apparently was introduced in pip-tools v6.5.1. 

This change feels reasonable as the plugin loading logic doesn't seem to be a location where we need to enforce package requirements, as it's only a small portion of the overall project.

I've also included a dependency update to ensure that the tests now pass even with the `zope.` to `zope-` naming style change included.

Other things I tried unsuccessfully:
* Downgrading pip-tools (ran into other issues)
* Adding an explicit dependency on `zope-` and `zope.` in the `requirements.in` (both failed in the same way as `requirements.txt` still ended up with `zope-`)