### PR TITLE
Handle a missing field

### DIFF
--- a/lemur/common/schema.py
+++ b/lemur/common/schema.py
@@ -156,6 +156,12 @@ def validate_schema(input_schema, output_schema):
 
             try:
                 resp = f(*args, **kwargs)
+            except KeyError as e:
+                capture_exception()
+                current_app.logger.exception(e)
+                missing_field = str(e).replace("'", "")  # This removes quotes around the missing key
+                msg = f"`{missing_field}` is required but is missing or not configured.  Please provide and try again."
+                return dict(message=msg), 500
             except Exception as e:
                 capture_exception()
                 current_app.logger.exception(e)

--- a/lemur/exceptions.py
+++ b/lemur/exceptions.py
@@ -45,7 +45,6 @@ class TokenExchangeFailed(LemurException):
         return f'Token exchange failed with {self.error}. {self.description}'
 
 
-
 class AttrNotFound(LemurException):
     def __init__(self, field):
         self.field = field

--- a/lemur/exceptions.py
+++ b/lemur/exceptions.py
@@ -36,6 +36,16 @@ class InvalidDistribution(LemurException):
         )
 
 
+class TokenExchangeFailed(LemurException):
+    def __init__(self, error, description):
+        self.error = error
+        self.description = description
+
+    def __str__(self):
+        return f'Token exchange failed with {self.error}. {self.description}'
+
+
+
 class AttrNotFound(LemurException):
     def __init__(self, field):
         self.field = field


### PR DESCRIPTION
Add a bit of error handling if we get thrown a key error. An example of this happening is in a new environment when populating Authorities if you missed the serial number or some sort of validity range it'd throw a generic error (no meaningful indification as to why it would fail to create), this way we got told specifically which field we're having issues with.