### PR TITLE
Escape {} for creating a new config

### DIFF
--- a/lemur/manage.py
+++ b/lemur/manage.py
@@ -157,12 +157,12 @@ IDP_GROUPS_KEYS = ["googleGroups"]  # a list of keys used by IDP(s) to return us
 # IDP_ROLES_PREFIX = "PREFIX-"  # prefix for all IDP-defined roles, used to match naming conventions
 # IDP_ROLES_SUFFIX = "_SUFFIX"  # suffix for all IDP-defined roles, used to match naming conventions
 # IDP_ROLES_DESCRIPTION = "Automatically generated role"  # Description to attach to automatically generated roles
-# IDP_ROLES_MAPPING = {}  # Dictionary that matches the IDP group name to the Lemur role. The Lemur role must exist.
-# Example: IDP_ROLES_MAPPING = {"security": "admin", "engineering": "operator", "jane_from_accounting": "read-only"}
+# IDP_ROLES_MAPPING = {{}}  # Dictionary that matches the IDP group name to the Lemur role. The Lemur role must exist.
+# Example: IDP_ROLES_MAPPING = {{"security": "admin", "engineering": "operator", "jane_from_accounting": "read-only"}}
 IDP_ASSIGN_ROLES_FROM_USER_GROUPS = True  # Assigns a Lemur role for each group found attached to the user
 IDP_CREATE_ROLES_FROM_USER_GROUPS = True  # Creates a Lemur role for each group found attached to the user if missing
 # Protects the built-in groups and prevents dynamically assigning users to them. Prevents IDP admin from becoming
-# Lemur admin. Use IDP_ROLES_MAPPING to create a mapping to assign these groups if desired. eg {"admin": "admin"}
+# Lemur admin. Use IDP_ROLES_MAPPING to create a mapping to assign these groups if desired. eg {{"admin": "admin"}}
 IDP_PROTECT_BUILTINS = True
 IDP_CREATE_PER_USER_ROLE = True  # Generates Lemur role for each user (allows cert assignment to a single user)
 


### PR DESCRIPTION
Small fix as when you run `lemur init` it doesn't like the unescaped braces.  Confirmed on a new install that it will create the config correctly and show the braces as originally expected.