### PR TITLE
Resolve daemon warnings for threading methods

### DIFF
--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -1724,7 +1724,7 @@ def run_server(port, cert_file_name):
         print(f"Started https server on port {port} using cert file {cert_file_name}")
 
     daemon = threading.Thread(name=f'server_{cert_file_name}', target=start_server)
-    daemon.setDaemon(True)  # Set as a daemon so it will be killed once the main thread is dead.
+    daemon.daemon = True  # Set as a daemon so it will be killed once the main thread is dead.
     daemon.start()
     return daemon
 
@@ -1807,7 +1807,7 @@ def test_allowed_issuance_for_domain(common_name, extensions, expected_error, au
             if expected_error:
                 pass
             else:
-                assert False, f"UnauthorizedError occured, input: CN({common_name}), SAN({extensions})"
+                assert False, f"UnauthorizedError occurred, input: CN({common_name}), SAN({extensions})"
 
         assert wrapper.call_count == authz_check_count
 


### PR DESCRIPTION
# PR Summary
This small PR resolves the `threading` deprecation warnings:
```python
/home/runner/work/lemur/lemur/lemur/tests/test_certificates.py:1727: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
```