### PR TITLE
Using newer versions of Python and nodejs to fix Docker build failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.7
+FROM python:3.8
 RUN apt-get update
 RUN apt-get install -y make software-properties-common curl
-RUN curl -sL https://deb.nodesource.com/setup_7.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 RUN apt-get update
-RUN apt-get install -y npm libldap2-dev libsasl2-dev libldap2-dev libssl-dev
+RUN apt-get install -y nodejs libldap2-dev libsasl2-dev libldap2-dev libssl-dev
 RUN pip install pip==20.0.2
 RUN pip install -U setuptools
 RUN pip install coveralls bandit


### PR DESCRIPTION
Running `docker compose run test` would fail. One of the required Python libraries is `celery[redis]==5.3.1` which is not available on Python 3.7 or older.

The `7.x` repository from NodeSource does not work with newer versions of Debian that the `python` containers are based on. I also had to install `nodejs` instead of just `npm` or it would fail. The `nodejs` package also installs `npm`.

I chose Python 3.8 since it is the lowest working version that supports that version of celery and Node.js 18 since it is the latest LTS release, and the tests pass when using it.