### PR TITLE
Undo #4041 and change to session query

### DIFF
--- a/lemur/database.py
+++ b/lemur/database.py
@@ -21,7 +21,7 @@ from lemur.extensions import db
 
 def filter_none(kwargs):
     """
-    Remove all `None` values froma  given dict. SQLAlchemy does not
+    Remove all `None` values from a  given dict. SQLAlchemy does not
     like to have values that are None passed to it.
 
     :param kwargs: Dict to filter

--- a/lemur/endpoints/service.py
+++ b/lemur/endpoints/service.py
@@ -59,7 +59,8 @@ def get_by_name_and_source(name, source):
     :return:
     """
     return (
-        Endpoint.query.filter(Endpoint.name == name)
+        database.session_query(Endpoint)
+        .filter(Endpoint.name == name)
         .filter(Endpoint.source.has(Source.label == source))
         .scalar()
     )

--- a/lemur/sources/service.py
+++ b/lemur/sources/service.py
@@ -86,89 +86,84 @@ def sync_endpoints(source):
         return new, updated, updated_by_hash
 
     for endpoint in endpoints:
-        try:
-            exists = endpoint_service.get_by_dnsname_and_port(
-                endpoint["dnsname"], endpoint["port"]
-            )
+        exists = endpoint_service.get_by_dnsname_and_port(
+            endpoint["dnsname"], endpoint["port"]
+        )
 
-            certificate_name = endpoint.pop("certificate_name")
+        certificate_name = endpoint.pop("certificate_name")
 
-            endpoint["certificate"] = certificate_service.get_by_name(certificate_name)
+        endpoint["certificate"] = certificate_service.get_by_name(certificate_name)
 
