### PR TITLE
Add PING_EXCLUDE_USER_PARAMS config option

### DIFF
--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -159,7 +159,7 @@ def retrieve_user(user_api_url, access_token):
     r = requests.get(user_api_url, params=user_params, headers=headers)
     # Some IDPs, like "Keycloak", require a POST instead of a GET
     if r.status_code == 400:
-        if current_app.config.get("PING_EXCLUDE_USER_PARAMS"):
+        if current_app.config.get("PING_EXCLUDE_USER_PARAMS", False):
             r = requests.post(user_api_url, headers=headers)
         else:
             r = requests.post(user_api_url, data=user_params, headers=headers)

--- a/lemur/auth/views.py
+++ b/lemur/auth/views.py
@@ -87,17 +87,6 @@ def exchange_for_access_token(
     response = r.json()
 
     if not r.ok or "error" in response:
-        if current_app.config.get("LOG_ACCESS_TOKEN_EXCHANGE", False):
-            current_app.logger.info(
-                "Access token exchange response error [%s], error description [%s], access token URL: [%s], \
-                client ID: [%s], client secret non-empty: [%s], redirect URI: [%s]",
-                response.get("error", "Unknown error"),
-                response.get("error_description", ""),
-                access_token_url,
-                client_id,
-                bool(secret),
-                redirect_uri,
-            )
         raise TokenExchangeFailed(response.get("error", "Unknown error"), response.get("error_description", ""))
 
     id_token = response.get("id_token")
@@ -170,7 +159,10 @@ def retrieve_user(user_api_url, access_token):
     r = requests.get(user_api_url, params=user_params, headers=headers)
     # Some IDPs, like "Keycloak", require a POST instead of a GET
     if r.status_code == 400:
-        r = requests.post(user_api_url, data=user_params, headers=headers)
+        if current_app.config.get("PING_EXCLUDE_USER_PARAMS"):
+            r = requests.post(user_api_url, headers=headers)
+        else:
+            r = requests.post(user_api_url, data=user_params, headers=headers)
 
     profile = r.json()
 


### PR DESCRIPTION
Removed logging from #4836, and adds a new config option `PING_EXCLUDE_USER_PARAMS` which allows the exclusion of a request body from user info requests.