### PR TITLE
Support manual certificate renewal process

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog
 
 Unreleased
 ~~~~~~~~~~~~~~~~~~~~
+Added manual issuer plugin. This plugin allows you to manage certificates issued by third party issuers that do not support automation.
 Added ENABLE_AUTOROTATION_FILTER: a configurable, plugin-independent callback that can be used to skip enabling autorotate
 based on your specific business logic. For example, you could disallow enabling autorotate on certs with notifications disabled.
 Added REISSUE_FILTER: a configurable, plugin-independent callback that can be used to reject reissuance requests

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -2453,6 +2453,12 @@ Vault
 :Description:
     Destination plugin to deploy certificates to Hashicorp Vault secret store.
 
+Manual
+-----
+:Type:
+    Issuer
+:Description:
+    Manage certificates issued by third party issuers that do not support automation. Import the CA's public key as an issuer, then create a new certificate using that issuer to create a pending cert, which includes a generated CSR. Using whatever manual process you have to complete this CSR, generate and upload the signed public key to the pending certificate, then Lemur will mark it as active and will manage the certificate's lifecycle from there.
 
 3rd Party Plugins
 =================

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -2455,6 +2455,9 @@ Vault
 
 Manual
 -----
+
+:Authors:
+    Philippe Desmarais <philippe.desmarais0trash@gmail.com>
 :Type:
     Issuer
 :Description:

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -2454,7 +2454,7 @@ Vault
     Destination plugin to deploy certificates to Hashicorp Vault secret store.
 
 Manual
------
+------
 
 :Authors:
     Philippe Desmarais <philippe.desmarais0trash@gmail.com>

--- a/lemur/plugins/bases/issuer.py
+++ b/lemur/plugins/bases/issuer.py
@@ -34,3 +34,12 @@ class IssuerPlugin(Plugin):
 
     def deactivate_certificate(self, certificate):
         raise NotImplementedError
+
+    @property
+    def allows_auto_resolve(self) -> bool:
+        """
+        Some issuers, such as the manual issuer, do not allow for auto-resolve
+        of pending certificates. This method allows plugins to indicate that they allow
+        auto-resolve, which will prevent Lemur from automatically calling fetch_acme_cert.apply_async.
+        """
+        return True

--- a/lemur/plugins/lemur_manual_issuer/__init__.py
+++ b/lemur/plugins/lemur_manual_issuer/__init__.py
@@ -1,0 +1,5 @@
+try:
+    from importlib.metadata import version
+    VERSION = version(__name__)
+except Exception as e:
+    VERSION = "unknown"

--- a/lemur/plugins/lemur_manual_issuer/plugin.py
+++ b/lemur/plugins/lemur_manual_issuer/plugin.py
@@ -57,19 +57,26 @@ class ManualIssuerPlugin(IssuerPlugin):
             f"Issuing new manual authority with options: {options}"
         )
 
-        plugin_options = options.get("plugin", {}).get("plugin_options")
-        if not plugin_options:
-            error = f"Invalid options for manual plugin: {options}"
-            current_app.logger.error(error)
-            raise InvalidConfiguration(error)
-
-        public_cert = None
-        for option in plugin_options:
-            if option.get("name") == "public_certificate":
-                public_cert = option.get("value")
+        plugin_options = get_plugin_options(options)
+        public_cert = get_option_pub_cert(plugin_options)
 
         roles = [
             {"username": "", "password": "", "name": options["name"] + "_admin"},
             {"username": "", "password": "", "name": options["name"] + "_operator"},
         ]
         return public_cert, None, None, roles
+
+def get_plugin_options(options):
+    plugin_options = options.get("plugin", {}).get("plugin_options")
+    if not plugin_options:
+        error = f"Invalid options for manual plugin: {options}"
+        current_app.logger.error(error)
+        raise InvalidConfiguration(error)
+    return plugin_options
+
+def get_option_pub_cert(plugin_options) -> Optional[str]:
+    public_cert = None
+    for option in plugin_options:
+        if option.get("name") == "public_certificate":
+            public_cert = option.get("value")
+    return public_cert

--- a/lemur/plugins/lemur_manual_issuer/plugin.py
+++ b/lemur/plugins/lemur_manual_issuer/plugin.py
@@ -1,0 +1,75 @@
+from typing import Optional, Tuple
+import uuid
+
+from flask import current_app
+
+from lemur.common.utils import check_validation
+from lemur.exceptions import InvalidConfiguration
+from lemur.plugins.bases import IssuerPlugin
+from lemur.plugins import lemur_manual_issuer as manual_issuer
+
+
+class ManualIssuerPlugin(IssuerPlugin):
+    title = "Manual"
+    slug = "manual-issuer"
+    description = "Enables the creation and signing of certificates by hand, using third-party tools or services."
+    version = manual_issuer.VERSION
+
+    options = [
+        {
+            "name": "public_certificate",
+            "type": "textarea",
+            "default": "",
+            "validation": check_validation("^-----BEGIN CERTIFICATE-----"),
+            "helpMessage": "External CA public certificate in PEM format. This is used to build the certificate chain and is required when creating an authority.",
+        }
+    ]
+
+    author = "Philippe Desmarais"
+    author_url = "https://github.com/netflix/lemur.git"
+
+    @property
+    def allows_auto_resolve(self):
+        return False
+
+    def create_certificate(self, _, options) -> Tuple[str, str, int]:
+        """
+        Directly returns a pending certificate.
+
+        :param csr:
+        :param options:
+        :return:
+        """
+        current_app.logger.debug(
+            f"Issuing a pending cert to complete later: {options}"
+        )
+        return "", "", int(uuid.uuid4())
+
+    @staticmethod
+    def create_authority(options) -> Tuple[Optional[str], Optional[str], Optional[str], list]:
+        """
+        The authority created here is bound to a single user-provided CA certificate. Only the CA's public cert is requested.
+
+        :param options:
+        :return:
+        """
+        current_app.logger.debug(
+            f"Issuing new manual authority with options: {options}"
+        )
+
+        plugin_options = options.get("plugin", {}).get("plugin_options")
+        if not plugin_options:
+            error = f"Invalid options for manual plugin: {options}"
+            current_app.logger.error(error)
+            raise InvalidConfiguration(error)
+
+        public_cert = None
+        for option in plugin_options:
+            if option.get("name") == "public_certificate":
+                public_cert = option.get("value")
+
+        roles = [
+            {"username": "", "password": "", "name": options["name"] + "_admin"},
+            {"username": "", "password": "", "name": options["name"] + "_operator"},
+        ]
+        return public_cert, None, None, roles

