### PR TITLE
chore: declare contents: read on the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
CI workflow does Python lint + tests across the matrix. Three other workflows already declare per-job permissions; `ci.yml` gets a workflow-level cap as the simpler form (all jobs read-only).