### PR TITLE
Drop support for python3.8, add 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,21 +8,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         postgres-version: [12, 15]
         os: [ubuntu-20.04, ubuntu-22.04]
         include:
-          - python-version: "3.8"
-            toxenv: py38
           - python-version: "3.9"
             toxenv: py39
           - python-version: "3.10"
             toxenv: py310
+          - python-version: "3.11"
+            toxenv: py311
         exclude:
           - os: ubuntu-20.04  # python 3.10 isn't working on 20.04 due to missing "libldap-2.5.so.0"
             python-version: "3.10"
-          - os: ubuntu-22.04  # python 3.8 isn't working on 22.04 due to missing "libldap_r-2.4.so.2"
-            python-version: "3.8"
           - os: ubuntu-22.04  # python 3.9 isn't working on 22.04 due to missing "libldap_r-2.4.so.2"
             python-version: "3.9"
       fail-fast: false # run all matrix jobs even if one fails, so we know if the problem is version-specific


### PR DESCRIPTION
3.8 is security only and EoL next year and 3.11 has been out for a year. we've had 2 PRs come up in the past week that hit 3.8 compatibility issues, so let's drop support to ease the maintenance burden