### PR TITLE
Update setuptools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
         python -m venv ~/env
         source ~/env/bin/activate
         python -m pip install --upgrade pip
+        python -m pip install --upgrade setuptools
         pip install coveralls bandit
         sudo apt-get update
         sudo apt-get install libsasl2-dev libldap2-dev xvfb


### PR DESCRIPTION
Update setuptools before running tests to ensure we get the latest version, which we need for dependabot PRs to build successfully.

This line could be removed once the default version our builds come with is 62.0.0 or higher.

**This change may require you to manually update your local version of setuptools to continue working with Lemur**: 
```
pip3 install --upgrade setuptools
```