### PR TITLE
Correct overly aggressive authorization enforcement

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+Unreleased
+~~~~~~~~~~
+- Corrected the GHSA-qcqw-jwxc-2hqg fix from 1.9.1. The original fix changed ``LEMUR_STRICT_ROLE_ENFORCEMENT`` to
+  default ``True``, which broke normal user operations (certificate issuance, notification management, etc.) for
+  any deployment where users are assigned custom group roles rather than the built-in ``admin`` or ``operator``
+  roles. By design, Lemur allows any authenticated user to perform write operations; the ``read-only`` role is an
+  explicit opt-in restriction for users who should only have read access. The correct fix targets only that case:
+  ``StrictRolePermission`` now explicitly denies identities carrying the ``read-only`` role, regardless of the flag
+  value, while permitting all other authenticated users. ``LEMUR_STRICT_ROLE_ENFORCEMENT`` is reverted to default
+  ``False``; setting it to ``True`` restricts write access to ``admin`` and ``operator`` only, as before.
+  ``ADMIN_ONLY_AUTHORITY_CREATION`` remains ``True`` (authority creation is an admin action).
+
 1.9.1 - `2026-05-19`
 ~~~~~~~~~~~~~~~~~~~~
 - Fixed authorization bypass (GHSA-qcqw-jwxc-2hqg) where ``StrictRolePermission`` and ``AuthorityCreatorPermission``

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ Unreleased
   value, while permitting all other authenticated users. ``LEMUR_STRICT_ROLE_ENFORCEMENT`` is reverted to default
   ``False``; setting it to ``True`` restricts write access to ``admin`` and ``operator`` only, as before.
   ``ADMIN_ONLY_AUTHORITY_CREATION`` remains ``True`` (authority creation is an admin action).
+  Note that by design, any authenticated user (not assigned ``read-only``) retains write access
+  to notifications, certificate upload, and domain management. Operators in higher-risk environments
+  should evaluate ``LEMUR_STRICT_ROLE_ENFORCEMENT = True`` to restrict these operations to ``admin``
+  and ``operator`` users. See the ``LEMUR_STRICT_ROLE_ENFORCEMENT`` documentation for details.
 
 1.9.1 - `2026-05-19`
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -441,9 +441,9 @@ Basic Configuration
         Controls role-based access enforcement for write operations. The default Lemur roles are
         ``admin``, ``operator``, and ``read-only``.
 
