### PR TITLE
Fixing openssl/pkcs12 export when chain is None

### DIFF
--- a/lemur/plugins/lemur_openssl/plugin.py
+++ b/lemur/plugins/lemur_openssl/plugin.py
@@ -46,7 +46,8 @@ def create_pkcs12(cert, chain, p12_tmp, key, alias, passphrase):
     :param passphrase:
     """
     assert isinstance(cert, str)
-    assert isinstance(chain, str)
+    if chain is not None:
+        assert isinstance(chain, str)
     assert isinstance(key, str)
 
     with mktempfile() as key_tmp:


### PR DESCRIPTION
When the chain certificate is None, the openssl export to a pklcs12 file will fail like:

```
2022-10-18 17:03:12,185 INFO sqlalchemy.engine.base.Engine SELECT certificates.id AS certificates_id, certificates.external_id AS certificates_external_id, certificates.owner AS certificates_owner, certificates.name AS certificates_name, certificates.description AS certificates_description, certificates.notify AS certificates_notify, certificates.body AS certificates_body, certificates.chain AS certificates_chain, certificates.csr AS certificates_csr, certificates.private_key AS certificates_private_key, certificates.issuer AS certificates_issuer, certificates.serial AS certificates_serial, certificates.cn AS certificates_cn, certificates.deleted AS certificates_deleted, certificates.dns_provider_id AS certificates_dns_provider_id, certificates.not_before AS certificates_not_before, certificates.not_after AS certificates_not_after, certificates.date_created AS certificates_date_created, certificates.signing_algorithm AS certificates_signing_algorithm, certificates.status AS certificates_status, certificates.bits AS certificates_bits, certificates.san AS certificates_san, certificates.rotation AS certificates_rotation, certificates.user_id AS certificates_user_id, certificates.authority_id AS certificates_authority_id, certificates.root_authority_id AS certificates_root_authority_id, certificates.rotation_policy_id AS certificates_rotation_policy_id, certificates.key_type AS certificates_key_type 
FROM certificates 
WHERE certificates.id = %(param_1)s
2022-10-18 17:03:12,185 INFO sqlalchemy.engine.base.Engine {'param_1': 203}
[2022-10-18 17:03:12,188] DEBUG in utils: No file /tmp/72774kci
No file /tmp/72774kci
No file /tmp/72774kci
[2022-10-18 17:03:12,189] ERROR in schema: 
Traceback (most recent call last):
  File "/opt/lemur/lemur/common/schema.py", line 158, in decorated_function
    resp = f(*args, **kwargs)
  File "/opt/lemur/lemur/certificates/views.py", line 1430, in post
    extension, passphrase, data = plugin.export(
  File "/opt/lemur/lemur/plugins/lemur_openssl/plugin.py", line 142, in export
    create_pkcs12(body, chain, output_tmp, key, alias, passphrase)
  File "/opt/lemur/lemur/plugins/lemur_openssl/plugin.py", line 49, in create_pkcs12
    assert isinstance(chain, str)
AssertionError

Traceback (most recent call last):
  File "/opt/lemur/lemur/common/schema.py", line 158, in decorated_function
    resp = f(*args, **kwargs)
  File "/opt/lemur/lemur/certificates/views.py", line 1430, in post
    extension, passphrase, data = plugin.export(
  File "/opt/lemur/lemur/plugins/lemur_openssl/plugin.py", line 142, in export
    create_pkcs12(body, chain, output_tmp, key, alias, passphrase)
  File "/opt/lemur/lemur/plugins/lemur_openssl/plugin.py", line 49, in create_pkcs12
    assert isinstance(chain, str)
AssertionError

Traceback (most recent call last):
  File "/opt/lemur/lemur/common/schema.py", line 158, in decorated_function
    resp = f(*args, **kwargs)
  File "/opt/lemur/lemur/certificates/views.py", line 1430, in post
    extension, passphrase, data = plugin.export(
  File "/opt/lemur/lemur/plugins/lemur_openssl/plugin.py", line 142, in export
    create_pkcs12(body, chain, output_tmp, key, alias, passphrase)
  File "/opt/lemur/lemur/plugins/lemur_openssl/plugin.py", line 49, in create_pkcs12
    assert isinstance(chain, str)
AssertionError
```
The code was asserting that chain is a `str` type, but None is also a valid option. Further down, if it's a None, then the chain will not be included in the generated pkcs12 because:

```python
            with open(cert_tmp, "w") as f:
                if chain:
                    f.writelines([cert.strip() + "\n", chain.strip() + "\n"])
                else:
                    f.writelines([cert.strip() + "\n"])
```

With this modification, both a string *or* a None value are acceptable types for the chain variable.