### PR TITLE
Clear passphrase "memory" in the export plugin options

### DIFF
--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -1555,6 +1555,11 @@ class CertificateExport(AuthenticatedResource):
             cert.body, cert.chain, cert.private_key, options
         )
 
+        # Clear memory for last passphrase if it's in plugin.options
+        for option in plugin.options:
+            if 'value' in option and option['value'] == passphrase:
+                del option['value']
+
         # we take a hit in message size when b64 encoding
         return dict(
             extension=extension,


### PR DESCRIPTION
Resolves https://github.com/Netflix/lemur/issues/4233

After an export operation is done, if any of the plugin options fields have the passphrase as their value, the value will be deleted. Since the plugin object will stay in use for future exports, that new "default" for the option will stick around for the next use otherwise.

I considered putting similar functionality in the actual openssl plugin where I saw the behavior, but it makes sense to me that this should exist in the certificate export functionality. Any plugin that stores the passphrase in any of its options will now have that cleared before the next use of the plugin.

One side effect of this... I can't be sure that all plugins will label the option holding a passphrase the same if they have one. For that reason, I didn't just look for an option called `passphrase` to clear. That would have worked for the openssl plugin at least. I opted to look for any options where the stored option value is equal to the passphrase returned above by the call to `plugin.export()`. That does mean that if I submit the passphrase for several of the fields, they will all have their values cleared out. I feel like that's probably a good thing if folks are setting all the options to the same thing as the passphrase.