-        **By design**, the default behavior (unset or ``False``) allows any authenticated user with at
-        least one role to perform write operations: issuing certificates, managing notifications,
-        uploading certificates, and so on. Authorization for specific resources (e.g. which Certificate
+        **By design**, the default behavior (unset or ``False``) allows any authenticated user to
+        perform write operations: issuing certificates, managing notifications, uploading certificates,
+        and so on. Authorization for specific resources (e.g. which Certificate
         Authority a user may issue from) is governed by role membership on those resources, not by this
         flag. This is intentional — most deployments rely on per-resource role membership rather than
         a global write restriction.
@@ -1004,9 +1004,9 @@ In addition to these built-in roles, Lemur creates and assigns **custom roles** 
 provided by your identity provider (see `IDP Configuration Options`_ and `LDAP Options`_). These custom
 roles govern per-resource access — for example, which Certificate Authorities a user may issue from.
 
-By default, any authenticated user who is not assigned the ``read-only`` role may perform write operations.
-This is intentional: authorization for specific resources is handled by per-resource role membership, not by
-a global write restriction. See ``LEMUR_STRICT_ROLE_ENFORCEMENT`` if you need to restrict write access to
+By default, any authenticated user may perform write operations unless they have been explicitly assigned the
+``read-only`` role. This is intentional: authorization for specific resources is handled by per-resource role
+membership, not by a global write restriction. See ``LEMUR_STRICT_ROLE_ENFORCEMENT`` if you need to restrict write access to
 ``admin`` and ``operator`` users only.
 
 Authentication Options

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -986,13 +986,13 @@ Roles and Authorization
 Lemur has three built-in roles:
 
 ``admin``
-    Full access to all resources and configuration. Admins can create and manage Certificate Authorities,
-    manage users and roles, and perform all operations available to other roles.
+    Required for managing Lemur's own infrastructure: creating and updating users, roles, sources,
+    destinations, and DNS providers. Admins also pass all other permission checks that normal users pass.
 
 ``operator``
-    Elevated access for day-to-day certificate operations. Operators can perform all write operations
-    (issuing certificates, managing notifications, etc.) and are subject to per-resource role membership
-    checks, but cannot manage users or global configuration.
+    Has no dedicated enforcement beyond what a normal authenticated user has, except when
+    ``LEMUR_STRICT_ROLE_ENFORCEMENT = True``, in which case ``operator`` (alongside ``admin``) is
+    required for write operations such as issuing certificates and managing notifications.
 
 ``read-only``
     Explicitly restricts a user to read access only. Users with this role cannot issue certificates,

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -980,6 +980,35 @@ Since the celery module, relies on the RedisHandler, the following options also 
 
         Which redis database to be used, by default redis offers databases 0-15 (default: 0)
 
+Roles and Authorization
+-----------------------
+
+Lemur has three built-in roles:
+
+``admin``
+    Full access to all resources and configuration. Admins can create and manage Certificate Authorities,
+    manage users and roles, and perform all operations available to other roles.
+
+``operator``
+    Elevated access for day-to-day certificate operations. Operators can perform all write operations
+    (issuing certificates, managing notifications, etc.) and are subject to per-resource role membership
+    checks, but cannot manage users or global configuration.
+
+``read-only``
+    Explicitly restricts a user to read access only. Users with this role cannot issue certificates,
+    create or modify notifications, upload certificates, or perform any other write operation. This role
+    is an **opt-in restriction** — it is not assigned automatically and must be explicitly given to users
+    who should only be able to view resources.
+
+In addition to these built-in roles, Lemur creates and assigns **custom roles** based on group memberships
+provided by your identity provider (see `IDP Configuration Options`_ and `LDAP Options`_). These custom
+roles govern per-resource access — for example, which Certificate Authorities a user may issue from.
+
+By default, any authenticated user who is not assigned the ``read-only`` role may perform write operations.
+This is intentional: authorization for specific resources is handled by per-resource role membership, not by
+a global write restriction. See ``LEMUR_STRICT_ROLE_ENFORCEMENT`` if you need to restrict write access to
+``admin`` and ``operator`` users only.
+
 Authentication Options
 ----------------------
 Lemur currently supports Basic Authentication, LDAP Authentication, Ping OAuth2, and Google out of the box. Additional flows can be added relatively easily.

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -441,11 +441,19 @@ Basic Configuration
         Controls role-based access enforcement for write operations. The default Lemur roles are
         ``admin``, ``operator``, and ``read-only``.
 
-        By default (unset or ``False``), users assigned the ``read-only`` role are denied write access,
-        while any other authenticated user (including those with custom group roles) may create or update
-        resources.
+        **By design**, the default behavior (unset or ``False``) allows any authenticated user with at
+        least one role to perform write operations: issuing certificates, managing notifications,
+        uploading certificates, and so on. Authorization for specific resources (e.g. which Certificate
+        Authority a user may issue from) is governed by role membership on those resources, not by this
+        flag. This is intentional — most deployments rely on per-resource role membership rather than
+        a global write restriction.
 
-        Set to ``True`` to restrict write access to only ``admin`` and ``operator`` users.
+        The ``read-only`` role is an explicit opt-in restriction. Assigning it to a user signals that
+        they should only be able to view resources, not modify them. Users without the ``read-only``
+        role are permitted to perform write operations by default.
+
+        Set to ``True`` to additionally restrict all write operations to only ``admin`` and ``operator``
+        users, regardless of per-resource role membership.
 
     ::
 

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -455,6 +455,20 @@ Basic Configuration
         Set to ``True`` to additionally restrict all write operations to only ``admin`` and ``operator``
         users, regardless of per-resource role membership.
 
+        .. note::
+            **Security considerations for the default (open) model.** By default, any authenticated
+            user may create or modify notifications (including webhook URLs, which can reach arbitrary
+            internal hosts), upload certificates with attacker-supplied keys to configured destinations
+            (e.g. AWS), create Certificate Authorities (if ``ADMIN_ONLY_AUTHORITY_CREATION`` is
+            ``False``), and manipulate the domain registry. These are intentional defaults that support
+            normal workflows in environments where all authenticated users are trusted.
+
+            In deployments where credential compromise is a realistic threat (phished employee, leaked
+            SSO token, insider access), any authenticated identity has meaningful access to the PKI
+            issuance plane. Setting ``LEMUR_STRICT_ROLE_ENFORCEMENT = True`` restricts all write
+            operations to ``admin`` and ``operator`` users, significantly reducing blast radius at
+            the cost of requiring explicit role provisioning for all users who need write access.
+
     ::
 
         LEMUR_STRICT_ROLE_ENFORCEMENT = True

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -438,18 +438,18 @@ Basic Configuration
 .. data:: LEMUR_STRICT_ROLE_ENFORCEMENT
     :noindex:
 
-        Controls role-based access enforcement for create/update operations. The default Lemur roles are
+        Controls role-based access enforcement for write operations. The default Lemur roles are
         ``admin``, ``operator``, and ``read-only``.
 
-        By default (unset or ``True``), role enforcement is active: only ``admin`` and ``operator`` users
-        may create or update resources. Users assigned the ``read-only`` role will be denied.
+        By default (unset or ``False``), users assigned the ``read-only`` role are denied write access,
+        while any other authenticated user (including those with custom group roles) may create or update
+        resources.
 
-        Set to ``False`` to explicitly opt in to relaxed enforcement, allowing any authenticated user to
-        create or update resources regardless of role.
+        Set to ``True`` to restrict write access to only ``admin`` and ``operator`` users.
 
     ::
 
-        LEMUR_STRICT_ROLE_ENFORCEMENT = False
+        LEMUR_STRICT_ROLE_ENFORCEMENT = True
 
 
 .. data:: SENTRY_DSN

--- a/lemur/auth/permissions.py
+++ b/lemur/auth/permissions.py
@@ -95,8 +95,7 @@ class StrictRolePermission(Permission):
     def allows(self, identity):
         if self._strict:
             return super().allows(identity)
-        # When not in strict mode, block read-only users and roleless identities.
+        # When not in strict mode, block only read-only users.
         # Empty needs (super().__init__()) would pass everyone including read-only,
         # which was the GHSA-qcqw-jwxc-2hqg vulnerability.
-        role_needs = {n for n in identity.provides if getattr(n, "method", None) == "role"}
-        return bool(role_needs) and RoleNeed("read-only") not in role_needs
+        return RoleNeed("read-only") not in identity.provides

--- a/lemur/auth/permissions.py
+++ b/lemur/auth/permissions.py
@@ -95,7 +95,8 @@ class StrictRolePermission(Permission):
     def allows(self, identity):
         if self._strict:
             return super().allows(identity)
-        # When not in strict mode, block only read-only users.
+        # When not in strict mode, block read-only users and roleless identities.
         # Empty needs (super().__init__()) would pass everyone including read-only,
         # which was the GHSA-qcqw-jwxc-2hqg vulnerability.
-        return RoleNeed("read-only") not in identity.provides
+        role_needs = {n for n in identity.provides if getattr(n, "method", None) == "role"}
+        return bool(role_needs) and RoleNeed("read-only") not in role_needs

--- a/lemur/auth/permissions.py
+++ b/lemur/auth/permissions.py
@@ -86,9 +86,16 @@ class AuthorityPermission(Permission):
 
 class StrictRolePermission(Permission):
     def __init__(self):
-        strict_role_enforcement = current_app.config.get("LEMUR_STRICT_ROLE_ENFORCEMENT", True)
-        if strict_role_enforcement:
-            needs = [RoleNeed("admin"), RoleNeed("operator")]
-            super().__init__(*needs)
+        self._strict = current_app.config.get("LEMUR_STRICT_ROLE_ENFORCEMENT", False)
+        if self._strict:
+            super().__init__(RoleNeed("admin"), RoleNeed("operator"))
         else:
             super().__init__()
+
+    def allows(self, identity):
+        if self._strict:
+            return super().allows(identity)
+        # When not in strict mode, block only read-only users.
+        # Empty needs (super().__init__()) would pass everyone including read-only,
+        # which was the GHSA-qcqw-jwxc-2hqg vulnerability.
+        return RoleNeed("read-only") not in identity.provides

--- a/lemur/tests/conftest.py
+++ b/lemur/tests/conftest.py
@@ -86,6 +86,8 @@ def db(app, request):
     UserFactory()
     r = RoleFactory(name="admin")
     u = UserFactory(roles=[r])
+    ro = RoleFactory(name="read-only")
+    UserFactory(roles=[ro])
     rp = RotationPolicyFactory(name="default")
     ApiKeyFactory(user=u)
 

--- a/lemur/tests/test_notifications.py
+++ b/lemur/tests/test_notifications.py
@@ -83,7 +83,7 @@ def test_notification_put(client, token, status):
 @pytest.mark.parametrize(
     "token,status",
     [
-        (VALID_USER_HEADER_TOKEN, 200),
+        (VALID_USER_HEADER_TOKEN, 403),
         (VALID_ADMIN_HEADER_TOKEN, 200),
         (VALID_ADMIN_API_TOKEN, 200),
         ("", 401),

--- a/lemur/tests/test_notifications.py
+++ b/lemur/tests/test_notifications.py
@@ -83,7 +83,7 @@ def test_notification_put(client, token, status):
 @pytest.mark.parametrize(
     "token,status",
     [
-        (VALID_USER_HEADER_TOKEN, 403),
+        (VALID_USER_HEADER_TOKEN, 200),
         (VALID_ADMIN_HEADER_TOKEN, 200),
         (VALID_ADMIN_API_TOKEN, 200),
         ("", 401),

--- a/lemur/tests/test_notifications.py
+++ b/lemur/tests/test_notifications.py
@@ -6,6 +6,7 @@ from lemur.notifications.views import *  # noqa
 from .vectors import (
     VALID_ADMIN_API_TOKEN,
     VALID_ADMIN_HEADER_TOKEN,
+    VALID_READ_ONLY_HEADER_TOKEN,
     VALID_USER_HEADER_TOKEN,
 )
 
@@ -86,6 +87,7 @@ def test_notification_put(client, token, status):
         (VALID_USER_HEADER_TOKEN, 200),
         (VALID_ADMIN_HEADER_TOKEN, 200),
         (VALID_ADMIN_API_TOKEN, 200),
+        (VALID_READ_ONLY_HEADER_TOKEN, 403),
         ("", 401),
     ],
 )
@@ -179,3 +181,24 @@ def test_notification_list_patch(client, token, status):
         client.patch(api.url_for(NotificationsList), data={}, headers=token).status_code
         == status
     )
+
+
+def test_notification_create_read_only_forbidden(client, notification_plugin):
+    """Read-only users must be denied write access (GHSA-qcqw-jwxc-2hqg)."""
+    import json
+    data = json.dumps({
+        "label": "ro-test-notification",
+        "description": "test",
+        "active": True,
+        "plugin": {
+            "slug": "test-notification",
+            "plugin_options": [],
+        },
+        "certificates": [],
+    })
+    resp = client.post(
+        api.url_for(NotificationsList),
+        data=data,
+        headers=VALID_READ_ONLY_HEADER_TOKEN,
+    )
+    assert resp.status_code == 403

--- a/lemur/tests/test_permissions.py
+++ b/lemur/tests/test_permissions.py
@@ -82,11 +82,6 @@ class TestStrictRolePermission:
             perm = StrictRolePermission()
         assert not perm.allows(_identity("read-only", "cryptographyservices"))
 
-    def test_default_blocks_roleless_identity(self):
-        # no roles = misconfigured provisioning, deny writes
-        with _patch_config():
-            perm = StrictRolePermission()
-        assert not perm.allows(_identity())
 
 
 class TestAuthorityCreatorPermission:

--- a/lemur/tests/test_permissions.py
+++ b/lemur/tests/test_permissions.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from flask_principal import Identity, RoleNeed
 
@@ -41,21 +41,40 @@ class TestStrictRolePermission:
             perm = StrictRolePermission()
         assert perm.allows(_identity("operator"))
 
+    def test_default_allows_custom_role(self):
+        with _patch_config():
+            perm = StrictRolePermission()
+        assert perm.allows(_identity("cryptographyservices"))
+
     def test_explicit_true_blocks_read_only(self):
         with _patch_config({"LEMUR_STRICT_ROLE_ENFORCEMENT": True}):
             perm = StrictRolePermission()
         assert not perm.allows(_identity("read-only"))
+
+    def test_explicit_true_blocks_custom_role(self):
+        with _patch_config({"LEMUR_STRICT_ROLE_ENFORCEMENT": True}):
+            perm = StrictRolePermission()
+        assert not perm.allows(_identity("cryptographyservices"))
 
     def test_explicit_true_allows_admin(self):
         with _patch_config({"LEMUR_STRICT_ROLE_ENFORCEMENT": True}):
             perm = StrictRolePermission()
         assert perm.allows(_identity("admin"))
 
-    def test_explicit_false_allows_read_only(self):
-        """Explicit opt-in to open access must be preserved."""
+    def test_explicit_true_allows_operator(self):
+        with _patch_config({"LEMUR_STRICT_ROLE_ENFORCEMENT": True}):
+            perm = StrictRolePermission()
+        assert perm.allows(_identity("operator"))
+
+    def test_explicit_false_blocks_read_only(self):
         with _patch_config({"LEMUR_STRICT_ROLE_ENFORCEMENT": False}):
             perm = StrictRolePermission()
-        assert perm.allows(_identity("read-only"))
+        assert not perm.allows(_identity("read-only"))
+
+    def test_explicit_false_allows_custom_role(self):
+        with _patch_config({"LEMUR_STRICT_ROLE_ENFORCEMENT": False}):
+            perm = StrictRolePermission()
+        assert perm.allows(_identity("cryptographyservices"))
 
 
 class TestAuthorityCreatorPermission:
@@ -80,7 +99,7 @@ class TestAuthorityCreatorPermission:
         assert perm.allows(_identity("admin"))
 
     def test_explicit_false_allows_read_only(self):
-        """Explicit opt-in to open access must be preserved."""
+        """Explicit opt-in to open authority creation must be preserved."""
         with _patch_config({"ADMIN_ONLY_AUTHORITY_CREATION": False}):
             perm = AuthorityCreatorPermission()
         assert perm.allows(_identity("read-only"))

--- a/lemur/tests/test_permissions.py
+++ b/lemur/tests/test_permissions.py
@@ -82,6 +82,12 @@ class TestStrictRolePermission:
             perm = StrictRolePermission()
         assert not perm.allows(_identity("read-only", "cryptographyservices"))
 
+    def test_default_blocks_roleless_identity(self):
+        # no roles = misconfigured provisioning, deny writes
+        with _patch_config():
+            perm = StrictRolePermission()
+        assert not perm.allows(_identity())
+
 
 class TestAuthorityCreatorPermission:
     def test_default_blocks_read_only(self):

--- a/lemur/tests/test_permissions.py
+++ b/lemur/tests/test_permissions.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 from flask_principal import Identity, RoleNeed
 
-from lemur.auth.permissions import StrictRolePermission, AuthorityCreatorPermission
+from lemur.auth.permissions import AuthorityCreatorPermission, StrictRolePermission
 
 
 def _config_get(overrides):
@@ -75,6 +75,12 @@ class TestStrictRolePermission:
         with _patch_config({"LEMUR_STRICT_ROLE_ENFORCEMENT": False}):
             perm = StrictRolePermission()
         assert perm.allows(_identity("cryptographyservices"))
+
+    def test_default_blocks_identity_with_read_only_and_custom_role(self):
+        # read-only wins even when combined with other roles
+        with _patch_config():
+            perm = StrictRolePermission()
+        assert not perm.allows(_identity("read-only", "cryptographyservices"))
 
 
 class TestAuthorityCreatorPermission:

--- a/lemur/tests/test_permissions.py
+++ b/lemur/tests/test_permissions.py
@@ -83,7 +83,6 @@ class TestStrictRolePermission:
         assert not perm.allows(_identity("read-only", "cryptographyservices"))
 
 
-
 class TestAuthorityCreatorPermission:
     def test_default_blocks_read_only(self):
         with _patch_config():

--- a/lemur/tests/test_user_service.py
+++ b/lemur/tests/test_user_service.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from lemur.users import service as user_service
 
@@ -11,6 +11,7 @@ def _role(name):
 
 def _patch_config(overrides=None):
     mock_app = MagicMock()
+
     def config_get(key, default=None):
         return (overrides or {}).get(key, default)
     mock_app.config.get.side_effect = config_get

--- a/lemur/tests/test_user_service.py
+++ b/lemur/tests/test_user_service.py
@@ -19,32 +19,48 @@ def _patch_config(overrides=None):
 
 
 class TestCreateStrictRoleEnforcement:
-    def test_default_blocks_user_with_no_default_role(self):
-        with _patch_config():
-            result = user_service.create("alice", "pass", "a@x.com", True, "", [_role("custom")])
-        assert isinstance(result, tuple)
-        error, status = result
-        assert status == 400
-        assert "LEMUR_STRICT_ROLE_ENFORCEMENT" in error["message"]
+    def test_default_allows_user_with_no_default_role(self):
+        with _patch_config(), \
+             patch("lemur.users.service.database.create") as mock_create, \
+             patch("lemur.users.service.log_service.audit_log"):
+            mock_create.return_value = MagicMock()
+            user_service.create("alice", "pass", "a@x.com", True, "", [_role("custom")])
+        mock_create.assert_called_once()
 
     def test_default_allows_user_with_admin_role(self):
         with _patch_config(), \
              patch("lemur.users.service.database.create") as mock_create, \
              patch("lemur.users.service.log_service.audit_log"):
             mock_create.return_value = MagicMock()
-            result = user_service.create("alice", "pass", "a@x.com", True, "", [_role("admin")])
+            user_service.create("alice", "pass", "a@x.com", True, "", [_role("admin")])
         mock_create.assert_called_once()
 
-    def test_default_allows_user_with_operator_role(self):
-        with _patch_config(), \
+    def test_explicit_true_blocks_user_with_no_default_role(self):
+        with _patch_config({"LEMUR_STRICT_ROLE_ENFORCEMENT": True}):
+            result = user_service.create("alice", "pass", "a@x.com", True, "", [_role("custom")])
+        assert isinstance(result, tuple)
+        error, status = result
+        assert status == 400
+        assert "LEMUR_STRICT_ROLE_ENFORCEMENT" in error["message"]
+
+    def test_explicit_true_allows_user_with_admin_role(self):
+        with _patch_config({"LEMUR_STRICT_ROLE_ENFORCEMENT": True}), \
+             patch("lemur.users.service.database.create") as mock_create, \
+             patch("lemur.users.service.log_service.audit_log"):
+            mock_create.return_value = MagicMock()
+            user_service.create("alice", "pass", "a@x.com", True, "", [_role("admin")])
+        mock_create.assert_called_once()
+
+    def test_explicit_true_allows_user_with_operator_role(self):
+        with _patch_config({"LEMUR_STRICT_ROLE_ENFORCEMENT": True}), \
              patch("lemur.users.service.database.create") as mock_create, \
              patch("lemur.users.service.log_service.audit_log"):
             mock_create.return_value = MagicMock()
             user_service.create("alice", "pass", "a@x.com", True, "", [_role("operator")])
         mock_create.assert_called_once()
 
-    def test_default_allows_user_with_read_only_role(self):
-        with _patch_config(), \
+    def test_explicit_true_allows_user_with_read_only_role(self):
+        with _patch_config({"LEMUR_STRICT_ROLE_ENFORCEMENT": True}), \
              patch("lemur.users.service.database.create") as mock_create, \
              patch("lemur.users.service.log_service.audit_log"):
             mock_create.return_value = MagicMock()
@@ -61,15 +77,7 @@ class TestCreateStrictRoleEnforcement:
 
 
 class TestUpdateStrictRoleEnforcement:
-    def test_default_blocks_user_with_no_default_role(self):
-        with _patch_config():
-            result = user_service.update(1, "alice", "a@x.com", True, "", [_role("custom")])
-        assert isinstance(result, tuple)
-        error, status = result
-        assert status == 400
-        assert "LEMUR_STRICT_ROLE_ENFORCEMENT" in error["message"]
-
-    def test_default_allows_user_with_admin_role(self):
+    def test_default_allows_user_with_no_default_role(self):
         with _patch_config(), \
              patch("lemur.users.service.get") as mock_get, \
              patch("lemur.users.service.database.update") as mock_update, \
@@ -77,8 +85,16 @@ class TestUpdateStrictRoleEnforcement:
              patch("lemur.users.service.log_service.audit_log"):
             mock_get.return_value = MagicMock()
             mock_update.return_value = MagicMock()
-            user_service.update(1, "alice", "a@x.com", True, "", [_role("admin")])
+            user_service.update(1, "alice", "a@x.com", True, "", [_role("custom")])
         mock_update.assert_called_once()
+
+    def test_explicit_true_blocks_user_with_no_default_role(self):
+        with _patch_config({"LEMUR_STRICT_ROLE_ENFORCEMENT": True}):
+            result = user_service.update(1, "alice", "a@x.com", True, "", [_role("custom")])
+        assert isinstance(result, tuple)
+        error, status = result
+        assert status == 400
+        assert "LEMUR_STRICT_ROLE_ENFORCEMENT" in error["message"]
 
     def test_explicit_false_allows_user_with_no_default_role(self):
         with _patch_config({"LEMUR_STRICT_ROLE_ENFORCEMENT": False}), \

--- a/lemur/tests/vectors.py
+++ b/lemur/tests/vectors.py
@@ -20,6 +20,12 @@ VALID_ADMIN_API_TOKEN = {
     "Content-Type": "application/json",
 }
 
+VALID_READ_ONLY_HEADER_TOKEN = {
+    "Authorization": "Basic "
+    + "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MjE2NTIwMjIsImV4cCI6MjM4NTY1MjAyMiwic3ViIjoiMyJ9.pMWHVtnlir4MFEwvYbqmLmqyIBld_PQc8_DiahtTDxs",
+    "Content-Type": "application/json",
+}
+
 
 #: CN=LemurTrust Unittests Root CA 2018
 ROOTCA_CERT_STR = """\

--- a/lemur/users/service.py
+++ b/lemur/users/service.py
@@ -28,7 +28,7 @@ def create(username, password, email, active, profile_picture, roles):
     :param roles:
     :return:
     """
-    strict_role_enforcement = current_app.config.get("LEMUR_STRICT_ROLE_ENFORCEMENT", True)
+    strict_role_enforcement = current_app.config.get("LEMUR_STRICT_ROLE_ENFORCEMENT", False)
     if strict_role_enforcement and not any(role.name in STRICT_ENFORCEMENT_DEFAULT_ROLES for role in roles):
         return dict(message="Default role required. Assign the user at least one of: admin, operator, read-only. "
                             "To disable this requirement, set LEMUR_STRICT_ROLE_ENFORCEMENT = False in your config."), 400
@@ -58,7 +58,7 @@ def update(user_id, username, email, active, profile_picture, roles, password=No
     :param password:
     :return:
     """
-    strict_role_enforcement = current_app.config.get("LEMUR_STRICT_ROLE_ENFORCEMENT", True)
+    strict_role_enforcement = current_app.config.get("LEMUR_STRICT_ROLE_ENFORCEMENT", False)
     if strict_role_enforcement and not any(role.name in STRICT_ENFORCEMENT_DEFAULT_ROLES for role in roles):
         return dict(message="Default role required. Assign the user at least one of: admin, operator, read-only. "
                             "To disable this requirement, set LEMUR_STRICT_ROLE_ENFORCEMENT = False in your config."), 400


### PR DESCRIPTION
Fix a lint issue

Fix an issue introduced in https://github.com/Netflix/lemur/commit/f478458d3213f4c185238821c6808a68a7f56277 where we're unintentionally over-aggressively enforcing strict authorization.

Summary:

Corrects the [GHSA-qcqw-jwxc-2hqg](https://github.com/Netflix/lemur/security/advisories/GHSA-qcqw-jwxc-2hqg) fix landed in https://github.com/Netflix/lemur/commit/f478458d3213f4c185238821c6808a68a7f56277.

The original fix changed `LEMUR_STRICT_ROLE_ENFORCEMENT` to default `True`, which correctly closed a Flask-Principal authorization bypass but was too broad: it broke normal cert issuance, uploads, and notification management for any user whose roles come from custom group assignments (e.g. groups auto-assigned at login) rather than the built-in `admin` or `operator` roles.

**The actual vulnerability** was that `StrictRolePermission` called `Permission.__init__()` with no needs when `LEMUR_STRICT_ROLE_ENFORCEMENT` was `False` (the default), and Flask-Principal grants any identity access — including users explicitly assigned the `read-only` role — when a permission has empty needs. The fix needed to target only that case.

**The correct fix:**
  - `LEMUR_STRICT_ROLE_ENFORCEMENT` is reverted to default `False`. `StrictRolePermission.allows()` is overridden to explicitly deny identities carrying the `read-only` role, regardless of the flag value. This closes the vulnerability without blocking normal users.
  - `LEMUR_STRICT_ROLE_ENFORCEMENT = True` is preserved as an opt-in for operators who want to restrict all write access to `admin` and `operator` users only.
  - `ADMIN_ONLY_AUTHORITY_CREATION` remains `True` — authority creation is genuinely an admin action and was correctly tightened by the original fix.
  - `LEMUR_STRICT_ROLE_ENFORCEMENT` in `users/service.py` is reverted to default `False` — user create/update no longer rejects users whose only roles are custom group roles.

Also fixes two lint errors introduced in the advisory commit (`test_user_service.py`: E306 missing blank line before nested def, I101 import order).

**Tests added:**
  - `test_notification_delete[read_only-403]` — HTTP-level proof that a `read-only` user is denied write access
  - `test_notification_create_read_only_forbidden` — valid payload reaching the permission check, confirming the create path is protected
  - `test_default_blocks_identity_with_read_only_and_custom_role` — `read-only` blocks even when combined with other roles
  - `test_explicit_true_blocks_custom_role` / `test_explicit_true_allows_operator` — full coverage of the strict-mode path

**Docs added:**
  - New "Roles and Authorization" section in `administration.rst` explaining the three built-in roles, the opt-in nature of `read-only`, and the default-open write access model
  - Updated `LEMUR_STRICT_ROLE_ENFORCEMENT` docs to reflect the corrected default and intent
  - Changelog entry explaining the partial revert and the reasoning
