### PR TITLE
Remove system_packages from readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,4 +23,3 @@ python:
    - requirements: requirements-docs.txt
    - method: setuptools
      path: .
-   system_packages: true


### PR DESCRIPTION
ReadTheDocs is removing support for installing system packages, so we should test removing them now to confirm we can still build docs.