### PR TITLE
fixed dependencies and small build issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ reset-db:
 
 setup-git:
 	@echo "--> Installing git hooks"
-	if [ -d .git/hooks ]; then \
+	if [[ -d .git/hooks && -d hooks ]]; then \
 		git config branch.autosetuprebase always; \
 		cd .git/hooks && ln -sf ../../hooks/* ./; \
 	fi
@@ -94,7 +94,7 @@ lint: lint-python lint-js
 lint-python:
 	@echo "--> Linting Python files"
 	PYFLAKES_NODOCTEST=1 flake8 lemur
-	mypy .
+	mypy  # scan the directory specified in mypy.ini
 	@echo ""
 
 lint-js:
@@ -116,10 +116,10 @@ endif
 	@echo "--> Updating Python requirements"
 	pip install --upgrade pip
 	pip install --upgrade pip-tools
-	pip-compile --output-file requirements.txt requirements.in -U --no-emit-index-url --resolver=backtracking
-	pip-compile --output-file requirements-docs.txt requirements-docs.in -U --no-emit-index-url --resolver=backtracking
-	pip-compile --output-file requirements-dev.txt requirements-dev.in -U --no-emit-index-url --resolver=backtracking
-	pip-compile --output-file requirements-tests.txt requirements-tests.in -U --no-emit-index-url --resolver=backtracking
+	pip-compile -v --output-file requirements.txt requirements.in -U --no-emit-index-url --resolver=backtracking
+	pip-compile -v --output-file requirements-tests.txt requirements-tests.in -U --no-emit-index-url --resolver=backtracking
+	pip-compile -v --output-file requirements-dev.txt requirements-dev.in -U --no-emit-index-url --resolver=backtracking
+	pip-compile -v --output-file requirements-docs.txt requirements-docs.in -U --no-emit-index-url --resolver=backtracking
 	@echo "--> Done updating Python requirements"
 	@echo "--> Installing new dependencies"
 	pip install -e .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,13 +8,13 @@ acme==2.9.0
     # via
     #   -r requirements-tests.txt
     #   certbot
-alembic==1.12.0
+alembic==1.13.1
     # via
     #   -r requirements-tests.txt
     #   flask-migrate
 alembic-autogenerate-enums==0.1.2
     # via -r requirements-tests.txt
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements-tests.txt
     #   kombu
@@ -34,7 +34,7 @@ async-timeout==4.0.3
     #   redis
 asyncpool==1.0
     # via -r requirements-tests.txt
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   -r requirements-tests.txt
     #   jschema-to-python
@@ -42,17 +42,17 @@ attrs==23.1.0
     #   jsonschema
     #   referencing
     #   sarif-om
-aws-sam-translator==1.78.0
+aws-sam-translator==1.86.0
     # via
     #   -r requirements-tests.txt
     #   cfn-lint
-aws-xray-sdk==2.12.1
+aws-xray-sdk==2.13.0
     # via
     #   -r requirements-tests.txt
     #   moto
-bandit==1.7.7
+bandit==1.7.8
     # via -r requirements-tests.txt
-bcrypt==4.0.1
+bcrypt==4.1.2
     # via
     #   -r requirements-tests.txt
     #   flask-bcrypt
@@ -63,29 +63,29 @@ billiard==4.2.0
     #   celery
 black==24.3.0
     # via -r requirements-tests.txt
-blinker==1.6.3
+blinker==1.7.0
     # via
     #   -r requirements-tests.txt
     #   flask
     #   flask-mail
     #   flask-principal
-boto3==1.34.19
+boto3==1.34.72
     # via
     #   -r requirements-tests.txt
     #   aws-sam-translator
     #   moto
-botocore==1.34.64
+botocore==1.34.72
     # via
     #   -r requirements-tests.txt
     #   aws-xray-sdk
     #   boto3
     #   moto
     #   s3transfer
-celery[redis]==5.3.5
+celery[redis]==5.3.6
     # via -r requirements-tests.txt
-certbot==2.8.0
+certbot==2.9.0
     # via -r requirements-tests.txt
-certifi==2023.11.17
+certifi==2024.2.2
     # via
     #   -r requirements-tests.txt
     #   requests
@@ -99,11 +99,11 @@ cffi==1.16.0
     #   pynacl
 cfgv==3.4.0
     # via pre-commit
-cfn-lint==0.82.2
+cfn-lint==0.86.1
     # via
     #   -r requirements-tests.txt
     #   moto
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via
     #   -r requirements-tests.txt
     #   requests
@@ -116,7 +116,7 @@ click==8.1.7
     #   click-plugins
     #   click-repl
     #   flask
-click-didyoumean==0.3.0
+click-didyoumean==0.3.1
     # via
     #   -r requirements-tests.txt
     #   celery
@@ -128,7 +128,7 @@ click-repl==0.3.0
     # via
     #   -r requirements-tests.txt
     #   celery
-cloudflare==2.16.0
+cloudflare==2.19.2
     # via -r requirements-tests.txt
 configargparse==1.7
     # via
@@ -140,7 +140,7 @@ configobj==5.0.8
     #   certbot
 coverage==7.4.4
     # via -r requirements-tests.txt
-cryptography==42.0.4
+cryptography==42.0.5
     # via
     #   -r requirements-tests.txt
     #   acme
@@ -152,7 +152,6 @@ cryptography==42.0.4
     #   pyspnego
     #   python-jose
     #   requests-ntlm
-    #   secretstorage
     #   sshpubkeys
     #   types-paramiko
     #   types-pyopenssl
@@ -161,9 +160,9 @@ deprecated==1.2.14
     # via
     #   -r requirements-tests.txt
     #   limits
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
-distro==1.8.0
+distro==1.9.0
     # via
     #   -r requirements-tests.txt
     #   certbot
@@ -173,7 +172,7 @@ dnspython==1.15.0
     #   dnspython3
 dnspython3==1.15.0
     # via -r requirements-tests.txt
-docker==6.1.3
+docker==7.0.0
     # via
     #   -r requirements-tests.txt
     #   moto
@@ -187,21 +186,21 @@ ecdsa==0.18.0
     #   moto
     #   python-jose
     #   sshpubkeys
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -r requirements-tests.txt
     #   pytest
 factory-boy==3.3.0
     # via -r requirements-tests.txt
-faker==23.2.1
+faker==24.4.0
     # via
     #   -r requirements-tests.txt
     #   factory-boy
-fakeredis==2.20.1
+fakeredis==2.21.3
     # via -r requirements-tests.txt
-filelock==3.12.4
+filelock==3.13.3
     # via virtualenv
-flake8==6.1.0
+flake8==7.0.0
     # via -r requirements-dev.in
 flask==2.3.3
     # via
@@ -223,7 +222,7 @@ flask-limiter==3.5.1
     # via -r requirements-tests.txt
 flask-mail==0.9.1
     # via -r requirements-tests.txt
-flask-migrate==4.0.5
+flask-migrate==4.0.7
     # via -r requirements-tests.txt
 flask-principal==0.4.0
     # via -r requirements-tests.txt
@@ -247,20 +246,20 @@ gunicorn==21.2.0
     # via -r requirements-tests.txt
 hvac==2.1.0
     # via -r requirements-tests.txt
-identify==2.5.30
+identify==2.5.35
     # via pre-commit
-idna==3.4
+idna==3.6
     # via
     #   -r requirements-tests.txt
     #   requests
-importlib-metadata==6.8.0
+importlib-metadata==7.1.0
     # via
     #   -r requirements-tests.txt
     #   certbot
     #   flask
     #   keyring
     #   twine
-importlib-resources==6.1.0
+importlib-resources==6.4.0
     # via
     #   -r requirements-tests.txt
     #   limits
@@ -276,16 +275,16 @@ itsdangerous==2.1.2
     # via
     #   -r requirements-tests.txt
     #   flask
-jaraco-classes==3.3.0
+jaraco-classes==3.3.1
+    # via keyring
+jaraco-context==4.3.0
+    # via keyring
+jaraco-functools==4.0.0
     # via keyring
 javaobj-py3==0.4.3
     # via
     #   -r requirements-tests.txt
     #   pyjks
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.3
     # via
     #   -r requirements-tests.txt
@@ -317,7 +316,7 @@ jsonpatch==1.33
     # via
     #   -r requirements-tests.txt
     #   cfn-lint
-jsonpickle==3.0.2
+jsonpickle==3.0.3
     # via
     #   -r requirements-tests.txt
     #   jschema-to-python
@@ -325,18 +324,18 @@ jsonpointer==2.4
     # via
     #   -r requirements-tests.txt
     #   jsonpatch
-jsonschema==4.19.1
+jsonschema==4.21.1
     # via
     #   -r requirements-tests.txt
     #   aws-sam-translator
     #   cfn-lint
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-path==0.3.1
+jsonschema-path==0.3.2
     # via
     #   -r requirements-tests.txt
     #   openapi-spec-validator
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via
     #   -r requirements-tests.txt
     #   jsonschema
@@ -345,17 +344,17 @@ junit-xml==1.9
     # via
     #   -r requirements-tests.txt
     #   cfn-lint
-keyring==24.2.0
+keyring==25.0.0
     # via twine
-kombu==5.3.3
+kombu==5.3.6
     # via
     #   -r requirements-tests.txt
     #   celery
-lazy-object-proxy==1.9.0
+lazy-object-proxy==1.10.0
     # via
     #   -r requirements-tests.txt
     #   openapi-spec-validator
-limits==3.6.0
+limits==3.10.1
     # via
     #   -r requirements-tests.txt
     #   flask-limiter
@@ -363,7 +362,7 @@ lockfile==0.12.2
     # via -r requirements-tests.txt
 logmatic-python==0.1.7
     # via -r requirements-tests.txt
-mako==1.2.4
+mako==1.3.2
     # via
     #   -r requirements-tests.txt
     #   alembic
@@ -371,7 +370,7 @@ markdown-it-py==3.0.0
     # via
     #   -r requirements-tests.txt
     #   rich
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   -r requirements-tests.txt
     #   jinja2
@@ -389,9 +388,11 @@ mdurl==0.1.2
     # via
     #   -r requirements-tests.txt
     #   markdown-it-py
-more-itertools==10.1.0
-    # via jaraco-classes
-moto[all]==4.2.10
+more-itertools==10.2.0
+    # via
+    #   jaraco-classes
+    #   jaraco-functools
+moto[all]==4.2.14
     # via -r requirements-tests.txt
 mpmath==1.3.0
     # via
@@ -401,7 +402,7 @@ multipart==0.2.4
     # via
     #   -r requirements-tests.txt
     #   moto
-mypy==1.8.0
+mypy==1.9.0
     # via -r requirements-tests.txt
 mypy-extensions==1.0.0
     # via
@@ -410,11 +411,11 @@ mypy-extensions==1.0.0
     #   mypy
 ndg-httpsclient==0.5.1
     # via -r requirements-tests.txt
-networkx==3.1
+networkx==3.2.1
     # via
     #   -r requirements-tests.txt
     #   cfn-lint
-nh3==0.2.14
+nh3==0.2.17
     # via readme-renderer
 nodeenv==1.8.0
     # via
@@ -434,7 +435,7 @@ ordered-set==4.1.0
     # via
     #   -r requirements-tests.txt
     #   flask-limiter
-packaging==23.2
+packaging==24.0
     # via
     #   -r requirements-tests.txt
     #   black
@@ -452,11 +453,11 @@ pathable==0.4.3
     # via
     #   -r requirements-tests.txt
     #   jsonschema-path
-pathspec==0.11.2
+pathspec==0.12.1
     # via
     #   -r requirements-tests.txt
     #   black
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements-tests.txt
     #   jschema-to-python
@@ -464,30 +465,30 @@ pbr==5.11.1
     #   stevedore
 pem==23.1.0
     # via -r requirements-tests.txt
-pkginfo==1.9.6
+pkginfo==1.10.0
     # via twine
-platformdirs==3.11.0
+platformdirs==4.2.0
     # via
     #   -r requirements-tests.txt
     #   black
     #   virtualenv
-pluggy==1.3.0
+pluggy==1.4.0
     # via
     #   -r requirements-tests.txt
     #   pytest
-pre-commit==3.6.2
+pre-commit==3.7.0
     # via -r requirements-dev.in
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.43
     # via
     #   -r requirements-tests.txt
     #   click-repl
 psycopg2==2.9.9
     # via -r requirements-tests.txt
-py-partiql-parser==0.4.2
+py-partiql-parser==0.5.0
     # via
     #   -r requirements-tests.txt
     #   moto
-pyasn1==0.5.0
+pyasn1==0.6.0
     # via
     #   -r requirements-tests.txt
     #   ndg-httpsclient
@@ -496,7 +497,7 @@ pyasn1==0.5.0
     #   python-jose
     #   python-ldap
     #   rsa
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.0
     # via
     #   -r requirements-tests.txt
     #   pyjks
@@ -507,23 +508,23 @@ pycparser==2.21
     # via
     #   -r requirements-tests.txt
     #   cffi
-pycryptodomex==3.19.1
+pycryptodomex==3.20.0
     # via
     #   -r requirements-tests.txt
     #   pyjks
-pydantic==2.4.2
+pydantic==2.6.4
     # via
     #   -r requirements-tests.txt
     #   aws-sam-translator
-pydantic-core==2.10.1
+pydantic-core==2.16.3
     # via
     #   -r requirements-tests.txt
     #   pydantic
-pyflakes==3.1.0
+pyflakes==3.2.0
     # via
     #   -r requirements-tests.txt
     #   flake8
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   -r requirements-tests.txt
     #   readme-renderer
@@ -542,7 +543,7 @@ pyopenssl==24.1.0
     #   acme
     #   josepy
     #   ndg-httpsclient
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via
     #   -r requirements-tests.txt
     #   moto
@@ -555,16 +556,16 @@ pyspnego==0.10.2
     # via
     #   -r requirements-tests.txt
     #   requests-ntlm
-pytest==8.0.0
+pytest==8.1.1
     # via
     #   -r requirements-tests.txt
     #   pytest-flask
     #   pytest-mock
 pytest-flask==1.3.0
     # via -r requirements-tests.txt
-pytest-mock==3.12.0
+pytest-mock==3.14.0
     # via -r requirements-tests.txt
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements-tests.txt
     #   arrow
@@ -583,7 +584,7 @@ python-json-logger==2.0.7
     #   logmatic-python
 python-ldap==3.4.4
     # via -r requirements-tests.txt
-pytz==2023.3.post1
+pytz==2024.1
     # via
     #   -r requirements-tests.txt
     #   acme
@@ -600,20 +601,20 @@ pyyaml==6.0.1
     #   moto
     #   pre-commit
     #   responses
-readme-renderer==42.0
+readme-renderer==43.0
     # via twine
-redis==5.0.1
+redis==5.0.3
     # via
     #   -r requirements-tests.txt
     #   celery
     #   fakeredis
-referencing==0.30.2
+referencing==0.31.1
     # via
     #   -r requirements-tests.txt
     #   jsonschema
     #   jsonschema-path
     #   jsonschema-specifications
-regex==2023.10.3
+regex==2023.12.25
     # via
     #   -r requirements-tests.txt
     #   cfn-lint
@@ -632,7 +633,7 @@ requests==2.31.0
     #   requests-toolbelt
     #   responses
     #   twine
-requests-mock==1.11.0
+requests-mock==1.12.0
     # via -r requirements-tests.txt
 requests-ntlm==1.2.0
     # via
@@ -640,7 +641,7 @@ requests-ntlm==1.2.0
     #   certsrv
 requests-toolbelt==1.0.0
     # via twine
-responses==0.23.3
+responses==0.25.0
     # via
     #   -r requirements-tests.txt
     #   moto
@@ -652,13 +653,13 @@ rfc3339-validator==0.1.4
     #   openapi-schema-validator
 rfc3986==2.0.0
     # via twine
-rich==13.6.0
+rich==13.7.1
     # via
     #   -r requirements-tests.txt
     #   bandit
     #   flask-limiter
     #   twine
-rpds-py==0.10.6
+rpds-py==0.18.0
     # via
     #   -r requirements-tests.txt
     #   jsonschema
@@ -667,7 +668,7 @@ rsa==4.9
     # via
     #   -r requirements-tests.txt
     #   python-jose
-s3transfer==0.10.0
+s3transfer==0.10.1
     # via
     #   -r requirements-tests.txt
     #   boto3
@@ -675,9 +676,7 @@ sarif-om==1.0.4
     # via
     #   -r requirements-tests.txt
     #   cfn-lint
-secretstorage==3.3.3
-    # via keyring
-sentry-sdk==1.40.0
+sentry-sdk==1.44.0
     # via -r requirements-tests.txt
 six==1.16.0
     # via
@@ -687,7 +686,6 @@ six==1.16.0
     #   flask-restful
     #   junit-xml
     #   python-dateutil
-    #   requests-mock
     #   retrying
     #   rfc3339-validator
 sortedcontainers==2.4.0
@@ -701,13 +699,13 @@ sqlalchemy==1.3.24
     #   flask-sqlalchemy
     #   marshmallow-sqlalchemy
     #   sqlalchemy-utils
-sqlalchemy-utils==0.41.1
+sqlalchemy-utils==0.41.2
     # via -r requirements-tests.txt
 sshpubkeys==3.3.1
     # via
     #   -r requirements-tests.txt
     #   moto
-stevedore==5.1.0
+stevedore==5.2.0
     # via
     #   -r requirements-tests.txt
     #   bandit
@@ -729,7 +727,7 @@ twofish==0.3.0
     # via
     #   -r requirements-tests.txt
     #   pyjks
-types-deprecated==1.2.9.20240106
+types-deprecated==1.2.9.20240311
     # via -r requirements-tests.txt
 types-paramiko==3.4.0.20240311
     # via -r requirements-tests.txt
@@ -739,23 +737,19 @@ types-pyopenssl==24.0.0.20240311
     #   types-redis
 types-pyrfc3339==1.1.1.5
     # via -r requirements-tests.txt
-types-python-dateutil==2.8.19.14
+types-python-dateutil==2.9.0.20240316
     # via
     #   -r requirements-tests.txt
     #   arrow
 types-pytz==2024.1.0.20240203
     # via -r requirements-tests.txt
-types-pyyaml==6.0.12.12
-    # via
-    #   -r requirements-tests.txt
-    #   responses
-types-redis==4.6.0.11
+types-redis==4.6.0.20240311
     # via -r requirements-tests.txt
 types-requests==2.31.0.6
     # via -r requirements-tests.txt
-types-setuptools==69.1.0.20240223
+types-setuptools==69.2.0.20240317
     # via -r requirements-tests.txt
-types-six==1.16.21.20240106
+types-six==1.16.21.20240311
     # via -r requirements-tests.txt
 types-tabulate==0.9.0.20240106
     # via -r requirements-tests.txt
@@ -763,7 +757,7 @@ types-urllib3==1.26.25.14
     # via
     #   -r requirements-tests.txt
     #   types-requests
-typing-extensions==4.8.0
+typing-extensions==4.10.0
     # via
     #   -r requirements-tests.txt
     #   alembic
@@ -775,7 +769,7 @@ typing-extensions==4.8.0
     #   mypy
     #   pydantic
     #   pydantic-core
-tzdata==2023.3
+tzdata==2024.1
     # via
     #   -r requirements-tests.txt
     #   celery
@@ -788,7 +782,7 @@ urllib3==1.26.18
     #   responses
     #   sentry-sdk
     #   twine
-validators==0.22.0
+validators==0.24.0
     # via -r requirements-tests.txt
 vine==5.1.0
     # via
@@ -796,23 +790,19 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.24.5
+virtualenv==20.25.1
     # via pre-commit
-wcwidth==0.2.8
+wcwidth==0.2.13
     # via
     #   -r requirements-tests.txt
     #   prompt-toolkit
-websocket-client==1.6.4
-    # via
-    #   -r requirements-tests.txt
-    #   docker
 werkzeug==3.0.1
     # via
     #   -r requirements-tests.txt
     #   flask
     #   moto
     #   pytest-flask
-wrapt==1.15.0
+wrapt==1.16.0
     # via
     #   -r requirements-tests.txt
     #   aws-xray-sdk
@@ -821,7 +811,7 @@ xmltodict==0.13.0
     # via
     #   -r requirements-tests.txt
     #   moto
-zipp==3.17.0
+zipp==3.18.1
     # via
     #   -r requirements-tests.txt
     #   importlib-metadata

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -9,15 +9,15 @@ acme==2.9.0
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
     #   certbot
-alabaster==0.7.13
+alabaster==0.7.16
     # via sphinx
-alembic==1.12.0
+alembic==1.13.1
     # via
     #   -r requirements-tests.txt
     #   flask-migrate
 alembic-autogenerate-enums==0.1.2
     # via -r requirements-tests.txt
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements-tests.txt
     #   kombu
@@ -39,7 +39,7 @@ async-timeout==4.0.3
     #   redis
 asyncpool==1.0
     # via -r requirements-tests.txt
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   -r requirements-tests.txt
     #   jschema-to-python
@@ -47,19 +47,19 @@ attrs==23.1.0
     #   jsonschema
     #   referencing
     #   sarif-om
-aws-sam-translator==1.78.0
+aws-sam-translator==1.86.0
     # via
     #   -r requirements-tests.txt
     #   cfn-lint
-aws-xray-sdk==2.12.1
+aws-xray-sdk==2.13.0
     # via
     #   -r requirements-tests.txt
     #   moto
-babel==2.13.0
+babel==2.14.0
     # via sphinx
-bandit==1.7.7
+bandit==1.7.8
     # via -r requirements-tests.txt
-bcrypt==4.0.1
+bcrypt==4.1.2
     # via
     #   -r requirements-tests.txt
     #   flask-bcrypt
@@ -70,19 +70,19 @@ billiard==4.2.0
     #   celery
 black==24.3.0
     # via -r requirements-tests.txt
-blinker==1.6.3
+blinker==1.7.0
     # via
     #   -r requirements-tests.txt
     #   flask
     #   flask-mail
     #   flask-principal
-boto3==1.34.19
+boto3==1.34.72
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
     #   aws-sam-translator
     #   moto
-botocore==1.34.64
+botocore==1.34.72
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
@@ -90,15 +90,15 @@ botocore==1.34.64
     #   boto3
     #   moto
     #   s3transfer
-celery[redis]==5.3.5
+celery[redis]==5.3.6
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
-certbot==2.8.0
+certbot==2.9.0
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
-certifi==2023.11.17
+certifi==2024.2.2
     # via
     #   -r requirements-tests.txt
     #   requests
@@ -112,11 +112,11 @@ cffi==1.16.0
     #   -r requirements-tests.txt
     #   cryptography
     #   pynacl
-cfn-lint==0.82.2
+cfn-lint==0.86.1
     # via
     #   -r requirements-tests.txt
     #   moto
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via
     #   -r requirements-tests.txt
     #   requests
@@ -129,7 +129,7 @@ click==8.1.7
     #   click-plugins
     #   click-repl
     #   flask
-click-didyoumean==0.3.0
+click-didyoumean==0.3.1
     # via
     #   -r requirements-tests.txt
     #   celery
@@ -141,7 +141,7 @@ click-repl==0.3.0
     # via
     #   -r requirements-tests.txt
     #   celery
-cloudflare==2.16.0
+cloudflare==2.19.2
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
@@ -155,7 +155,7 @@ configobj==5.0.8
     #   certbot
 coverage==7.4.4
     # via -r requirements-tests.txt
-cryptography==42.0.4
+cryptography==42.0.5
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
@@ -176,7 +176,7 @@ deprecated==1.2.14
     # via
     #   -r requirements-tests.txt
     #   limits
-distro==1.8.0
+distro==1.9.0
     # via
     #   -r requirements-tests.txt
     #   certbot
@@ -188,7 +188,7 @@ dnspython3==1.15.0
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
-docker==6.1.3
+docker==7.0.0
     # via
     #   -r requirements-tests.txt
     #   moto
@@ -207,17 +207,17 @@ ecdsa==0.18.0
     #   moto
     #   python-jose
     #   sshpubkeys
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -r requirements-tests.txt
     #   pytest
 factory-boy==3.3.0
     # via -r requirements-tests.txt
-faker==23.2.1
+faker==24.4.0
     # via
     #   -r requirements-tests.txt
     #   factory-boy
-fakeredis==2.20.1
+fakeredis==2.21.3
     # via -r requirements-tests.txt
 flask==2.3.3
     # via
@@ -248,7 +248,7 @@ flask-mail==0.9.1
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
-flask-migrate==4.0.5
+flask-migrate==4.0.7
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
@@ -285,19 +285,19 @@ hvac==2.1.0
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
-idna==3.4
+idna==3.6
     # via
     #   -r requirements-tests.txt
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.8.0
+importlib-metadata==7.1.0
     # via
     #   -r requirements-tests.txt
     #   certbot
     #   flask
     #   sphinx
-importlib-resources==6.1.0
+importlib-resources==6.4.0
     # via
     #   -r requirements-tests.txt
     #   limits
@@ -351,7 +351,7 @@ jsonpatch==1.33
     # via
     #   -r requirements-tests.txt
     #   cfn-lint
-jsonpickle==3.0.2
+jsonpickle==3.0.3
     # via
     #   -r requirements-tests.txt
     #   jschema-to-python
@@ -359,18 +359,18 @@ jsonpointer==2.4
     # via
     #   -r requirements-tests.txt
     #   jsonpatch
-jsonschema==4.19.1
+jsonschema==4.21.1
     # via
     #   -r requirements-tests.txt
     #   aws-sam-translator
     #   cfn-lint
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-path==0.3.1
+jsonschema-path==0.3.2
     # via
     #   -r requirements-tests.txt
     #   openapi-spec-validator
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via
     #   -r requirements-tests.txt
     #   jsonschema
@@ -379,15 +379,15 @@ junit-xml==1.9
     # via
     #   -r requirements-tests.txt
     #   cfn-lint
-kombu==5.3.3
+kombu==5.3.6
     # via
     #   -r requirements-tests.txt
     #   celery
-lazy-object-proxy==1.9.0
+lazy-object-proxy==1.10.0
     # via
     #   -r requirements-tests.txt
     #   openapi-spec-validator
-limits==3.6.0
+limits==3.10.1
     # via
     #   -r requirements-tests.txt
     #   flask-limiter
@@ -397,7 +397,7 @@ logmatic-python==0.1.7
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
-mako==1.2.4
+mako==1.3.2
     # via
     #   -r requirements-tests.txt
     #   alembic
@@ -405,7 +405,7 @@ markdown-it-py==3.0.0
     # via
     #   -r requirements-tests.txt
     #   rich
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   -r requirements-tests.txt
     #   jinja2
@@ -424,7 +424,7 @@ mdurl==0.1.2
     # via
     #   -r requirements-tests.txt
     #   markdown-it-py
-moto[all]==4.2.10
+moto[all]==4.2.14
     # via -r requirements-tests.txt
 mpmath==1.3.0
     # via
@@ -434,7 +434,7 @@ multipart==0.2.4
     # via
     #   -r requirements-tests.txt
     #   moto
-mypy==1.8.0
+mypy==1.9.0
     # via -r requirements-tests.txt
 mypy-extensions==1.0.0
     # via
@@ -443,7 +443,7 @@ mypy-extensions==1.0.0
     #   mypy
 ndg-httpsclient==0.5.1
     # via -r requirements-tests.txt
-networkx==3.1
+networkx==3.2.1
     # via
     #   -r requirements-tests.txt
     #   cfn-lint
@@ -461,7 +461,7 @@ ordered-set==4.1.0
     # via
     #   -r requirements-tests.txt
     #   flask-limiter
-packaging==23.2
+packaging==24.0
     # via
     #   -r requirements-tests.txt
     #   black
@@ -482,11 +482,11 @@ pathable==0.4.3
     # via
     #   -r requirements-tests.txt
     #   jsonschema-path
-pathspec==0.11.2
+pathspec==0.12.1
     # via
     #   -r requirements-tests.txt
     #   black
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements-tests.txt
     #   jschema-to-python
@@ -496,25 +496,25 @@ pem==23.1.0
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
-platformdirs==3.11.0
+platformdirs==4.2.0
     # via
     #   -r requirements-tests.txt
     #   black
-pluggy==1.3.0
+pluggy==1.4.0
     # via
     #   -r requirements-tests.txt
     #   pytest
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.43
     # via
     #   -r requirements-tests.txt
     #   click-repl
 psycopg2==2.9.9
     # via -r requirements-tests.txt
-py-partiql-parser==0.4.2
+py-partiql-parser==0.5.0
     # via
     #   -r requirements-tests.txt
     #   moto
-pyasn1==0.5.0
+pyasn1==0.6.0
     # via
     #   -r requirements-tests.txt
     #   ndg-httpsclient
@@ -523,7 +523,7 @@ pyasn1==0.5.0
     #   python-jose
     #   python-ldap
     #   rsa
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.0
     # via
     #   -r requirements-tests.txt
     #   pyjks
@@ -532,21 +532,21 @@ pycparser==2.21
     # via
     #   -r requirements-tests.txt
     #   cffi
-pycryptodomex==3.19.1
+pycryptodomex==3.20.0
     # via
     #   -r requirements-tests.txt
     #   pyjks
-pydantic==2.4.2
+pydantic==2.6.4
     # via
     #   -r requirements-tests.txt
     #   aws-sam-translator
-pydantic-core==2.10.1
+pydantic-core==2.16.3
     # via
     #   -r requirements-tests.txt
     #   pydantic
-pyflakes==3.1.0
+pyflakes==3.2.0
     # via -r requirements-tests.txt
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   -r requirements-tests.txt
     #   rich
@@ -570,7 +570,7 @@ pyopenssl==24.1.0
     #   acme
     #   josepy
     #   ndg-httpsclient
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via
     #   -r requirements-tests.txt
     #   moto
@@ -583,16 +583,16 @@ pyspnego==0.10.2
     # via
     #   -r requirements-tests.txt
     #   requests-ntlm
-pytest==8.0.0
+pytest==8.1.1
     # via
     #   -r requirements-tests.txt
     #   pytest-flask
     #   pytest-mock
 pytest-flask==1.3.0
     # via -r requirements-tests.txt
-pytest-mock==3.12.0
+pytest-mock==3.14.0
     # via -r requirements-tests.txt
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements-tests.txt
     #   arrow
@@ -611,7 +611,7 @@ python-json-logger==2.0.7
     #   logmatic-python
 python-ldap==3.4.4
     # via -r requirements-tests.txt
-pytz==2023.3.post1
+pytz==2024.1
     # via
     #   -r requirements-tests.txt
     #   acme
@@ -627,19 +627,19 @@ pyyaml==6.0.1
     #   jsonschema-path
     #   moto
     #   responses
-redis==5.0.1
+redis==5.0.3
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
     #   celery
     #   fakeredis
-referencing==0.30.2
+referencing==0.31.1
     # via
     #   -r requirements-tests.txt
     #   jsonschema
     #   jsonschema-path
     #   jsonschema-specifications
-regex==2023.10.3
+regex==2023.12.25
     # via
     #   -r requirements-tests.txt
     #   cfn-lint
@@ -657,13 +657,13 @@ requests==2.31.0
     #   requests-ntlm
     #   responses
     #   sphinx
-requests-mock==1.11.0
+requests-mock==1.12.0
     # via -r requirements-tests.txt
 requests-ntlm==1.2.0
     # via
     #   -r requirements-tests.txt
     #   certsrv
-responses==0.23.3
+responses==0.25.0
     # via
     #   -r requirements-tests.txt
     #   moto
@@ -675,12 +675,12 @@ rfc3339-validator==0.1.4
     # via
     #   -r requirements-tests.txt
     #   openapi-schema-validator
-rich==13.6.0
+rich==13.7.1
     # via
     #   -r requirements-tests.txt
     #   bandit
     #   flask-limiter
-rpds-py==0.10.6
+rpds-py==0.18.0
     # via
     #   -r requirements-tests.txt
     #   jsonschema
@@ -689,7 +689,7 @@ rsa==4.9
     # via
     #   -r requirements-tests.txt
     #   python-jose
-s3transfer==0.10.0
+s3transfer==0.10.1
     # via
     #   -r requirements-tests.txt
     #   boto3
@@ -697,7 +697,7 @@ sarif-om==1.0.4
     # via
     #   -r requirements-tests.txt
     #   cfn-lint
-sentry-sdk==1.40.0
+sentry-sdk==1.44.0
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
@@ -709,7 +709,6 @@ six==1.16.0
     #   flask-restful
     #   junit-xml
     #   python-dateutil
-    #   requests-mock
     #   retrying
     #   rfc3339-validator
     #   sphinxcontrib-httpdomain
@@ -723,20 +722,15 @@ sphinx==7.2.6
     # via
     #   -r requirements-docs.in
     #   sphinx-rtd-theme
-    #   sphinxcontrib-applehelp
-    #   sphinxcontrib-devhelp
-    #   sphinxcontrib-htmlhelp
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-jquery
-    #   sphinxcontrib-qthelp
-    #   sphinxcontrib-serializinghtml
 sphinx-rtd-theme==2.0.0
     # via -r requirements-docs.in
-sphinxcontrib-applehelp==1.0.7
+sphinxcontrib-applehelp==1.0.8
     # via sphinx
-sphinxcontrib-devhelp==1.0.5
+sphinxcontrib-devhelp==1.0.6
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.4
+sphinxcontrib-htmlhelp==2.0.5
     # via sphinx
 sphinxcontrib-httpdomain==1.8.1
     # via -r requirements-docs.in
@@ -744,9 +738,9 @@ sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.6
+sphinxcontrib-qthelp==1.0.7
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.9
+sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
 sqlalchemy==1.3.24
     # via
@@ -756,7 +750,7 @@ sqlalchemy==1.3.24
     #   flask-sqlalchemy
     #   marshmallow-sqlalchemy
     #   sqlalchemy-utils
-sqlalchemy-utils==0.41.1
+sqlalchemy-utils==0.41.2
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
@@ -764,7 +758,7 @@ sshpubkeys==3.3.1
     # via
     #   -r requirements-tests.txt
     #   moto
-stevedore==5.1.0
+stevedore==5.2.0
     # via
     #   -r requirements-tests.txt
     #   bandit
@@ -786,7 +780,7 @@ twofish==0.3.0
     # via
     #   -r requirements-tests.txt
     #   pyjks
-types-deprecated==1.2.9.20240106
+types-deprecated==1.2.9.20240311
     # via -r requirements-tests.txt
 types-paramiko==3.4.0.20240311
     # via -r requirements-tests.txt
@@ -796,23 +790,19 @@ types-pyopenssl==24.0.0.20240311
     #   types-redis
 types-pyrfc3339==1.1.1.5
     # via -r requirements-tests.txt
-types-python-dateutil==2.8.19.14
+types-python-dateutil==2.9.0.20240316
     # via
     #   -r requirements-tests.txt
     #   arrow
 types-pytz==2024.1.0.20240203
     # via -r requirements-tests.txt
-types-pyyaml==6.0.12.12
-    # via
-    #   -r requirements-tests.txt
-    #   responses
-types-redis==4.6.0.11
+types-redis==4.6.0.20240311
     # via -r requirements-tests.txt
 types-requests==2.31.0.6
     # via -r requirements-tests.txt
-types-setuptools==69.1.0.20240223
+types-setuptools==69.2.0.20240317
     # via -r requirements-tests.txt
-types-six==1.16.21.20240106
+types-six==1.16.21.20240311
     # via -r requirements-tests.txt
 types-tabulate==0.9.0.20240106
     # via -r requirements-tests.txt
@@ -820,7 +810,7 @@ types-urllib3==1.26.25.14
     # via
     #   -r requirements-tests.txt
     #   types-requests
-typing-extensions==4.8.0
+typing-extensions==4.10.0
     # via
     #   -r requirements-tests.txt
     #   alembic
@@ -832,7 +822,7 @@ typing-extensions==4.8.0
     #   mypy
     #   pydantic
     #   pydantic-core
-tzdata==2023.3
+tzdata==2024.1
     # via
     #   -r requirements-tests.txt
     #   celery
@@ -844,7 +834,7 @@ urllib3==1.26.18
     #   requests
     #   responses
     #   sentry-sdk
-validators==0.22.0
+validators==0.24.0
     # via -r requirements-tests.txt
 vine==5.1.0
     # via
@@ -853,14 +843,10 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.8
+wcwidth==0.2.13
     # via
     #   -r requirements-tests.txt
     #   prompt-toolkit
-websocket-client==1.6.4
-    # via
-    #   -r requirements-tests.txt
-    #   docker
 werkzeug==3.0.1
     # via
     #   -r requirements-docs.in
@@ -868,7 +854,7 @@ werkzeug==3.0.1
     #   flask
     #   moto
     #   pytest-flask
-wrapt==1.15.0
+wrapt==1.16.0
     # via
     #   -r requirements-tests.txt
     #   aws-xray-sdk
@@ -878,7 +864,7 @@ xmltodict==0.13.0
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
     #   moto
-zipp==3.17.0
+zipp==3.18.1
     # via
     #   -r requirements-tests.txt
     #   importlib-metadata

--- a/requirements-tests.in
+++ b/requirements-tests.in
@@ -2,13 +2,13 @@
 -r requirements.txt
 bandit
 black
-celery[redis]==5.3.5
+celery[redis]>=5.3.5
 coverage
 factory-boy
 Faker
 fakeredis
 freezegun
-moto[all]
+moto[all] < 5
 nose
 openapi-spec-validator
 pyflakes

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -8,13 +8,13 @@ acme==2.9.0
     # via
     #   -r requirements.txt
     #   certbot
-alembic==1.12.0
+alembic==1.13.1
     # via
     #   -r requirements.txt
     #   flask-migrate
 alembic-autogenerate-enums==0.1.2
     # via -r requirements.txt
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements.txt
     #   kombu
@@ -32,7 +32,7 @@ async-timeout==4.0.3
     #   redis
 asyncpool==1.0
     # via -r requirements.txt
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   -r requirements.txt
     #   jschema-to-python
@@ -40,13 +40,13 @@ attrs==23.1.0
     #   jsonschema
     #   referencing
     #   sarif-om
-aws-sam-translator==1.78.0
+aws-sam-translator==1.86.0
     # via cfn-lint
-aws-xray-sdk==2.12.1
+aws-xray-sdk==2.13.0
     # via moto
-bandit==1.7.7
+bandit==1.7.8
     # via -r requirements-tests.in
-bcrypt==4.0.1
+bcrypt==4.1.2
     # via
     #   -r requirements.txt
     #   flask-bcrypt
@@ -57,31 +57,31 @@ billiard==4.2.0
     #   celery
 black==24.3.0
     # via -r requirements-tests.in
-blinker==1.6.3
+blinker==1.7.0
     # via
     #   -r requirements.txt
     #   flask
     #   flask-mail
     #   flask-principal
-boto3==1.34.19
+boto3==1.34.72
     # via
     #   -r requirements.txt
     #   aws-sam-translator
     #   moto
-botocore==1.34.64
+botocore==1.34.72
     # via
     #   -r requirements.txt
     #   aws-xray-sdk
     #   boto3
     #   moto
     #   s3transfer
-celery[redis]==5.3.5
+celery[redis]==5.3.6
     # via
     #   -r requirements-tests.in
     #   -r requirements.txt
-certbot==2.8.0
+certbot==2.9.0
     # via -r requirements.txt
-certifi==2023.11.17
+certifi==2024.2.2
     # via
     #   -r requirements.txt
     #   requests
@@ -93,9 +93,9 @@ cffi==1.16.0
     #   -r requirements.txt
     #   cryptography
     #   pynacl
-cfn-lint==0.82.2
+cfn-lint==0.86.1
     # via moto
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via
     #   -r requirements.txt
     #   requests
@@ -108,7 +108,7 @@ click==8.1.7
     #   click-plugins
     #   click-repl
     #   flask
-click-didyoumean==0.3.0
+click-didyoumean==0.3.1
     # via
     #   -r requirements.txt
     #   celery
@@ -120,7 +120,7 @@ click-repl==0.3.0
     # via
     #   -r requirements.txt
     #   celery
-cloudflare==2.16.0
+cloudflare==2.19.2
     # via -r requirements.txt
 configargparse==1.7
     # via
@@ -132,7 +132,7 @@ configobj==5.0.8
     #   certbot
 coverage==7.4.4
     # via -r requirements-tests.in
-cryptography==42.0.4
+cryptography==42.0.5
     # via
     #   -r requirements.txt
     #   acme
@@ -152,7 +152,7 @@ deprecated==1.2.14
     # via
     #   -r requirements.txt
     #   limits
-distro==1.8.0
+distro==1.9.0
     # via
     #   -r requirements.txt
     #   certbot
@@ -162,7 +162,7 @@ dnspython==1.15.0
     #   dnspython3
 dnspython3==1.15.0
     # via -r requirements.txt
-docker==6.1.3
+docker==7.0.0
     # via moto
 dyn==1.8.6
     # via -r requirements.txt
@@ -171,15 +171,15 @@ ecdsa==0.18.0
     #   moto
     #   python-jose
     #   sshpubkeys
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via pytest
 factory-boy==3.3.0
     # via -r requirements-tests.in
-faker==23.2.1
+faker==24.4.0
     # via
     #   -r requirements-tests.in
     #   factory-boy
-fakeredis==2.20.1
+fakeredis==2.21.3
     # via -r requirements-tests.in
 flask==2.3.3
     # via
@@ -201,7 +201,7 @@ flask-limiter==3.5.1
     # via -r requirements.txt
 flask-mail==0.9.1
     # via -r requirements.txt
-flask-migrate==4.0.5
+flask-migrate==4.0.7
     # via -r requirements.txt
 flask-principal==0.4.0
     # via -r requirements.txt
@@ -223,16 +223,16 @@ gunicorn==21.2.0
     # via -r requirements.txt
 hvac==2.1.0
     # via -r requirements.txt
-idna==3.4
+idna==3.6
     # via
     #   -r requirements.txt
     #   requests
-importlib-metadata==6.8.0
+importlib-metadata==7.1.0
     # via
     #   -r requirements.txt
     #   certbot
     #   flask
-importlib-resources==6.1.0
+importlib-resources==6.4.0
     # via
     #   -r requirements.txt
     #   limits
@@ -273,31 +273,31 @@ jsonlines==4.0.0
     #   cloudflare
 jsonpatch==1.33
     # via cfn-lint
-jsonpickle==3.0.2
+jsonpickle==3.0.3
     # via jschema-to-python
 jsonpointer==2.4
     # via jsonpatch
-jsonschema==4.19.1
+jsonschema==4.21.1
     # via
     #   aws-sam-translator
     #   cfn-lint
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-path==0.3.1
+jsonschema-path==0.3.2
     # via openapi-spec-validator
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via
     #   jsonschema
     #   openapi-schema-validator
 junit-xml==1.9
     # via cfn-lint
-kombu==5.3.3
+kombu==5.3.6
     # via
     #   -r requirements.txt
     #   celery
-lazy-object-proxy==1.9.0
+lazy-object-proxy==1.10.0
     # via openapi-spec-validator
-limits==3.6.0
+limits==3.10.1
     # via
     #   -r requirements.txt
     #   flask-limiter
@@ -305,7 +305,7 @@ lockfile==0.12.2
     # via -r requirements.txt
 logmatic-python==0.1.7
     # via -r requirements.txt
-mako==1.2.4
+mako==1.3.2
     # via
     #   -r requirements.txt
     #   alembic
@@ -313,7 +313,7 @@ markdown-it-py==3.0.0
     # via
     #   -r requirements.txt
     #   rich
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   -r requirements.txt
     #   jinja2
@@ -329,13 +329,13 @@ mdurl==0.1.2
     # via
     #   -r requirements.txt
     #   markdown-it-py
-moto[all]==4.2.10
+moto[all]==4.2.14
     # via -r requirements-tests.in
 mpmath==1.3.0
     # via sympy
 multipart==0.2.4
     # via moto
-mypy==1.8.0
+mypy==1.9.0
     # via -r requirements-tests.in
 mypy-extensions==1.0.0
     # via
@@ -343,7 +343,7 @@ mypy-extensions==1.0.0
     #   mypy
 ndg-httpsclient==0.5.1
     # via -r requirements.txt
-networkx==3.1
+networkx==3.2.1
     # via cfn-lint
 nose==1.3.7
     # via -r requirements-tests.in
@@ -357,7 +357,7 @@ ordered-set==4.1.0
     # via
     #   -r requirements.txt
     #   flask-limiter
-packaging==23.2
+packaging==24.0
     # via
     #   -r requirements.txt
     #   black
@@ -373,28 +373,28 @@ parsedatetime==2.6
     #   certbot
 pathable==0.4.3
     # via jsonschema-path
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   jschema-to-python
     #   sarif-om
     #   stevedore
 pem==23.1.0
     # via -r requirements.txt
-platformdirs==3.11.0
+platformdirs==4.2.0
     # via black
-pluggy==1.3.0
+pluggy==1.4.0
     # via pytest
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.43
     # via
     #   -r requirements.txt
     #   click-repl
 psycopg2==2.9.9
     # via -r requirements.txt
-py-partiql-parser==0.4.2
+py-partiql-parser==0.5.0
     # via moto
-pyasn1==0.5.0
+pyasn1==0.6.0
     # via
     #   -r requirements.txt
     #   ndg-httpsclient
@@ -403,7 +403,7 @@ pyasn1==0.5.0
     #   python-jose
     #   python-ldap
     #   rsa
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.0
     # via
     #   -r requirements.txt
     #   pyjks
@@ -412,17 +412,17 @@ pycparser==2.21
     # via
     #   -r requirements.txt
     #   cffi
-pycryptodomex==3.19.1
+pycryptodomex==3.20.0
     # via
     #   -r requirements.txt
     #   pyjks
-pydantic==2.4.2
+pydantic==2.6.4
     # via aws-sam-translator
-pydantic-core==2.10.1
+pydantic-core==2.16.3
     # via pydantic
-pyflakes==3.1.0
+pyflakes==3.2.0
     # via -r requirements-tests.in
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   -r requirements.txt
     #   rich
@@ -440,7 +440,7 @@ pyopenssl==24.1.0
     #   acme
     #   josepy
     #   ndg-httpsclient
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via moto
 pyrfc3339==1.1
     # via
@@ -451,16 +451,16 @@ pyspnego==0.10.2
     # via
     #   -r requirements.txt
     #   requests-ntlm
-pytest==8.0.0
+pytest==8.1.1
     # via
     #   -r requirements-tests.in
     #   pytest-flask
     #   pytest-mock
 pytest-flask==1.3.0
     # via -r requirements-tests.in
-pytest-mock==3.12.0
+pytest-mock==3.14.0
     # via -r requirements-tests.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements.txt
     #   arrow
@@ -477,7 +477,7 @@ python-json-logger==2.0.7
     #   logmatic-python
 python-ldap==3.4.4
     # via -r requirements.txt
-pytz==2023.3.post1
+pytz==2024.1
     # via
     #   -r requirements.txt
     #   acme
@@ -493,17 +493,17 @@ pyyaml==6.0.1
     #   jsonschema-path
     #   moto
     #   responses
-redis==5.0.1
+redis==5.0.3
     # via
     #   -r requirements.txt
     #   celery
     #   fakeredis
-referencing==0.30.2
+referencing==0.31.1
     # via
     #   jsonschema
     #   jsonschema-path
     #   jsonschema-specifications
-regex==2023.10.3
+regex==2023.12.25
     # via cfn-lint
 requests==2.31.0
     # via
@@ -518,36 +518,36 @@ requests==2.31.0
     #   requests-mock
     #   requests-ntlm
     #   responses
-requests-mock==1.11.0
+requests-mock==1.12.0
     # via -r requirements-tests.in
 requests-ntlm==1.2.0
     # via
     #   -r requirements.txt
     #   certsrv
-responses==0.23.3
+responses==0.25.0
     # via moto
 retrying==1.3.4
     # via -r requirements.txt
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
-rich==13.6.0
+rich==13.7.1
     # via
     #   -r requirements.txt
     #   bandit
     #   flask-limiter
-rpds-py==0.10.6
+rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
 rsa==4.9
     # via python-jose
-s3transfer==0.10.0
+s3transfer==0.10.1
     # via
     #   -r requirements.txt
     #   boto3
 sarif-om==1.0.4
     # via cfn-lint
-sentry-sdk==1.40.0
+sentry-sdk==1.44.0
     # via -r requirements.txt
 six==1.16.0
     # via
@@ -557,7 +557,6 @@ six==1.16.0
     #   flask-restful
     #   junit-xml
     #   python-dateutil
-    #   requests-mock
     #   retrying
     #   rfc3339-validator
 sortedcontainers==2.4.0
@@ -569,11 +568,11 @@ sqlalchemy==1.3.24
     #   flask-sqlalchemy
     #   marshmallow-sqlalchemy
     #   sqlalchemy-utils
-sqlalchemy-utils==0.41.1
+sqlalchemy-utils==0.41.2
     # via -r requirements.txt
 sshpubkeys==3.3.1
     # via moto
-stevedore==5.1.0
+stevedore==5.2.0
     # via bandit
 sympy==1.12
     # via cfn-lint
@@ -588,7 +587,7 @@ twofish==0.3.0
     # via
     #   -r requirements.txt
     #   pyjks
-types-deprecated==1.2.9.20240106
+types-deprecated==1.2.9.20240311
     # via -r requirements-tests.in
 types-paramiko==3.4.0.20240311
     # via -r requirements-tests.in
@@ -598,27 +597,25 @@ types-pyopenssl==24.0.0.20240311
     #   types-redis
 types-pyrfc3339==1.1.1.5
     # via -r requirements-tests.in
-types-python-dateutil==2.8.19.14
+types-python-dateutil==2.9.0.20240316
     # via
     #   -r requirements.txt
     #   arrow
 types-pytz==2024.1.0.20240203
     # via -r requirements-tests.in
-types-pyyaml==6.0.12.12
-    # via responses
-types-redis==4.6.0.11
+types-redis==4.6.0.20240311
     # via -r requirements-tests.in
 types-requests==2.31.0.6
     # via -r requirements-tests.in
-types-setuptools==69.1.0.20240223
+types-setuptools==69.2.0.20240317
     # via -r requirements-tests.in
-types-six==1.16.21.20240106
+types-six==1.16.21.20240311
     # via -r requirements-tests.in
 types-tabulate==0.9.0.20240106
     # via -r requirements-tests.in
 types-urllib3==1.26.25.14
     # via types-requests
-typing-extensions==4.8.0
+typing-extensions==4.10.0
     # via
     #   -r requirements.txt
     #   alembic
@@ -630,7 +627,7 @@ typing-extensions==4.8.0
     #   mypy
     #   pydantic
     #   pydantic-core
-tzdata==2023.3
+tzdata==2024.1
     # via
     #   -r requirements.txt
     #   celery
@@ -642,7 +639,7 @@ urllib3==1.26.18
     #   requests
     #   responses
     #   sentry-sdk
-validators==0.22.0
+validators==0.24.0
     # via -r requirements.txt
 vine==5.1.0
     # via
@@ -650,19 +647,17 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.8
+wcwidth==0.2.13
     # via
     #   -r requirements.txt
     #   prompt-toolkit
-websocket-client==1.6.4
-    # via docker
 werkzeug==3.0.1
     # via
     #   -r requirements.txt
     #   flask
     #   moto
     #   pytest-flask
-wrapt==1.15.0
+wrapt==1.16.0
     # via
     #   -r requirements.txt
     #   aws-xray-sdk
@@ -671,7 +666,7 @@ xmltodict==0.13.0
     # via
     #   -r requirements.txt
     #   moto
-zipp==3.17.0
+zipp==3.18.1
     # via
     #   -r requirements.txt
     #   importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,11 +8,11 @@ acme==2.9.0
     # via
     #   -r requirements.in
     #   certbot
-alembic==1.12.0
+alembic==1.13.1
     # via flask-migrate
 alembic-autogenerate-enums==0.1.2
     # via -r requirements.in
-amqp==5.1.1
+amqp==5.2.0
     # via kombu
 aniso8601==9.0.1
     # via flask-restful
@@ -22,31 +22,31 @@ async-timeout==4.0.3
     # via redis
 asyncpool==1.0
     # via -r requirements.in
-attrs==23.1.0
+attrs==23.2.0
     # via jsonlines
-bcrypt==4.0.1
+bcrypt==4.1.2
     # via
     #   flask-bcrypt
     #   paramiko
 billiard==4.2.0
     # via celery
-blinker==1.6.3
+blinker==1.7.0
     # via
     #   flask
     #   flask-mail
     #   flask-principal
-boto3==1.34.19
+boto3==1.34.72
     # via -r requirements.in
-botocore==1.34.64
+botocore==1.34.72
     # via
     #   -r requirements.in
     #   boto3
     #   s3transfer
-celery[redis]==5.3.5
+celery[redis]==5.3.6
     # via -r requirements.in
-certbot==2.8.0
+certbot==2.9.0
     # via -r requirements.in
-certifi==2023.11.17
+certifi==2024.2.2
     # via
     #   -r requirements.in
     #   requests
@@ -57,7 +57,7 @@ cffi==1.16.0
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via
@@ -66,19 +66,19 @@ click==8.1.7
     #   click-plugins
     #   click-repl
     #   flask
-click-didyoumean==0.3.0
+click-didyoumean==0.3.1
     # via celery
 click-plugins==1.1.1
     # via celery
 click-repl==0.3.0
     # via celery
-cloudflare==2.16.0
+cloudflare==2.19.2
     # via -r requirements.in
 configargparse==1.7
     # via certbot
 configobj==5.0.8
     # via certbot
-cryptography==42.0.4
+cryptography==42.0.5
     # via
     #   -r requirements.in
     #   acme
@@ -90,7 +90,7 @@ cryptography==42.0.4
     #   requests-ntlm
 deprecated==1.2.14
     # via limits
-distro==1.8.0
+distro==1.9.0
     # via certbot
 dnspython==1.15.0
     # via dnspython3
@@ -117,7 +117,7 @@ flask-limiter==3.5.1
     # via -r requirements.in
 flask-mail==0.9.1
     # via -r requirements.in
-flask-migrate==4.0.5
+flask-migrate==4.0.7
     # via -r requirements.in
 flask-principal==0.4.0
     # via -r requirements.in
@@ -135,13 +135,13 @@ gunicorn==21.2.0
     # via -r requirements.in
 hvac==2.1.0
     # via -r requirements.in
-idna==3.4
+idna==3.6
     # via requests
-importlib-metadata==6.8.0
+importlib-metadata==7.1.0
     # via
     #   certbot
     #   flask
-importlib-resources==6.1.0
+importlib-resources==6.4.0
     # via limits
 inflection==0.5.1
     # via -r requirements.in
@@ -165,19 +165,19 @@ josepy==1.14.0
     #   certbot
 jsonlines==4.0.0
     # via cloudflare
-kombu==5.3.3
+kombu==5.3.6
     # via celery
-limits==3.6.0
+limits==3.10.1
     # via flask-limiter
 lockfile==0.12.2
     # via -r requirements.in
 logmatic-python==0.1.7
     # via -r requirements.in
-mako==1.2.4
+mako==1.3.2
     # via alembic
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   jinja2
     #   mako
@@ -194,7 +194,7 @@ ndg-httpsclient==0.5.1
     # via -r requirements.in
 ordered-set==4.1.0
     # via flask-limiter
-packaging==23.2
+packaging==24.0
     # via
     #   gunicorn
     #   limits
@@ -204,25 +204,25 @@ parsedatetime==2.6
     # via certbot
 pem==23.1.0
     # via -r requirements.in
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.43
     # via click-repl
 psycopg2==2.9.9
     # via -r requirements.in
-pyasn1==0.5.0
+pyasn1==0.6.0
     # via
     #   ndg-httpsclient
     #   pyasn1-modules
     #   pyjks
     #   python-ldap
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.0
     # via
     #   pyjks
     #   python-ldap
 pycparser==2.21
     # via cffi
-pycryptodomex==3.19.1
+pycryptodomex==3.20.0
     # via pyjks
-pygments==2.16.1
+pygments==2.17.2
     # via rich
 pyjks==20.0.0
     # via -r requirements.in
@@ -242,7 +242,7 @@ pyrfc3339==1.1
     #   certbot
 pyspnego==0.10.2
     # via requests-ntlm
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   arrow
     #   botocore
@@ -251,7 +251,7 @@ python-json-logger==2.0.7
     # via logmatic-python
 python-ldap==3.4.4
     # via -r requirements.in
-pytz==2023.3.post1
+pytz==2024.1
     # via
     #   acme
     #   certbot
@@ -261,7 +261,7 @@ pyyaml==6.0.1
     # via
     #   -r requirements.in
     #   cloudflare
-redis==5.0.1
+redis==5.0.3
     # via
     #   -r requirements.in
     #   celery
@@ -277,11 +277,11 @@ requests-ntlm==1.2.0
     # via certsrv
 retrying==1.3.4
     # via -r requirements.in
-rich==13.6.0
+rich==13.7.1
     # via flask-limiter
-s3transfer==0.10.0
+s3transfer==0.10.1
     # via boto3
-sentry-sdk==1.40.0
+sentry-sdk==1.44.0
     # via -r requirements.in
 six==1.16.0
     # via
@@ -297,45 +297,45 @@ sqlalchemy==1.3.24
     #   flask-sqlalchemy
     #   marshmallow-sqlalchemy
     #   sqlalchemy-utils
-sqlalchemy-utils==0.41.1
+sqlalchemy-utils==0.41.2
     # via -r requirements.in
 tabulate==0.9.0
     # via -r requirements.in
 twofish==0.3.0
     # via pyjks
-types-python-dateutil==2.8.19.14
+types-python-dateutil==2.9.0.20240316
     # via arrow
-typing-extensions==4.8.0
+typing-extensions==4.10.0
     # via
     #   alembic
     #   flask-limiter
     #   kombu
     #   limits
-tzdata==2023.3
+tzdata==2024.1
     # via celery
 urllib3==1.26.18
     # via
     #   botocore
     #   requests
     #   sentry-sdk
-validators==0.22.0
+validators==0.24.0
     # via -r requirements.in
 vine==5.1.0
     # via
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.8
+wcwidth==0.2.13
     # via prompt-toolkit
 werkzeug==3.0.1
     # via
     #   -r requirements.in
     #   flask
-wrapt==1.15.0
+wrapt==1.16.0
     # via deprecated
 xmltodict==0.13.0
     # via -r requirements.in
-zipp==3.17.0
+zipp==3.18.1
     # via
     #   importlib-metadata
     #   importlib-resources


### PR DESCRIPTION
Numerous small fixes

- Fixed the problem where if a `hooks` directory doesn't exist in the project root, then setup-git step would create a symlink named `*`
- `lint-python` now scans the lemur package and not all python files in the repo, because that could also, for example, include installed python packages, if the virtual env directory is inside the repo directory.
- pip-compile now has verbose output, for ease of troubleshooting dependency issues.
- pip-compile steps reordered in the order of their dependency, otherwise they can cause spurious version conflicts.
- `celery[redis]>=5.3.5` (Instead of `== 5.3.5`) in requirements-tests.in to avoid version conflicts with requirements.txt, because  the latest verison of celery is now at least 5.3.6
- `moto[all] < 5` because lemur/plugins/lemur_aws/tests/ is not compatible with moto v5 . moto v5 no longer has mock_sts, mock_s3 and so on

Hi from Squarespace Product Security team!
We are avid users of Lemur and would like to contribute our fixes back to the community!