### PR TITLE
Sync source: handling idle/invalidated connection

### DIFF
--- a/lemur/database.py
+++ b/lemur/database.py
@@ -67,6 +67,13 @@ def commit():
     db.session.commit()
 
 
+def rollback():
+    """
+    Helper to rollback the current session.
+    """
+    db.session.rollback()
+
+
 def add(model):
     """
     Helper to add a `model` to the current session.

--- a/lemur/sources/service.py
+++ b/lemur/sources/service.py
@@ -92,6 +92,9 @@ def sync_endpoints(source):
                 endpoint["dnsname"], endpoint["port"]
             )
         except OperationalError as e:
+            # This is a workaround for handling sqlalchemy error "idle-in-transaction timeout", which is seen rarely
+            # during the sync of sources with few thousands of resources. The DB interaction may need a rewrite to
+            # avoid prolonged idle transactions.
             if e.connection_invalidated:
                 # all the update, insert operations are committed individually. So this should be harmless/no-op
                 database.rollback()

--- a/lemur/sources/service.py
+++ b/lemur/sources/service.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 import copy
 
 from flask import current_app
+from sqlalchemy.exc import OperationalError
 from sentry_sdk import capture_exception
 from sqlalchemy import cast
 from sqlalchemy_utils import ArrowType
@@ -86,9 +87,20 @@ def sync_endpoints(source):
         return new, updated, updated_by_hash
 
     for endpoint in endpoints:
-        exists = endpoint_service.get_by_dnsname_and_port(
-            endpoint["dnsname"], endpoint["port"]
-        )
+        try:
+            exists = endpoint_service.get_by_dnsname_and_port(
+                endpoint["dnsname"], endpoint["port"]
+            )
+        except OperationalError as e:
+            if e.connection_invalidated:
+                # all the update, insert operations are committed individually. So this should be harmless/no-op
+                database.rollback()
+                # retry one more time
+                exists = endpoint_service.get_by_dnsname_and_port(
+                    endpoint["dnsname"], endpoint["port"]
+                )
+            else:
+                raise e
 
         certificate_name = endpoint.pop("certificate_name")
 


### PR DESCRIPTION
This is a workaround for handling sqlalchemy error "idle-in-transaction timeout", which is seen rarely during the sync of sources with few thousands of resources. The DB interaction may need a rewrite to avoid prolonged idle transactions. Perhaps upgrading sqlalchemy to 1.4x may fix it.