### PR TITLE
Add LEMUR_EXCLUDED_REGIONS global config to skip regions during disco…

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -322,6 +322,14 @@ Basic Configuration
        If Lemur is deployed in and managing endpoints AWS GovCloud, for example, you must set this to `aws-us-gov`.
 
 
+.. data:: LEMUR_EXCLUDED_REGIONS
+   :noindex:
+
+       A list of AWS region names that Lemur should skip when discovering endpoints. Useful for temporarily excluding
+       regions that are unreachable or experiencing disruptions. For example::
+
+           LEMUR_EXCLUDED_REGIONS = ["me-south-1"]
+
 .. data:: LEMUR_STRICT_ROLE_ENFORCEMENT
     :noindex:
 

--- a/lemur/plugins/lemur_aws/plugin.py
+++ b/lemur/plugins/lemur_aws/plugin.py
@@ -313,6 +313,10 @@ class AWSSourcePlugin(SourcePlugin):
         else:
             regions = "".join(regions.split()).split(",")
 
+        excluded_regions = current_app.config.get("LEMUR_EXCLUDED_REGIONS", [])
+        if excluded_regions:
+            regions = [r for r in regions if r not in excluded_regions]
+
         policy_cache = {}
         for region in regions:
             elbs = elb.get_all_elbs(account_number=account_number, region=region)


### PR DESCRIPTION
…very

Allows operators to exclude specific AWS regions (e.g. me-south-1) from endpoint discovery without modifying per-source configuration. Useful for temporarily bypassing regions experiencing disruptions.