### PR TITLE
checking for existence of `config` field

### DIFF
--- a/lemur/factory.py
+++ b/lemur/factory.py
@@ -60,7 +60,7 @@ def create_app(app_name=None, blueprints=None, config=None):
     # get config option value from command line
     if ctx and config is None:
         script_info = ctx.obj
-        if script_info:
+        if script_info and getattr(script_info, 'config'):
             config = script_info.config
 
     configure_app(app, config)

--- a/lemur/factory.py
+++ b/lemur/factory.py
@@ -60,8 +60,8 @@ def create_app(app_name=None, blueprints=None, config=None):
     # get config option value from command line
     if ctx and config is None:
         script_info = ctx.obj
-        if script_info and getattr(script_info, 'config'):
-            config = script_info.config
+        if script_info:
+            config = getattr(script_info, 'config')
 
     configure_app(app, config)
     configure_blueprints(app, blueprints)


### PR DESCRIPTION
Bug fix:
If using the built-in flask command, like `run`  (like `lemur run -p 127.0.0.1`), the `def cli(script_info, config)`  function is not being called, and thus `config` is not being set. 
This causes a crash downstream, when factory.py tries to fetch data from .config

The fix allows `run` to execute correctly, as long as the config is passed in via LEMUR_CONF environment variable.

