### PR TITLE
fix(certificates): guard is_attached_to_endpoint against missing get_endpoint_certificate_names

### DIFF
--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -1093,6 +1093,12 @@ def is_attached_to_endpoint(certificate_name, endpoint_name):
     :return: True if certificate is attached to the given endpoint, False otherwise
     """
     endpoint = endpoint_service.get_by_name(endpoint_name)
+    if not hasattr(endpoint.source.plugin, "get_endpoint_certificate_names"):
+        current_app.logger.warning(
+            f"Source plugin {endpoint.source.plugin_name} does not implement "
+            "get_endpoint_certificate_names — assuming certificate is not attached"
+        )
+        return False
     attached_certificates = endpoint.source.plugin.get_endpoint_certificate_names(endpoint)
     return certificate_name in attached_certificates
 


### PR DESCRIPTION
## Summary

- `is_attached_to_endpoint` in `lemur/certificates/service.py` raised `AttributeError` (→ HTTP 500) when a cert was attached to an endpoint whose source plugin lacked `get_endpoint_certificate_names`. This blocked all revocations for certs with COA destinations.
- `AdapterSourcePlugin` (DataDog's COA source plugin) does not implement `get_endpoint_certificate_names`, triggering the bug on every revoke attempt for those certs.
- Adds a `hasattr` guard: plugins missing the method log a warning and return `False` (not attached), allowing revocation to proceed.

Fixes RDNA-1016.

## Test plan

- [ ] Existing certificate test suite passes (requires Postgres; DB-connected run in CI).
- [ ] Manual test: revoke a cert whose source plugin is `AdapterSourcePlugin` — verify 200 response and warning log line `"Source plugin … does not implement get_endpoint_certificate_names"`.
- [ ] Regression: revoke a cert whose source plugin implements `get_endpoint_certificate_names` — verify existing attachment-check behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)