### PR TITLE
Correct bad changelog merge and update release date to Monday

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ~~~~~~~~~~~~~~~~~~~~
 
-1.8.0 - `2024-05-17`
+1.8.0 - `2024-05-20`
 ~~~~~~~~~~~~~~~~~~~~
 
 - Added `PING_EXCLUDE_USER_PARAMS` config option.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,13 +3,12 @@ Changelog
 
 Unreleased
 ~~~~~~~~~~~~~~~~~~~~
-Added Google CA issuer plugin. This plugin creates certificates via Google CA Manager API.
 
 1.8.0 - `2024-05-17`
 ~~~~~~~~~~~~~~~~~~~~
 
 - Added `PING_EXCLUDE_USER_PARAMS` config option.
-- Issuer plugin for Google CA Manager.
+- Added Google CA issuer plugin. This plugin creates certificates via Google CA Manager API.
 - Allow CN to be optional in reissue and clone.
 
 Special thanks to all who contributed to this release, notably:


### PR DESCRIPTION
Correct an unintentional bad changelog merge from #4850.

Also updated the date to Monday May 20 to avoid releasing a new version on Friday evening.