### PR TITLE
cert name with optional CN for async issuance

### DIFF
--- a/lemur/pending_certificates/models.py
+++ b/lemur/pending_certificates/models.py
@@ -22,6 +22,7 @@ from sqlalchemy_utils.types.arrow import ArrowType
 from lemur.certificates.models import get_sequence
 from lemur.common import defaults, utils
 from lemur.database import BaseModel
+from lemur.domains.models import Domain
 from lemur.models import (
     pending_cert_source_associations,
     pending_cert_destination_associations,
@@ -138,6 +139,8 @@ class PendingCertificate(BaseModel):
             self.private_key = self.private_key.strip()
         self.external_id = kwargs.get("external_id")
 
+        domains = [Domain(name=x.value) for x in kwargs["extensions"]["sub_alt_names"]["names"]]
+
         # when destinations are appended they require a valid name.
         if kwargs.get("name"):
             self.name = get_or_increase_name(defaults.text_to_slug(kwargs["name"]), 0)
@@ -150,7 +153,8 @@ class PendingCertificate(BaseModel):
                     kwargs["authority"].name,
                     dt.now(),
                     dt.now(),
-                    False,
+                    len(domains) > 1,
+                    domains
                 ),
                 self.external_id,
             )

--- a/lemur/pending_certificates/models.py
+++ b/lemur/pending_certificates/models.py
@@ -139,7 +139,9 @@ class PendingCertificate(BaseModel):
             self.private_key = self.private_key.strip()
         self.external_id = kwargs.get("external_id")
 
-        domains = [Domain(name=x.value) for x in kwargs["extensions"]["sub_alt_names"]["names"]]
+        domains = []
+        if kwargs.get("extensions"):
+            domains = [Domain(name=x.value) for x in kwargs["extensions"]["sub_alt_names"]["names"]]
 
         # when destinations are appended they require a valid name.
         if kwargs.get("name"):


### PR DESCRIPTION
Send SANs white creating pending cert name. This is needed for creating a cert without requesting a CN, as CN is optional. This is an extension of an old PR https://github.com/Netflix/lemur/pull/3845. Current code changes are relevant to only async cert issuance.