### PR TITLE
Add listener certification for SNI

### DIFF
--- a/lemur/plugins/lemur_aws/elb.py
+++ b/lemur/plugins/lemur_aws/elb.py
@@ -6,6 +6,7 @@
 .. moduleauthor:: Kevin Glisson <kglisson@netflix.com>
 """
 import botocore
+import click
 from flask import current_app
 
 from retrying import retry
@@ -208,51 +209,6 @@ def get_listener_arn_from_endpoint(endpoint_name, endpoint_port, **kwargs):
             extra={
                 "endpoint_name": str(endpoint_name),
                 "endpoint_port": str(endpoint_port),
-            }
-        )
-        raise
-
-
-@sts_client("elbv2")
-@retry(retry_on_exception=retry_throttled, wait_fixed=2000, stop_max_attempt_number=20)
-def has_listener_cert_for_sni(listener_arn, **kwargs):
-    """
-    Describe listener to list certificates in use
-    For cert added as SNI listener, it will be listed with both, default true and false
-    :param listener_arn:
-    :return: True/False
-    """
-    try:
-        listener_certificates = kwargs["client"].describe_listener_certificates(
-            ListenerArn=listener_arn
-        )
-
-        default_cert = ""
-
-        for cert in listener_certificates["Certificates"]:
-            if cert["IsDefault"]:
-                default_cert = cert["CertificateArn"]
-                break
-
-        for cert in listener_certificates["Certificates"]:
-            if cert["IsDefault"] is False and cert["CertificateArn"] == default_cert:
-                return True
-
-        return False
-
-    except Exception as e:  # noqa
-        metrics.send(
-            "has_listener_cert_for_SNI_error",
-            "counter",
-            1,
-            metric_tags={
-                "error": str(e),
-                "listener_arn": listener_arn,
-            },
-        )
-        capture_exception(
-            extra={
-                "listener_arn": listener_arn,
             }
         )
         raise
@@ -466,13 +422,14 @@ def attach_certificate_v2(listener_arn, port, certificates, **kwargs):
     :param certificates:
     """
     try:
-        needs_cert_update_for_sni = has_listener_cert_for_sni(listener_arn)
+        needs_cert_update_for_sni = has_listener_cert_for_sni(listener_arn, kwargs["client"])
 
         modified_listener = kwargs["client"].modify_listener(
             ListenerArn=listener_arn, Port=port, Certificates=certificates
         )
 
         if needs_cert_update_for_sni:
+            click.echo("[+] Adding cert as listener cert for SNI")
             kwargs["client"].add_listener_certificates(
                 ListenerArn=listener_arn, Certificates=certificates
             )
@@ -483,3 +440,49 @@ def attach_certificate_v2(listener_arn, port, certificates, **kwargs):
             current_app.logger.warning("Loadbalancer does not exist.")
         else:
             raise e
+
+
+def has_listener_cert_for_sni(listener_arn, client):
+    """
+    Describe listener to list certificates in use
+    For cert added as SNI listener, it will be listed with both, default true and false
+    :param listener_arn:
+    :return: True/False
+    """
+    try:
+        listener_certificates = client.describe_listener_certificates(
+            ListenerArn=listener_arn
+        )
+
+        default_cert = ""
+
+        for cert in listener_certificates["Certificates"]:
+            if cert["IsDefault"]:
+                default_cert = cert["CertificateArn"]
+                break
+
+        if not default_cert:
+            return false
+
+        for cert in listener_certificates["Certificates"]:
+            if cert["IsDefault"] is False and cert["CertificateArn"] == default_cert:
+                return True
+
+        return False
+
+    except Exception as e:  # noqa
+        metrics.send(
+            "has_listener_cert_for_SNI_error",
+            "counter",
+            1,
+            metric_tags={
+                "error": str(e),
+                "listener_arn": listener_arn,
+            },
+        )
+        capture_exception(
+            extra={
+                "listener_arn": listener_arn,
+            }
+        )
+        raise

--- a/lemur/plugins/lemur_aws/elb.py
+++ b/lemur/plugins/lemur_aws/elb.py
@@ -6,7 +6,6 @@
 .. moduleauthor:: Kevin Glisson <kglisson@netflix.com>
 """
 import botocore
-import click
 from flask import current_app
 
 from retrying import retry
@@ -429,7 +428,7 @@ def attach_certificate_v2(listener_arn, port, certificates, **kwargs):
         )
 
         if needs_cert_update_for_sni:
-            click.echo("[+] Adding cert as listener cert for SNI")
+            current_app.logger.info(f"Adding cert as listener cert for SNI. listener_arn: {listener_arn}")
             kwargs["client"].add_listener_certificates(
                 ListenerArn=listener_arn, Certificates=certificates
             )
@@ -457,7 +456,7 @@ def has_listener_cert_for_sni(listener_arn, client):
         default_cert = ""
 
         for cert in listener_certificates["Certificates"]:
-            if cert["IsDefault"]:
+            if "IsDefault" in cert and cert["IsDefault"]:
                 default_cert = cert["CertificateArn"]
                 break
 
@@ -465,7 +464,7 @@ def has_listener_cert_for_sni(listener_arn, client):
             return False
 
         for cert in listener_certificates["Certificates"]:
-            if cert["IsDefault"] is False and cert["CertificateArn"] == default_cert:
+            if "IsDefault" in cert and cert["IsDefault"] is False and cert["CertificateArn"] == default_cert:
                 return True
 
         return False

--- a/lemur/plugins/lemur_aws/elb.py
+++ b/lemur/plugins/lemur_aws/elb.py
@@ -462,7 +462,7 @@ def has_listener_cert_for_sni(listener_arn, client):
                 break
 
         if not default_cert:
-            return false
+            return False
 
         for cert in listener_certificates["Certificates"]:
             if cert["IsDefault"] is False and cert["CertificateArn"] == default_cert:


### PR DESCRIPTION
If cert is used as Listener cert for SNI, lemur cert rotation does not configure new cert the same way. Along with `modify_listener`, it needs to do `add_listener_certificates`. 
Currently this code relies on `describe_listener_certificates` to see if there is a cert added with default value as both - true and false. 