### PR TITLE
Fix JWT subject claim to comply with PyJWT string requirement

### DIFF
--- a/lemur/auth/service.py
+++ b/lemur/auth/service.py
@@ -73,9 +73,9 @@ def create_token(user, aid=None, ttl=None):
 
     # Handle Just a User ID & User Object.
     if isinstance(user, int):
-        payload["sub"] = user
+        payload["sub"] = str(user)
     else:
-        payload["sub"] = user.id
+        payload["sub"] = str(user.id)
     if aid is not None:
         payload["aid"] = aid
     # Custom TTLs are only supported on Access Keys.
@@ -157,7 +157,7 @@ def login_required(f):
             if access_key.application_name:
                 g.caller_application = access_key.application_name
 
-        user = user_service.get(payload["sub"])
+        user = user_service.get(int(payload["sub"]))
 
         if not user.active:
             return dict(message="User is not currently active"), 403

--- a/lemur/tests/vectors.py
+++ b/lemur/tests/vectors.py
@@ -2,21 +2,21 @@ from lemur.common.utils import parse_certificate
 
 VALID_USER_HEADER_TOKEN = {
     "Authorization": "Basic "
-    + "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MjE2NTIwMjIsImV4cCI6MjM4NTY1MjAyMiwic3ViIjoxfQ.uK4PZjVAs0gt6_9h2EkYkKd64nFXdOq-rHsJZzeQicc",
+    + "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MjE2NTIwMjIsImV4cCI6MjM4NTY1MjAyMiwic3ViIjoiMSJ9.UQBQzJHyUJNgTVKQRHsBw3tz-plqRWAXiaSIYnOfY9g",
     "Content-Type": "application/json",
 }
 
 
 VALID_ADMIN_HEADER_TOKEN = {
     "Authorization": "Basic "
-    + "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1MjE2NTE2NjMsInN1YiI6MiwiYWlkIjoxfQ.wyf5PkQNcggLrMFqxDfzjY-GWPw_XsuWvU2GmQaC5sg",
+    + "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MjE2NTE2NjMsInN1YiI6IjIiLCJhaWQiOjF9.iwffQd6msR9Qpythn7IHzk1LpZtz7rLWcdP3ECL1R9I",
     "Content-Type": "application/json",
 }
 
 
 VALID_ADMIN_API_TOKEN = {
     "Authorization": "Basic "
-    + "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjIsImFpZCI6MSwiaWF0IjoxNDM1MjMzMzY5fQ.umW0I_oh4MVZ2qrClzj9SfYnQl6cd0HGzh9EwkDW60I",
+    + "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyIiwiYWlkIjoxLCJpYXQiOjE0MzUyMzMzNjl9.G4LPxutGiMAJBQfVxVqfECplVOguiDHHQSu0z32q3-0",
     "Content-Type": "application/json",
 }
 


### PR DESCRIPTION
The PyJWT library now enforces that the 'sub' claim must be a string, but Lemur was setting it to an integer user ID, causing token validation to fail with "Subject must be a string" errors.

This fix:
- Converts user IDs to strings when creating JWT tokens
- Converts the subject back to int when validating tokens for user lookup
- Maintains backward compatibility with existing functionality

Fixes authentication issues where login succeeded but subsequent API requests returned 403 forbidden errors.