### PR TITLE
Fix rotate CLI skipping endpoints due to list mutation during iteration

### DIFF
--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -322,7 +322,7 @@ def rotate(endpoint_name, source, new_certificate_name, old_certificate_name, me
             log_data["certificate"] = new_cert.name
             log_data["certificate_old"] = old_cert.name
             log_data["message"] = "Rotating endpoint from old to new cert"
-            for endpoint in old_cert.endpoints:
+            for endpoint in list(old_cert.endpoints):
                 click.echo(f"[+] Rotating {endpoint.name}")
                 log_data["endpoint"] = endpoint.dnsname
                 request_rotation(endpoint, new_cert, message, commit)
@@ -471,7 +471,7 @@ def rotate_region(endpoint_name, new_certificate_name, old_certificate_name, mes
             log_data["message"] = "Rotating endpoint from old to new cert"
             click.echo(log_data)
             current_app.logger.info(log_data)
-            for endpoint in old_cert.endpoints:
+            for endpoint in list(old_cert.endpoints):
                 log_data["endpoint"] = endpoint.dnsname
                 request_rotation_region(endpoint, new_cert, message, commit, log_data, region)
 


### PR DESCRIPTION
## Problem

`lemur certificate rotate -o OLD -n NEW` silently skips 1 endpoint per rotation.

`rotate()` iterates `old_cert.endpoints`, a live SQLAlchemy instrumented list. Inside the loop, `request_rotation` calls `deployment_service.rotate_certificate` which reassigns `endpoint.certificate = new_cert`. This removes the endpoint from `old_cert.endpoints` mid-iteration, causing the iterator to skip whichever element slides into the vacated slot.

With N endpoints, N-1 are processed and 1 is silently skipped. The same bug exists in `rotate_region()`.

## Fix

Snapshot the list before iterating: `list(old_cert.endpoints)`.

## How it was found

During a certificate migration across 6 GCP target-ssl-proxies: 5 were rotated, 1 was silently skipped with no error or log message. Had to manually rotate the missing endpoint.