### PR TITLE
defining version to avoid invalid version error

### DIFF
--- a/lemur/__about__.py
+++ b/lemur/__about__.py
@@ -15,7 +15,7 @@ __title__ = "lemur"
 __summary__ = "Certificate management and orchestration service"
 __uri__ = "https://github.com/Netflix/lemur"
 
-__version__ = "develop"
+__version__ = "1.2.dev0"
 
 __author__ = "The Lemur developers"
 __email__ = "security@netflix.com"


### PR DESCRIPTION
trying to avoid this error 
```
/apps/lemur/lib/python3.9/site-packages/setuptools/dist.py:543: UserWarning: The version specified ('develop') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
```