### PR TITLE
Add CERT_NAME_RESOLVER hook to /certificates/name/{name} endpoint

### DIFF
--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -254,7 +254,12 @@ class CertificatesNameQuery(AuthenticatedResource):
 
         args = parser.parse_args()
         args["user"] = g.user
-        return service.query_name(certificate_name, args)
+        result = service.query_name(certificate_name, args)
+        resolver = current_app.config.get("CERT_NAME_RESOLVER")
+        if resolver:
+            caller = getattr(g, "caller_application", None)
+            result = resolver(certificate_name, result, caller)
+        return result
 
 
 class CertificatesList(AuthenticatedResource):


### PR DESCRIPTION
Allows operators to register a post-processor callable that can inspect and redirect certificate name lookups. Useful when an external certificate lifecycle manager has taken over management of a cert — the resolver can substitute the currently-active externally-managed cert in place of the original.

Config: CERT_NAME_RESOLVER — callable(cert_name, result, caller) -> result