### PR TITLE
Add config variable for Flask migration directory

### DIFF
--- a/lemur/factory.py
+++ b/lemur/factory.py
@@ -158,7 +158,7 @@ def configure_extensions(app):
     :param app:
     """
     db.init_app(app)
-    migrate.init_app(app, db)
+    migrate.init_app(app, db, app.config.get("FLASK_MIGRATIONS_PATH", "migrations"))
     principal.init_app(app)
     smtp_mail.init_app(app)
     metrics.init_app(app)


### PR DESCRIPTION
Small change to allow for specifying a Flask migration directory.  We default to the Flask default of just "migrations" if it's missing (so for current/existing environments it won't change). 