### PR TITLE
Enforce duplicate destination check for certificate updates

### DIFF
--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -11,6 +11,7 @@ from builtins import str
 from flask import Blueprint, make_response, jsonify, g, current_app
 from flask_restful import reqparse, Api, inputs
 
+from lemur.certificates.service import validate_no_duplicate_destinations
 from lemur.common import validators
 from lemur.plugins.bases.authorization import UnauthorizedError
 from sentry_sdk import capture_exception
@@ -918,6 +919,14 @@ class Certificates(AuthenticatedResource):
                     dict(message="You are not authorized to update this certificate"),
                     403,
                 )
+
+        try:
+            validate_no_duplicate_destinations(data["destinations"])
+        except Exception as e:
+            return (
+                dict(message=str(e)),
+                400,
+            )
 
         for destination in data["destinations"]:
             if destination.plugin.requires_key:

--- a/lemur/tests/conftest.py
+++ b/lemur/tests/conftest.py
@@ -38,6 +38,7 @@ from .factories import (
     CACertificateFactory,
     DnsProviderFactory,
     OptionalCNAuthorityFactory,
+    DuplicateAllowedDestinationFactory,
 )
 
 
@@ -141,6 +142,13 @@ def optional_cn_authority(session):
 @pytest.fixture
 def destination(session):
     d = DestinationFactory()
+    session.commit()
+    return d
+
+
+@pytest.fixture
+def duplicate_allowed_destination(session):
+    d = DuplicateAllowedDestinationFactory()
     session.commit()
     return d
 
@@ -281,6 +289,15 @@ def destination_plugin():
 
     register(TestDestinationPlugin)
     return TestDestinationPlugin
+
+
+@pytest.fixture
+def duplicate_allowed_destination_plugin():
+    from lemur.plugins.base import register
+    from .plugins.destination_plugin import TestDestinationPluginDuplicatesAllowed
+
+    register(TestDestinationPluginDuplicatesAllowed)
+    return TestDestinationPluginDuplicatesAllowed
 
 
 @pytest.fixture

--- a/lemur/tests/factories.py
+++ b/lemur/tests/factories.py
@@ -209,6 +209,22 @@ class DestinationFactory(BaseFactory):
 
     plugin_name = "test-destination"
     label = Sequence(lambda n: "destination{0}".format(n))
+    options = [{"name": "exportPlugin", "type": "export-plugin", "value": {"plugin_options": [{}]}},
+               {"name": "accountNumber", "type": "str", "value": "1234567890"}]
+
+    class Meta:
+        """Factory Configuration."""
+
+        model = Destination
+
+
+class DuplicateAllowedDestinationFactory(BaseFactory):
+    """Destination factory."""
+
+    plugin_name = "test-destination-dupe-allowed"
+    label = Sequence(lambda n: "duplicate-allowed-destination{0}".format(n))
+    options = [{"name": "exportPlugin", "type": "export-plugin", "value": {"plugin_options": [{}]}},
+               {"name": "accountNumber", "type": "str", "value": "1234567890"}]
 
     class Meta:
         """Factory Configuration."""

--- a/lemur/tests/plugins/destination_plugin.py
+++ b/lemur/tests/plugins/destination_plugin.py
@@ -14,3 +14,21 @@ class TestDestinationPlugin(DestinationPlugin):
 
     def upload(self, name, body, private_key, cert_chain, options, **kwargs):
         return
+
+
+class TestDestinationPluginDuplicatesAllowed(DestinationPlugin):
+    title = "Test with Duplicates Allowed"
+    slug = "test-destination-dupe-allowed"
+    description = "Enables testing; allows duplicates"
+
+    author = "Jasmine Schladen"
+    author_url = "https://github.com/netflix/lemur.git"
+
+    def __init__(self, *args, **kwargs):
+        super(TestDestinationPluginDuplicatesAllowed, self).__init__(*args, **kwargs)
+
+    def allow_multiple_per_account(self):
+        return True
+
+    def upload(self, name, body, private_key, cert_chain, options, **kwargs):
+        return

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -1904,6 +1904,6 @@ def test_certificate_update_duplicate_destinations_allowed(client, crypto_author
     )
     assert resp.status_code == 200
     resp_cert = resp.json
-    assert len(resp_cert['destinations']) is 2
+    assert len(resp_cert['destinations']) == 2
     assert destination_output_schema.dump(destination1).data in resp_cert['destinations']
     assert destination_output_schema.dump(destination2).data in resp_cert['destinations']


### PR DESCRIPTION
This check is enforced on creation and reissuance, but not on edit, which can lead to certs that cannot be reissued.