### PR TITLE
Correct publishing workflow

### DIFF
--- a/.github/workflows/lemur-publish-release-pypi.yml
+++ b/.github/workflows/lemur-publish-release-pypi.yml
@@ -42,6 +42,7 @@ jobs:
   pypi-publish:
     name: upload release to PyPI
     runs-on: ubuntu-latest
+    needs: build # wait for the build job to complete
     environment:
       name: release
       url: https://pypi.org/p/lemur


### PR DESCRIPTION
Correct publishing workflow to make the publishing job wait for the build job to complete.