--- a/lemur/plugins/lemur_manual_issuer/tests/conftest.py
+++ b/lemur/plugins/lemur_manual_issuer/tests/conftest.py
@@ -1,0 +1,1 @@
+from lemur.tests.conftest import *  # noqa

--- a/lemur/plugins/lemur_manual_issuer/tests/test_manual.py
+++ b/lemur/plugins/lemur_manual_issuer/tests/test_manual.py
@@ -1,0 +1,60 @@
+import pytest
+from flask import Flask
+from lemur.plugins.lemur_manual_issuer import plugin
+
+def test_allows_auto_resolve_property():
+    p = plugin.ManualIssuerPlugin()
+    assert p.allows_auto_resolve is False
+
+def test_create_certificate_returns_pending():
+    p = plugin.ManualIssuerPlugin()
+    app = Flask('test')
+    with app.app_context():
+        cert, chain, external_id = p.create_certificate(None, {})
+        assert cert == ""
+        assert chain == ""
+        assert isinstance(external_id, int)
+
+def test_create_authority_returns_expected_roles():
+    app = Flask('test')
+    with app.app_context():
+        options = {
+            "name": "test",
+            "plugin": {
+                "plugin_options": [
+                    {"name": "public_certificate", "value": "-----BEGIN CERTIFICATE-----FAKE"}
+                ]
+            }
+        }
+        pub, chain, key, roles = plugin.ManualIssuerPlugin.create_authority(options)
+        assert pub.startswith("-----BEGIN CERTIFICATE-----")
+        assert chain is None
+        assert key is None
+        assert roles[0]["name"] == "test_admin"
+        assert roles[1]["name"] == "test_operator"
+
+def test_get_plugin_options_valid():
+    options = {"plugin": {"plugin_options": [1, 2, 3]}}
+    result = plugin.get_plugin_options(options)
+    assert result == [1, 2, 3]
+
+def test_get_plugin_options_invalid():
+    options = {"plugin": {}}
+    app = Flask('test')
+    with app.app_context():
+        with pytest.raises(plugin.InvalidConfiguration):
+            plugin.get_plugin_options(options)
+
+def test_get_option_pub_cert():
+    opts = [
+        {"name": "public_certificate", "value": "CERTDATA"},
+        {"name": "other", "value": "X"}
+    ]
+    result = plugin.get_option_pub_cert(opts)
+    assert result == "CERTDATA"
+
+
+def test_get_option_pub_cert_none():
+    opts = []
+    result = plugin.get_option_pub_cert(opts)
+    assert result is None

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -927,10 +927,10 @@ def test_get_account_number(client):
 def test_mint_certificate(issuer_plugin, authority):
     from lemur.certificates.service import mint
 
-    cert_body, private_key, chain, external_id, csr = mint(
+    mint_result = mint(
         authority=authority, csr=CSR_STR
     )
-    assert cert_body == SAN_CERT_STR
+    assert mint_result.certificate_body == SAN_CERT_STR
 
 
 def test_create_certificate(issuer_plugin, authority, user):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ entrust_issuer = "lemur.plugins.lemur_entrust.plugin:EntrustIssuerPlugin"
 entrust_source = "lemur.plugins.lemur_entrust.plugin:EntrustSourcePlugin"
 azure_destination = "lemur.plugins.lemur_azure_dest.plugin:AzureDestinationPlugin"
 google_ca_issuer = "lemur.plugins.lemur_google_ca.plugin:GoogleCaIssuerPlugin"
+manual_issuer = "lemur.plugins.lemur_manual_issuer.plugin:ManualIssuerPlugin"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
Implements and closes #5342

This PR does three things:

- Creates a new, barebones plugin. This plugin has a field to insert the associated root CA's public cert in the issuer creation form. Unlike some of the other plugins, the CA cert is a user-provided value. Once the issuer is created, the plugin simply issues a pending certificate, and it's up to the user to complete it with their own process

- Adds a new property to the base plugin class that allows async issuer plugins to bypass the acme auto resolve process. This property defaults to the current behavior, but is overriden for the new issuer to avoid errors if ACME_DISABLE_AUTORESOLVE isn't True

- Creates unit tests and documentation for the above items