### PR TITLE
Switch to not_valid_after_utc and not_valid_before_utc

### DIFF
--- a/lemur/common/defaults.py
+++ b/lemur/common/defaults.py
@@ -295,7 +295,7 @@ def not_before(cert):
     :param cert:
     :return: Datetime
     """
-    return cert.not_valid_before
+    return cert.not_valid_before_utc
 
 
 def not_after(cert):
@@ -306,4 +306,4 @@ def not_after(cert):
 
     :return: Datetime
     """
-    return cert.not_valid_after
+    return cert.not_valid_after_utc


### PR DESCRIPTION
Cleans up these warnings:

```
CryptographyDeprecationWarning: Properties that return a naïve datetime object have been deprecated. Please switch to not_valid_before_utc. return cert.not_valid_before
```

```
CryptographyDeprecationWarning: Properties that return a naïve datetime object have been deprecated. Please switch to not_valid_after_utc. return cert.not_valid_after
```