### PR TITLE
Sync endpoint: capture error and continue

### DIFF
--- a/lemur/sources/service.py
+++ b/lemur/sources/service.py
@@ -168,6 +168,7 @@ def sync_endpoints(source):
         except Exception as e:
             current_app.logger.warning(f"Error in processing sync endpoint "
                                        f"dnsname={endpoint['dnsname']} port={endpoint['port']}: {format(e)}")
+            capture_exception()
 
     return new, updated, updated_by_hash
 


### PR DESCRIPTION
If encouraged any error in an endpoint sync, log and continue with the next endpoint