### PR TITLE
No fine-grained authz for admins

### DIFF
--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -520,7 +520,9 @@ class CertificatesList(AuthenticatedResource):
         data["creator"] = g.user
         # allowed_issuance_for_domain throws UnauthorizedError if caller is not authorized
         try:
-            service.allowed_issuance_for_domain(data["common_name"], data["extensions"])
+            # unless admin, perform fine grained authorization
+            if not g.user.is_admin:
+                service.allowed_issuance_for_domain(data["common_name"], data["extensions"])
         except UnauthorizedError as e:
             return dict(message=str(e)), 403
         else:


### PR DESCRIPTION
Skip the domain authorization provider check for admin.
Domain authorization can be configured with [USER_DOMAIN_AUTHORIZATION_PROVIDER](https://lemur.readthedocs.io/en/latest/administration.html?highlight=USER_DOMAIN_AUTHORIZATION_PROVIDER#authorization-providers). Being in-line with admin capabilities as offered by Lemur (including authority management, cert management etc), this PR allows admin to issue all the certificates.