-            # if get cert by name failed, we attempt a search via serial number and hash comparison
-            # and link the endpoint certificate to Lemur certificate
-            if not endpoint["certificate"]:
-                certificate_attached_to_endpoint = None
-                try:
-                    certificate_attached_to_endpoint = s.get_certificate_by_name(certificate_name, source.options)
-                except NotImplementedError:
-                    current_app.logger.warning(
-                        "Unable to describe server certificate for endpoints in source {0}:"
-                        " plugin has not implemented 'get_certificate_by_name'".format(
-                            source.label
+        # if get cert by name failed, we attempt a search via serial number and hash comparison
+        # and link the endpoint certificate to Lemur certificate
+        if not endpoint["certificate"]:
+            certificate_attached_to_endpoint = None
+            try:
+                certificate_attached_to_endpoint = s.get_certificate_by_name(certificate_name, source.options)
+            except NotImplementedError:
+                current_app.logger.warning(
+                    "Unable to describe server certificate for endpoints in source {0}:"
+                    " plugin has not implemented 'get_certificate_by_name'".format(
+                        source.label
+                    )
+                )
+                capture_exception()
+
+            if certificate_attached_to_endpoint:
+                lemur_matching_cert, updated_by_hash_tmp = find_cert(certificate_attached_to_endpoint)
+                updated_by_hash += updated_by_hash_tmp
+
+                if lemur_matching_cert:
+                    endpoint["certificate"] = lemur_matching_cert[0]
+
+                if len(lemur_matching_cert) > 1:
+                    current_app.logger.error(
+                        "Too Many Certificates Found{0}. Name: {1} Endpoint: {2}".format(
+                            len(lemur_matching_cert), certificate_name, endpoint["name"]
                         )
                     )
-                    capture_exception()
+                    metrics.send("endpoint.certificate.conflict",
+                                 "gauge", len(lemur_matching_cert),
+                                 metric_tags={"cert": certificate_name, "endpoint": endpoint["name"],
+                                              "acct": s.get_option("accountNumber", source.options)})
 
-                if certificate_attached_to_endpoint:
-                    lemur_matching_cert, updated_by_hash_tmp = find_cert(certificate_attached_to_endpoint)
-                    updated_by_hash += updated_by_hash_tmp
+        if not endpoint["certificate"]:
+            current_app.logger.error({
+                "message": "Certificate Not Found",
+                "certificate_name": certificate_name,
+                "endpoint_name": endpoint["name"],
+                "dns_name": endpoint.get("dnsname"),
+                "account": s.get_option("accountNumber", source.options),
+            })
 
-                    if lemur_matching_cert:
-                        endpoint["certificate"] = lemur_matching_cert[0]
+            metrics.send("endpoint.certificate.not.found",
+                         "counter", 1,
+                         metric_tags={"cert": certificate_name, "endpoint": endpoint["name"],
+                                      "acct": s.get_option("accountNumber", source.options),
+                                      "dnsname": endpoint.get("dnsname")})
+            continue
 
-                    if len(lemur_matching_cert) > 1:
-                        current_app.logger.error(
-                            "Too Many Certificates Found{0}. Name: {1} Endpoint: {2}".format(
-                                len(lemur_matching_cert), certificate_name, endpoint["name"]
-                            )
-                        )
-                        metrics.send("endpoint.certificate.conflict",
-                                     "gauge", len(lemur_matching_cert),
-                                     metric_tags={"cert": certificate_name, "endpoint": endpoint["name"],
-                                                  "acct": s.get_option("accountNumber", source.options)})
+        policy = endpoint.pop("policy")
 
-            if not endpoint["certificate"]:
-                current_app.logger.error({
-                    "message": "Certificate Not Found",
-                    "certificate_name": certificate_name,
-                    "endpoint_name": endpoint["name"],
-                    "dns_name": endpoint.get("dnsname"),
-                    "account": s.get_option("accountNumber", source.options),
-                })
+        policy_ciphers = []
+        for nc in policy["ciphers"]:
+            policy_ciphers.append(endpoint_service.get_or_create_cipher(name=nc))
 
-                metrics.send("endpoint.certificate.not.found",
-                             "counter", 1,
-                             metric_tags={"cert": certificate_name, "endpoint": endpoint["name"],
-                                          "acct": s.get_option("accountNumber", source.options),
-                                          "dnsname": endpoint.get("dnsname")})
-                continue
+        policy["ciphers"] = policy_ciphers
+        endpoint["policy"] = endpoint_service.get_or_create_policy(**policy)
+        endpoint["source"] = source
 
-            policy = endpoint.pop("policy")
+        if not exists:
+            current_app.logger.debug(
+                "Endpoint Created: Name: {name}".format(name=endpoint["name"])
+            )
+            endpoint_service.create(**endpoint)
+            new += 1
 
-            policy_ciphers = []
-            for nc in policy["ciphers"]:
-                policy_ciphers.append(endpoint_service.get_or_create_cipher(name=nc))
-
-            policy["ciphers"] = policy_ciphers
-            endpoint["policy"] = endpoint_service.get_or_create_policy(**policy)
-            endpoint["source"] = source
-
-            if not exists:
-                current_app.logger.debug(
-                    "Endpoint Created: Name: {name}".format(name=endpoint["name"])
-                )
-                endpoint_service.create(**endpoint)
-                new += 1
-
-            else:
-                current_app.logger.debug("Endpoint Updated: {}".format(endpoint))
-                endpoint_service.update(exists.id, **endpoint)
-                updated += 1
-        except Exception as e:
-            current_app.logger.warning(f"Error in processing sync endpoint "
-                                       f"dnsname={endpoint['dnsname']} port={endpoint['port']}: {format(e)}")
-            capture_exception()
+        else:
+            current_app.logger.debug("Endpoint Updated: {}".format(endpoint))
+            endpoint_service.update(exists.id, **endpoint)
+            updated += 1
 
     return new, updated, updated_by_hash
 

--- a/lemur/tests/test_endpoints.py
+++ b/lemur/tests/test_endpoints.py
@@ -21,6 +21,13 @@ def test_rotate_certificate(client, source_plugin):
     assert endpoint.certificate == new_certificate
 
 
+def test_get_by_name_and_source(client, source_plugin):
+    from lemur.endpoints.service import get_by_name_and_source
+
+    endpoint = EndpointFactory()
+    assert endpoint == get_by_name_and_source(endpoint.name, endpoint.source.label)
+
+
 @pytest.mark.parametrize(
     "token,status",
     [


### PR DESCRIPTION
Removing try-catch added in #4041 since it would likely has not updated the endpoint and will proceed with expiring the endpoint in parent method. Improving sync needs more specific types of errors to be handled if we want to proceed with rest of the endpoints.
Intermittent failure is recently seen in long running `source sync` celery task, the error is `psycopg2.errors.IdleInTransactionSessionTimeout` while reading endpoint details from database. The root cause it yet unclear. Changing the endpoint look up to a database session query from model query to see if that helps.