### PR TITLE
No fine-grained authz for role global_cert_issuer

### DIFF
--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -520,8 +520,8 @@ class CertificatesList(AuthenticatedResource):
         data["creator"] = g.user
         # allowed_issuance_for_domain throws UnauthorizedError if caller is not authorized
         try:
-            # unless admin, perform fine grained authorization
-            if not g.user.is_admin and not data["authority"].is_private_authority:
+            # unless admin or global_cert_issuer, perform fine grained authorization
+            if not g.user.is_admin_or_global_cert_issuer and not data["authority"].is_private_authority:
                 service.allowed_issuance_for_domain(data["common_name"], data["extensions"])
         except UnauthorizedError as e:
             return dict(message=str(e)), 403

--- a/lemur/manage.py
+++ b/lemur/manage.py
@@ -225,6 +225,17 @@ class InitializeApp(Command):
             )
             sys.stdout.write("[+] Created 'operator' role\n")
 
+        global_cert_issuer_role = role_service.get_by_name("global_cert_issuer")
+
+        if global_cert_issuer_role:
+            sys.stdout.write("[-] global_cert_issuer role already created, skipping...!\n")
+        else:
+            # we create a global_cert_issuer role
+            global_cert_issuer_role = role_service.create(
+                "global_cert_issuer", description="This is the Lemur global_cert_issuer role."
+            )
+            sys.stdout.write("[+] Created 'global_cert_issuer' role\n")
+
         read_only_role = role_service.get_by_name("read-only")
 
         if read_only_role:

--- a/lemur/users/models.py
+++ b/lemur/users/models.py
@@ -92,6 +92,18 @@ class User(db.Model):
             if role.name == "admin":
                 return True
 
+    @property
+    def is_admin_or_global_cert_issuer(self):
+        """
+        Determine if the current user is a global cert issuer. The user has either 'admin' or 'global_cert_issuer' role
+        associated with them.
+
+        :return:
+        """
+        for role in self.roles:
+            if role.name == "admin" or role.name == "global_cert_issuer":
+                return True
+
     def __repr__(self):
         return "User(username={username})".format(username=self.username)
 


### PR DESCRIPTION
Similar to the change https://github.com/Netflix/lemur/pull/4034, allow users with global_cert_issuer to skip fine grained domain authorization and issue certificate for any domain. This allows to have a subset of users who'll have admin equivalent of permissions only when it comes to issuing certificates.
One still needs to have CA level access, which is current lemur behavior.