### PR TITLE
Fix message attribute of a couple logs

### DIFF
--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -194,7 +194,7 @@ def report_failed_task(**kwargs):
     with flask_app.app_context():
         log_data = {
             "function": f"{__name__}.{sys._getframe().f_code.co_name}",
-            "Message": "Celery Task Failure",
+            "message": "Celery Task Failure",
         }
 
         # Add traceback if exception info is in the kwargs
@@ -219,7 +219,7 @@ def report_revoked_task(**kwargs):
     with flask_app.app_context():
         log_data = {
             "function": f"{__name__}.{sys._getframe().f_code.co_name}",
-            "Message": "Celery Task Revoked",
+            "message": "Celery Task Revoked",
         }
 
         error_tags = get_celery_request_tags(**kwargs)


### PR DESCRIPTION
For consistency, use lowercase `message` attribute for all logs.