### PR TITLE
Catch per-region errors in endpoint discovery to allow partial progress

### DIFF
--- a/lemur/plugins/lemur_aws/plugin.py
+++ b/lemur/plugins/lemur_aws/plugin.py
@@ -324,6 +324,8 @@ class AWSSourcePlugin(SourcePlugin):
                     "region": region,
                 })
                 capture_exception()
+                metrics.send("source_sync_fail", "counter", 1,
+                             metric_tags={"source": f"{account_number}/{region}/classic"})
                 continue
 
             current_app.logger.info({
@@ -352,6 +354,8 @@ class AWSSourcePlugin(SourcePlugin):
                     "region": region,
                 })
                 capture_exception()
+                metrics.send("source_sync_fail", "counter", 1,
+                             metric_tags={"source": f"{account_number}/{region}/elbv2"})
                 continue
 
             current_app.logger.info({

--- a/lemur/plugins/lemur_aws/plugin.py
+++ b/lemur/plugins/lemur_aws/plugin.py
@@ -315,7 +315,17 @@ class AWSSourcePlugin(SourcePlugin):
 
         policy_cache = {}
         for region in regions:
-            elbs = elb.get_all_elbs(account_number=account_number, region=region)
+            try:
+                elbs = elb.get_all_elbs(account_number=account_number, region=region)
+            except Exception:  # noqa
+                current_app.logger.warning({
+                    "message": "Failed to describe classic load balancers, skipping region",
+                    "account_number": account_number,
+                    "region": region,
+                })
+                capture_exception()
+                continue
+
             current_app.logger.info({
                 "message": "Describing classic load balancers",
                 "account_number": account_number,
@@ -333,7 +343,17 @@ class AWSSourcePlugin(SourcePlugin):
                     continue
 
             # fetch advanced ELBs
-            elbs_v2 = elb.get_all_elbs_v2(account_number=account_number, region=region)
+            try:
+                elbs_v2 = elb.get_all_elbs_v2(account_number=account_number, region=region)
+            except Exception:  # noqa
+                current_app.logger.warning({
+                    "message": "Failed to describe advanced load balancers, skipping region",
+                    "account_number": account_number,
+                    "region": region,
+                })
+                capture_exception()
+                continue
+
             current_app.logger.info({
                 "message": "Describing advanced load balancers",
                 "account_number": account_number,


### PR DESCRIPTION
Previously a timeout or error in any region (e.g. get_all_elbs) would abort discovery for the entire account. Now each region is wrapped independently so a bad region is skipped and the rest continue.