### PR TITLE
Requests Logging

### DIFF
--- a/lemur/default.conf.py
+++ b/lemur/default.conf.py
@@ -16,3 +16,6 @@ DEBUG = False
 
 LOG_LEVEL = "DEBUG"
 LOG_FILE = "lemur.log"
+LOG_REQUEST_HEADERS = False
+LOG_SANITIZE_REQUEST_HEADERS = True
+LOG_REQUEST_HEADERS_SKIP_ENDPOINT = ["/metrics", "/healthcheck"]

--- a/lemur/exceptions.py
+++ b/lemur/exceptions.py
@@ -45,7 +45,6 @@ class TokenExchangeFailed(LemurException):
         return f'Token exchange failed with {self.error}. {self.description}'
 
 
-
 class AttrNotFound(LemurException):
     def __init__(self, field):
         self.field = field

--- a/lemur/exceptions.py
+++ b/lemur/exceptions.py
@@ -36,6 +36,16 @@ class InvalidDistribution(LemurException):
         )
 
 
+class TokenExchangeFailed(LemurException):
+    def __init__(self, error, description):
+        self.error = error
+        self.description = description
+
+    def __str__(self):
+        return f'Token exchange failed with {self.error}. {self.description}'
+
+
+
 class AttrNotFound(LemurException):
     def __init__(self, field):
         self.field = field

--- a/lemur/manage.py
+++ b/lemur/manage.py
@@ -126,7 +126,9 @@ METRIC_PROVIDERS = []
 LOG_LEVEL = "DEBUG"
 LOG_FILE = "lemur.log"
 LOG_UPGRADE_FILE = "db_upgrade.log"
-
+LOG_REQUEST_HEADERS = False
+LOG_SANITIZE_REQUEST_HEADERS = True
+LOG_REQUEST_HEADERS_SKIP_ENDPOINT = ["/metrics", "/healthcheck"]  # These endpoints are noisy so skip them by default
 
 # Database
 


### PR DESCRIPTION
Add in functionality to log requests that come in.  This is useful both for debugging purposes as well as if we want to be able to audit usage logs.

We sanitize the URLs that touch /api/ by default to avoid exposing any sort of query parameters that could contain sensitive information.  This can be disabled for debugging purposes (not recommended in a prod env).

We also skip /metrics and /healthcheck, as these tend to be noisy and don't really do much for logging/debugging purposes.  This is set in an app config variable so that we can add endpoints to skip or otherwise modify what we're logging.

We log this at info level it can be turned off simply by increasing the log level.

This functionality defaults to off to avoid spamming existing folks who don't want this level of logging turned on.