### PR TITLE
Bump jinja to 3.1.3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -298,7 +298,7 @@ jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   -r requirements-tests.txt
     #   flask

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -327,7 +327,7 @@ javaobj-py3==0.4.3
     # via
     #   -r requirements-tests.txt
     #   pyjks
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   -r requirements-tests.txt
     #   flask

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -255,7 +255,7 @@ javaobj-py3==0.4.3
     # via
     #   -r requirements.txt
     #   pyjks
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   -r requirements.txt
     #   flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -151,7 +151,7 @@ itsdangerous==2.1.2
     #   flask
 javaobj-py3==0.4.3
     # via pyjks
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   -r requirements.in
     #   flask


### PR DESCRIPTION
Note: due to https://github.com/dependabot/dependabot-core/issues/8382, we can no longer unignore any dependencies due to the master -> main rename until this issue is resolved