### PR TITLE
fix: update tests to reflect GHSA security hardening changes

### DIFF
--- a/lemur/tests/test_roles.py
+++ b/lemur/tests/test_roles.py
@@ -79,7 +79,7 @@ def test_role_post_(client, token, status):
 @pytest.mark.parametrize(
     "token,status",
     [
-        (VALID_USER_HEADER_TOKEN, 400),
+        (VALID_USER_HEADER_TOKEN, 403),
         (VALID_ADMIN_HEADER_TOKEN, 400),
         (VALID_ADMIN_API_TOKEN, 400),
         ("", 401),
@@ -140,10 +140,7 @@ def test_role_put_with_data_and_user(client, session):
         client.put(
             api.url_for(Roles, role_id=role.id), data=json.dumps(data), headers=headers
         ).status_code
-        == 200
-    )
-    assert (
-        client.get(api.url_for(RolesList), data={}, headers=headers).json["total"] > 1
+        == 403
     )
 
 

--- a/lemur/tests/test_verify.py
+++ b/lemur/tests/test_verify.py
@@ -1,6 +1,7 @@
 import pytest
 import requests
 import requests_mock
+from unittest.mock import patch
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization, hashes
@@ -58,5 +59,7 @@ def test_verify_crl_unreachable(cert_builder, private_key):
             with open(cert_tmp, "wb") as f:
                 f.write(cert.public_bytes(serialization.Encoding.PEM))
 
-            with pytest.raises(Exception, match="Unable to retrieve CRL:"):
-                crl_verify(cert, cert_tmp)
+            # Patch DNS resolution so the SSRF check passes, letting the mocked Timeout fire.
+            with patch("lemur.certificates.verify.socket.gethostbyname", return_value="93.184.216.34"):
+                with pytest.raises(Exception, match="Unable to retrieve CRL:"):
+                    crl_verify(cert, cert_tmp)


### PR DESCRIPTION
- test_role_put: non-admin users now get 403 (admin-only) before schema validation can return 400
- test_role_put_with_data_and_user: role members no longer permitted to update roles; expect 403 instead of 200
- test_verify_crl_unreachable: patch socket.gethostbyname so the new SSRF hostname validation passes, allowing the mocked Timeout to fire