### PR TITLE
one canonical Flask debug config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog
 
 Unreleased
 ~~~~~~~~~~~~~~~~~~~~
+To avoid confusion, the debug app configuration property has been replaced with the standard DEBUG flask app config.
 Added ability for new versions of LEMUR_TOKEN_SECRET via the LEMUR_TOKEN_SECRETS config option. This allows for
 migration and rotation of the secret.
 

--- a/docker/src/lemur.conf.py
+++ b/docker/src/lemur.conf.py
@@ -16,7 +16,7 @@ LOG_FILE = str(os.environ.get('LOG_FILE', '/home/lemur/.lemur/lemur.log'))
 LOG_JSON = True
 
 CORS = os.environ.get("CORS") == "True"
-debug = os.environ.get("DEBUG") == "True"
+DEBUG = os.environ.get("DEBUG") == "True"
 
 
 def get_random_secret(length):

--- a/lemur/manage.py
+++ b/lemur/manage.py
@@ -86,7 +86,7 @@ THREADS_PER_PAGE = 8
 
 # These will need to be set to `True` if you are developing locally
 CORS = False
-debug = False
+DEBUG = False
 
 # this is the secret key used by flask session management
 SECRET_KEY = "{flask_secret_key}"

--- a/lemur/tests/conf.py
+++ b/lemur/tests/conf.py
@@ -20,7 +20,7 @@ THREADS_PER_PAGE = 8
 
 # These will need to be set to `True` if you are developing locally
 CORS = False
-debug = False
+DEBUG = False
 
 TESTING = True
 


### PR DESCRIPTION
Flask configuration variables are case sensitive. Therefore, DEBUG and debug would be two different configuration variables, if both were used.

However, by convention and per Flask's documentation, the correct configuration variable for activating debug mode is DEBUG, not debug.

In other words, Flask recognizes DEBUG as the configuration variable to control the activation of debug mode. Using debug would not have the desired effect unless you've added custom code in your application to also check for a debug configuration variable.