### PR TITLE
Add access token debug log behind config property

### DIFF
--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -87,6 +87,17 @@ def exchange_for_access_token(
     response = r.json()
 
     if not r.ok or "error" in response:
+        if current_app.config.get("LOG_ACCESS_TOKEN_EXCHANGE"):
+            current_app.logger.info(
+                "Access token exchange response error [%s], error description [%s], access token URL: [%s], \
+                client ID: [%s], client secret non-empty: [%s], redirect URI: [%s]",
+                response.get("error", "Unknown error"),
+                response.get("error_description", ""),
+                access_token_url,
+                client_id,
+                bool(secret),
+                redirect_uri,
+            )
         raise TokenExchangeFailed(response.get("error", "Unknown error"), response.get("error_description", ""))
 
     id_token = response.get("id_token")

--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -87,7 +87,7 @@ def exchange_for_access_token(
     response = r.json()
 
     if not r.ok or "error" in response:
-        if current_app.config.get("LOG_ACCESS_TOKEN_EXCHANGE"):
+        if current_app.config.get("LOG_ACCESS_TOKEN_EXCHANGE", False):
             current_app.logger.info(
                 "Access token exchange response error [%s], error description [%s], access token URL: [%s], \
                 client ID: [%s], client secret non-empty: [%s], redirect URI: [%s]",


### PR DESCRIPTION
Adds an info-level log message behind the `LOG_ACCESS_TOKEN_EXCHANGE` config property to log info about the access token exchange. Does not log anything sensitive, off by default.