### PR TITLE
replace like with is none check if cn is none

### DIFF
--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -322,12 +322,16 @@ def get_certificates_with_same_cn_with_rotate_on(cn, date_created):
     date_created_max = date_created.ceil('day')
 
     query = database.session_query(Certificate)\
-        .filter(Certificate.cn.like(cn))\
         .filter(Certificate.rotation == true())\
         .filter(Certificate.not_after >= now)\
         .filter(Certificate.date_created >= date_created_min)\
         .filter(Certificate.date_created <= date_created_max)\
         .filter(not_(Certificate.replaced.any()))
+
+    if cn is not None:
+        query = query.filter(Certificate.cn.like(cn))
+    else:
+        query = query.filter(Certificate.cn.is_(None))
 
     return query.all()
 


### PR DESCRIPTION
```
File \"/apps/lemur/lemur/certificates/service.py\", line 325, in get_certificates_with_same_cn_with_rotate_on\n    .filter(Certificate.cn.like(cn))

sqlalchemy.exc.ArgumentError: Only '=', '!=', 'is_()', 'isnot()', 'is_distinct_from()', 'isnot_distinct_from()' operators can be used with None/True/False
```