### PR TITLE
log san on cert mint failure

### DIFF
--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -491,6 +491,9 @@ def create(**kwargs):
             "message": "Exception minting certificate",
             "issuer": kwargs["authority"].name,
             "cn": kwargs.get("common_name"),
+            "san":  ",".join(
+                str(x.value) for x in kwargs["extensions"]["sub_alt_names"]["names"]
+            ),
         }
         current_app.logger.error(log_data, exc_info=True)
         capture_exception()

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -491,7 +491,7 @@ def create(**kwargs):
             "message": "Exception minting certificate",
             "issuer": kwargs["authority"].name,
             "cn": kwargs.get("common_name"),
-            "san":  ",".join(
+            "san": ",".join(
                 str(x.value) for x in kwargs["extensions"]["sub_alt_names"]["names"]
             ),
         }


### PR DESCRIPTION
Along with `CN`, log `SAN` for debugging on cert mint failure