### PR TITLE
De-activate endpoint (Entrust)

### DIFF
--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -1013,6 +1013,11 @@ def remove_from_destination(certificate, destination):
         plugin.clean(certificate=certificate, options=destination.options)
 
 
+def deactivate(certificate):
+    plugin = plugins.get(certificate.authority.plugin_name)
+    return plugin.deactivate_certificate(certificate)
+
+
 def revoke(certificate, reason):
     plugin = plugins.get(certificate.authority.plugin_name)
     plugin.revoke_certificate(certificate, reason)

--- a/lemur/plugins/bases/issuer.py
+++ b/lemur/plugins/bases/issuer.py
@@ -31,3 +31,6 @@ class IssuerPlugin(Plugin):
 
     def cancel_ordered_certificate(self, pending_cert, **kwargs):
         raise NotImplementedError
+
+    def deactivate_certificate(self, certificate):
+        raise NotImplementedError

--- a/lemur/plugins/lemur_entrust/plugin.py
+++ b/lemur/plugins/lemur_entrust/plugin.py
@@ -327,7 +327,7 @@ class EntrustIssuerPlugin(IssuerPlugin):
             metrics.send("entrust_deactivate_certificate", "counter", 1)
             return handle_response(response)
         else:
-            # the certificate is no longer valid, or doesn't exist and cannot be deacticated
+            # the certificate is no longer valid, or doesn't exist and cannot be deactivated
             return 200
 
     @staticmethod

--- a/lemur/plugins/lemur_entrust/plugin.py
+++ b/lemur/plugins/lemur_entrust/plugin.py
@@ -319,8 +319,9 @@ class EntrustIssuerPlugin(IssuerPlugin):
         }
 
         # backwards compatible change to protect this endpoint from being used in production
-        if self.options and "staging_account" in self.options and self.options.get("staging_account") is False:
-            raise Exception("This issuer is not configured to deactivate certificates.")
+        for option in self.options:
+            if option.get("name") == "staging_account" and option.get("value") is True:
+                raise Exception("This issuer is not configured to deactivate certificates.")
 
         # Let's first check the status of the certificate
         base_url = current_app.config.get("ENTRUST_URL")

--- a/lemur/plugins/lemur_entrust/plugin.py
+++ b/lemur/plugins/lemur_entrust/plugin.py
@@ -459,7 +459,7 @@ class EntrustSourcePlugin(SourcePlugin):
                 break
             else:
                 offset += 1
-        current_app.logger.info(f"Retrieved {processed_certs} ertificates")
+        current_app.logger.info(f"Retrieved {processed_certs} certificates")
         return certs
 
     def get_endpoints(self, options, **kwargs):

--- a/lemur/plugins/lemur_entrust/tests/test_entrust.py
+++ b/lemur/plugins/lemur_entrust/tests/test_entrust.py
@@ -76,11 +76,26 @@ def test_create_authority(app):
     assert role == [{"username": "", "password": "", "name": "entrust_test_Entrust_authority_admin"}]
 
 
-@patch("lemur.plugins.lemur_entrust.plugin.current_app")
-def test_deactivate_certificate(app, authority, certificate):
-    from lemur.plugins.bases.issuer import deactivate_certificate
-    authority.options = {
-        "deactivate_certificate": True,
-    }
-    with self.assertRaisesRegex(Exception, "This issuer is not configured to deactivate certificates."):
-        deactivate_certificate(certificate)
+def test_deactivate_certificate(app):
+    from lemur.plugins.base import plugins
+    import requests_mock
+    p = plugins.get("entrust-issuer")
+
+    mock_cert = Mock()
+    mock_cert.external_id = 1
+
+    p.options = [
+            {
+                "name": "staging_account",
+                "type": "bool",
+                "required": True,
+                "helpMessage": "Set to True if this is an Entrust staging account.",
+                "default": False,
+                "value": True,
+            }
+    ]
+    try:
+        p.deactivate_certificate(mock_cert)
+        assert False
+    except Exception as inst:
+        assert inst.args[0] == "This issuer is not configured to deactivate certificates."

--- a/lemur/plugins/lemur_entrust/tests/test_entrust.py
+++ b/lemur/plugins/lemur_entrust/tests/test_entrust.py
@@ -22,7 +22,7 @@ def config_mock(*args):
     return values[args[0]]
 
 
-@patch("lemur.plugins.lemur_digicert.plugin.current_app")
+@patch("lemur.plugins.lemur_entrust.plugin.current_app")
 def test_determine_end_date(mock_current_app):
     with freeze_time(time_to_freeze=arrow.get(2016, 11, 3).datetime):
         assert arrow.get(2017, 12, 3).format('YYYY-MM-DD') == plugin.determine_end_date(0)  # 1 year + 1 month

--- a/lemur/plugins/lemur_entrust/tests/test_entrust.py
+++ b/lemur/plugins/lemur_entrust/tests/test_entrust.py
@@ -78,22 +78,19 @@ def test_create_authority(app):
 
 def test_deactivate_certificate(app):
     from lemur.plugins.base import plugins
-    import requests_mock
     p = plugins.get("entrust-issuer")
 
     mock_cert = Mock()
     mock_cert.external_id = 1
 
-    p.options = [
-            {
-                "name": "staging_account",
-                "type": "bool",
-                "required": True,
-                "helpMessage": "Set to True if this is an Entrust staging account.",
-                "default": False,
-                "value": True,
-            }
-    ]
+    p.options = [{
+        "name": "staging_account",
+        "type": "bool",
+        "required": True,
+        "helpMessage": "Set to True if this is an Entrust staging account.",
+        "default": False,
+        "value": True,
+    }]
     try:
         p.deactivate_certificate(mock_cert)
         assert False

--- a/lemur/plugins/lemur_entrust/tests/test_entrust.py
+++ b/lemur/plugins/lemur_entrust/tests/test_entrust.py
@@ -74,3 +74,13 @@ def test_create_authority(app):
     p = plugins.get("entrust-issuer")
     entrust_root, intermediate, role = p.create_authority(options)
     assert role == [{"username": "", "password": "", "name": "entrust_test_Entrust_authority_admin"}]
+
+
+@patch("lemur.plugins.lemur_entrust.plugin.current_app")
+def test_deactivate_certificate(app, authority, certificate):
+    from lemur.plugins.bases.issuer import deactivate_certificate
+    authority.options = {
+        "deactivate_certificate": True,
+    }
+    with self.assertRaisesRegex(Exception, "This issuer is not configured to deactivate certificates."):
+        deactivate_certificate(certificate)


### PR DESCRIPTION
Entrust staging environment gives the option to deactivate provisioned certificates to regain used certificate tokens. 