### PR TITLE
Upgrade Python, Ubuntu, and Postgres

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # These owners will be the default owners for everything in the repo.
-*                            @hosseinsh @charhate @jtschladen @douglasc-nflx
+*                            @hosseinsh @charhate @jtschladen @douglasc-nflx @jmcrawford45

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,23 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
-        postgres-version: [10, 12]
-        os: [ubuntu-18.04, ubuntu-20.04]
+        python-version: ["3.8", "3.9", "3.10"]
+        postgres-version: [12, 15]
+        os: [ubuntu-20.04, ubuntu-22.04]
         include:
-          - python-version: 3.8
+          - python-version: "3.8"
             toxenv: py38
-          - python-version: 3.9
+          - python-version: "3.9"
             toxenv: py39
+          - python-version: "3.10"
+            toxenv: py310
+        exclude:
+          - os: ubuntu-20.04  # python 3.10 isn't working on 20.04 due to missing "libldap-2.5.so.0"
+            python-version: "3.10"
+          - os: ubuntu-22.04  # python 3.8 isn't working on 22.04 due to missing "libldap_r-2.4.so.2"
+            python-version: "3.8"
+          - os: ubuntu-22.04  # python 3.9 isn't working on 22.04 due to missing "libldap_r-2.4.so.2"
+            python-version: "3.9"
       fail-fast: false # run all matrix jobs even if one fails, so we know if the problem is version-specific
 
     services:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,8 +14,11 @@ sphinx:
 formats: all
 
 # Set the version of Python and requirements required to build the docs
+build:
+   os: ubuntu-22.04
+   tools:
+      python: "3.10"
 python:
-   version: 3.8
    install:
    - requirements: requirements-docs.txt
    - method: setuptools

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,45 @@ Changelog
 
 Unreleased
 ~~~~~~~~~~~~~~~~~~~~
+
+
+1.4.0 - `2023-04-04`
+~~~~~~~~~~~~~~~~~~~~
+Added support for Python 3.10, Postgres 15, and Ubuntu 22.04.
+Removed support for Postgres 10 and Ubuntu 18.04.
+
+Python 3.11 is known not to work with the current version of Flask.
+
+All combinations tested via GitHub Actions are listed below:
+
+.. list-table:: Version Support Matrix
+   :header-rows: 1
+
+   * - Python
+     - Postgres
+     - Ubuntu
+   * - 3.8
+     - 12
+     - 20.04
+   * - 3.8
+     - 15
+     - 20.04
+   * - 3.9
+     - 12
+     - 20.04
+   * - 3.9
+     - 15
+     - 20.04
+   * - 3.9
+     - 15
+     - 20.04
+   * - 3.10
+     - 12
+     - 22.04
+   * - 3.10
+     - 15
+     - 22.04
+
 Added additional validation and logging for destinations.
 Destination labels are now limited to 32 characters, and s3
 prefixes can no longer begin with /.
@@ -11,7 +50,6 @@ S3 destination path prefixes now default to "" instead of "None/"
 Enforce case consistency in authority signing algorithms. Specifically, this renames SHA384withECDSA -> sha384WithECDSA
 and SHA512withECDSA -> sha512WithECDSA. Notably, the backend schema will still accept the uppercase equivalents to
 maintain backwards compatibility.
-
 
 1.3.2 - `2023-02-24`
 ~~~~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -169,6 +169,7 @@ setup(
         'Topic :: Software Development',
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Natural Language :: English",
         "License :: OSI Approved :: Apache Software License"
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,2 @@
 [tox]
-envlist = py38,py39
+envlist = py38,py39,py310


### PR DESCRIPTION
**Python** 
Added: 3.10 (attempted to add 3.11, but it appears to require a Flask upgrade)
Kept: 3.8, 3.9

**Ubuntu**
Added: 22.04 (not tested with Python 3.8 or 3.9)
Kept: 20.04 (not tested with Python 3.10)
Removed: 18.04

**Postgres** 
Added: 15
Kept: 12
Removed: 10