### PR TITLE
Fix role mapping in oauth2 authentication

### DIFF
--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -153,7 +153,7 @@ def retrieve_user(user_api_url, access_token):
 
     headers = {}
 
-    if current_app.config.get("PING_INCLUDE_BEARER_TOKEN") and "ping" in current_app.config.get("PING_INCLUDE_BEARER_TOKEN"):
+    if current_app.config.get("PING_INCLUDE_BEARER_TOKEN") and "ping" in current_app.config.get("ACTIVE_PROVIDERS"):
         headers = {"Authorization": f"Bearer {access_token}"}
     else:
         headers = {"Authorization": f"Bearer {access_token}"}


### PR DESCRIPTION
When logging in with an oauth provider, the default roles (admin, operator and read-only) are not assigned.
The problem is that the roles are not obtained from the OAUTH2_USER_API_URL. They are obtained from the id_token.

It is mandatory to add the "Authorization" header of the oidc2 providers to obtain the user's information.