### PR TITLE
Skip private CA from fine-grained authz

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -1050,6 +1050,16 @@ If you are not using a custom authorization provider you do not need to configur
 
             USER_DOMAIN_AUTHORIZATION_PROVIDER = "<yourauthorizationpluginslug>"
 
+.. data:: LEMUR_PRIVATE_AUTHORITY_PLUGIN_NAMES
+    :noindex:
+
+        Lemur can be used to issue certificates with private CA. One can write own issuer plugin to do so. Domain level authorization
+        is skipped for private CA i.e., the one implementing custom issuer plugin. Currently this config is not used elsewhere.
+
+        ::
+
+            LEMUR_PRIVATE_AUTHORITY_PLUGIN_NAMES = ["issuerpluginslug1", "issuerpluginslug2"]
+
 Metric Providers
 ~~~~~~~~~~~~~~~~
 

--- a/lemur/authorities/models.py
+++ b/lemur/authorities/models.py
@@ -101,6 +101,15 @@ class Authority(db.Model):
         return None
 
     @property
+    def is_private_authority(self):
+        """
+        Tells if authority is private/internal. In other words, it is not publicly trusted.
+        If plugin is configured in list LEMUR_PRIVATE_AUTHORITY_PLUGIN_NAMES, the authority is treated as private
+        :return: True if private, False otherwise
+        """
+        return self.plugin_name in current_app.config.get("LEMUR_PRIVATE_AUTHORITY_PLUGIN_NAMES", [])
+
+    @property
     def max_issuance_days(self):
         if self.is_cab_compliant:
             return current_app.config.get("PUBLIC_CA_MAX_VALIDITY_DAYS", 397)

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -482,7 +482,7 @@ def create(**kwargs):
             plugin_accounts = dest_plugin_accounts.setdefault(dest.plugin_name, {})
             account = get_plugin_option("accountNumber", dest.options)
             if account in plugin_accounts:
-                raise Exception(f"Too many destintions for plugin {dest.plugin_name} and account {account}")
+                raise Exception(f"Too many destinations for plugin {dest.plugin_name} and account {account}")
             plugin_accounts[account] = True
 
     try:

--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -521,7 +521,7 @@ class CertificatesList(AuthenticatedResource):
         # allowed_issuance_for_domain throws UnauthorizedError if caller is not authorized
         try:
             # unless admin, perform fine grained authorization
-            if not g.user.is_admin:
+            if not g.user.is_admin and not data["authority"].is_private_authority:
                 service.allowed_issuance_for_domain(data["common_name"], data["extensions"])
         except UnauthorizedError as e:
             return dict(message=str(e)), 403


### PR DESCRIPTION
CA implementing plugin listed in `LEMUR_PRIVATE_AUTHORITY_PLUGIN_NAMES` will be treated as internal CA. Fine-grained authorization will not be performed for such an authority/CA. The code change could be made more generic if need be
(1) Decouple internal CA and bypass of domain level authz
(2) Move this logic to internal authorization provider implementation accepting authority details in addition to existing parameters