### PR TITLE
Remove unsafe paginate method and replace with sort_and_page

### DIFF
--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -145,7 +145,8 @@ def get_all_valid_certs(authority_plugin_name, paginate=False, page=1, count=100
         query = query.filter(Certificate.date_created <= created_on_or_before.format("YYYY-MM-DD"))
 
     if paginate:
-        items = database.paginate(query, page, count)
+        args = {"page": page, "count": count, "sort_by": "id", "sort_dir": "desc"}
+        items = database.sort_and_page(query, Certificate, args)
         return items['items']
 
     return query.all()
@@ -731,7 +732,8 @@ def query_common_name(common_name, args):
         query = query.filter(Certificate.cn.ilike(common_name))
 
     if paginate:
-        return database.paginate(query, page, count)
+        args = {"page": page, "count": count, "sort_by": "id", "sort_dir": "desc"}
+        return database.sort_and_page(query, Certificate, args)
 
     return query.all()
 

--- a/lemur/database.py
+++ b/lemur/database.py
@@ -309,8 +309,7 @@ def sort_and_page(query, model, args):
     :param query: search query
     :param model: model to use for resulting items
     :param args: arguments to query with, including sorting and paging parameters
-    :return:the items given the count and page specified. The items would be an empty list
-    if page number exceeds max page number based on count per page and total number of records.
+    :return: the items given the count and page specified
     """
     sort_by = args.pop("sort_by")
     sort_dir = args.pop("sort_dir")

--- a/lemur/database.py
+++ b/lemur/database.py
@@ -9,7 +9,6 @@
 
 .. moduleauthor:: Kevin Glisson <kglisson@netflix.com>
 """
-import math
 from inflection import underscore
 from sqlalchemy import exc, func, distinct
 from sqlalchemy.orm import make_transient, lazyload
@@ -225,24 +224,6 @@ def sort(query, model, field, direction):
     return query.order_by(column.desc() if direction == "desc" else column.asc())
 
 
-def paginate(query, page, count):
-    """
-    Returns the items given the count and page specified. The items would be an empty list
-    if page number exceeds max page number based on count per page and total number of records.
-
-    :param query: search query
-    :param page: current page number
-    :param count: results per page
-    """
-    total = get_count(query)
-    # Check if input page is higher than total number of pages based on count per page and total
-    # In such a case Flask-SQLAlchemy pagination call results in 404
-    if math.ceil(total / count) < page:
-        return dict(items=[], total=total)
-    items = query.paginate(page, count).items
-    return dict(items=items, total=total)
-
-
 def update_list(model, model_attr, item_model, items):
     """
     Helper that correctly updates a models items
@@ -323,12 +304,13 @@ def get_count(q):
 
 def sort_and_page(query, model, args):
     """
-    Helper that allows us to combine sorting and paging
+    Helper that allows us to combine sorting and paging. Note that paging is not safe unless combined with sorting.
 
-    :param query:
-    :param model:
-    :param args:
-    :return:
+    :param query: search query
+    :param model: model to use for resulting items
+    :param args: arguments to query with, including sorting and paging parameters
+    :return:the items given the count and page specified. The items would be an empty list
+    if page number exceeds max page number based on count per page and total number of records.
     """
     sort_by = args.pop("sort_by")
     sort_dir = args.pop("sort_dir")
@@ -347,5 +329,6 @@ def sort_and_page(query, model, args):
 
     # offset calculated at zero
     page -= 1
+    # this is equivalent to query.paginate(page, count) where page has not been pre-decremented
     items = query.offset(count * page).limit(count).all()
     return dict(items=items, total=total)


### PR DESCRIPTION
This change removes the `paginate` method from the database utilities. This is being removed because it is not safe to paginate in Postgres without sorting first. Instead, we replace the two usages of that `paginate` method with `page_and_sort`, which is another pre-existing database utility that _also_ supports sorting.

Note that there is still an issue where any endpoint that allows pagination (and in fact, they all provide pagination _by default_) also allows the user to omit sorting (again, sorting is omitted _by default_). Fixing that may be a larger task, as we might need to sort by different fields depending on the table. Therefore, I will not attempt to fix that issue here.

I've also added some tests for the `query_common_name` method which was affected by this bug, though unfortunately these tests don't appear to catch the bug even without the fix. I haven't found a way to reproduce the issue in unit tests.