### PR TITLE
Fix release workflow 

### DIFF
--- a/.github/workflows/lemur-publish-release-pypi.yml
+++ b/.github/workflows/lemur-publish-release-pypi.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         # from refs/tags/v0.8.1 get 0.8.1
         VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
-        PLACEHOLDER='__version__ = "develop"'
+        PLACEHOLDER='^__version__ =.*'
         VERSION_FILE='lemur/__about__.py'
         # in case placeholder is missing, exists with code 1 and github actions aborts the build
         grep "$PLACEHOLDER" "$VERSION_FILE"


### PR DESCRIPTION
the __version__ is no longer set to "develop", and our release scripts needs to accommodate for that

this change ensures the `sed` replaces the `__version__` regardless it's current value. 