### PR TITLE
Handle token exchange failure

### DIFF
--- a/lemur/exceptions.py
+++ b/lemur/exceptions.py
@@ -45,7 +45,6 @@ class TokenExchangeFailed(LemurException):
         return f'Token exchange failed with {self.error}. {self.description}'
 
 
-
 class AttrNotFound(LemurException):
     def __init__(self, field):
         self.field = field

--- a/lemur/exceptions.py
+++ b/lemur/exceptions.py
@@ -36,6 +36,16 @@ class InvalidDistribution(LemurException):
         )
 
 
+class TokenExchangeFailed(LemurException):
+    def __init__(self, error, description):
+        self.error = error
+        self.description = description
+
+    def __str__(self):
+        return f'Token exchange failed with {self.error}. {self.description}'
+
+
+
 class AttrNotFound(LemurException):
     def __init__(self, field):
         self.field = field


### PR DESCRIPTION
Small PR to catch a case where token exchange can fail, this provides some error catching/handling around either the request directly failing or the ID/token missing (previously would just throw a generic KeyError if one of these were missing).