### PR TITLE
Enable dependabot updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,18 @@
   version: 2
   updates:
-    - directory: "/"
+    - package-ecosystem: "pip"
+      directory: "/"
       schedule:
         interval: "weekly"
         day: "monday"
         time: "08:00"
         timezone: "America/Los_Angeles"
-      package-ecosystem: "pip"
-      reviewers:
-        - "hosseinsh"
-        - "charhate"
-        - "jtschladen"
-        - "douglasc-nflx"
       versioning-strategy: auto
       open-pull-requests-limit: 20
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+        interval: "weekly"
+        day: "monday"
+        time: "08:00"
+        timezone: "America/Los_Angeles"


### PR DESCRIPTION
I noticed that our GitHub action for CodeQL scanning is out of date. I also noticed that Dependabot now supports [updating actions](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot), so I'd like to let Dependabot take care of updating CodeQL for us.