### PR TITLE
remove noisy, unactionable log

### DIFF
--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -417,12 +417,6 @@ class Certificate(BaseModel):
                     return_extensions["crl_distribution_points"] = {
                         "include_crl_dp": value
                     }
-
-                # TODO: Not supporting custom OIDs yet. https://github.com/Netflix/lemur/issues/665
-                else:
-                    current_app.logger.warning(
-                        "Custom OIDs not yet supported for clone operation."
-                    )
         except InvalidCodepoint as e:
             capture_exception()
             current_app.logger.warning(


### PR DESCRIPTION
this logs accounts for 40% of volume in production deployments. The original issue was closed years ago, and we currently have no plans to support this