### PR TITLE
exclude python-ldap in readthedocs only

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,8 +18,9 @@ build:
    os: ubuntu-22.04
    tools:
       python: "3.11"
-   commands:
-      - grep -v "python-ldap" requirements-docs.txt > tempreqs && mv tempreqs requirements-docs.txt
+   jobs:
+      pre_install:
+         - grep -v "python-ldap" requirements-docs.txt > tempreqs && mv tempreqs requirements-docs.txt
 
 
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,6 +18,10 @@ build:
    os: ubuntu-22.04
    tools:
       python: "3.11"
+   commands:
+      - grep -v "python-ldap" requirements-docs.txt > tempreqs && mv tempreqs requirements-docs.txt
+
+
 python:
    install:
    - requirements: requirements-docs.txt

--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,6 @@ endif
 	pip-compile --output-file requirements-dev.txt requirements-dev.in -U --no-emit-index-url --resolver=backtracking
 	pip-compile --output-file requirements-tests.txt requirements-tests.in -U --no-emit-index-url --resolver=backtracking
 	@echo "--> Done updating Python requirements"
-	@echo "--> Removing python-ldap from requirements-docs.txt"
-	grep -v "python-ldap" requirements-docs.txt > tempreqs && mv tempreqs requirements-docs.txt
 	@echo "--> Installing new dependencies"
 	pip install -e .
 	@echo "--> Done installing new dependencies"

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -628,6 +628,8 @@ python-json-logger==2.0.7
     #   -r requirements-tests.txt
     #   logmatic-python
     # via -r requirements-tests.txt
+python-ldap==3.4.3
+    # via -r requirements-tests.txt
 pytz==2023.3.post1
     # via
     #   -r requirements-tests.txt


### PR DESCRIPTION
CI is currently broken due to #4664 . We refactored out requirements files to use -r to make global resolves easier, but this means that dependabot PRs now add python-ldap to requirements-docs.txt. Instead of focusing on removing this dep at make time, let's only remove it at the stage where it's problematic (we can't install during readthedocs build because the env doesn't support arbitrary package installs).